### PR TITLE
Add JWT session auth, user DB, auth/admin API endpoints and login UI

### DIFF
--- a/api/_lib/auth.js
+++ b/api/_lib/auth.js
@@ -1,0 +1,94 @@
+const { SignJWT, jwtVerify } = require('jose');
+
+const COOKIE_NAME = 'sg_session';
+const SESSION_TTL_SECONDS = 60 * 60 * 24 * 7;
+
+function getJwtSecret() {
+  const secret = process.env.AUTH_SECRET || process.env.NEXTAUTH_SECRET;
+  if (!secret) {
+    throw new Error('Missing AUTH_SECRET (or NEXTAUTH_SECRET) environment variable.');
+  }
+  return new TextEncoder().encode(secret);
+}
+
+async function signSessionToken(payload) {
+  const secret = getJwtSecret();
+  return new SignJWT(payload)
+    .setProtectedHeader({ alg: 'HS256' })
+    .setIssuedAt()
+    .setExpirationTime(`${SESSION_TTL_SECONDS}s`)
+    .sign(secret);
+}
+
+async function verifySessionToken(token) {
+  const secret = getJwtSecret();
+  const { payload } = await jwtVerify(token, secret);
+  return payload;
+}
+
+function parseCookies(req) {
+  const rawCookie = req.headers.cookie || '';
+  const cookies = {};
+  rawCookie.split(';').forEach((entry) => {
+    const [name, ...rest] = entry.trim().split('=');
+    if (!name) return;
+    cookies[name] = decodeURIComponent(rest.join('='));
+  });
+  return cookies;
+}
+
+function setSessionCookie(res, token) {
+  const secure = process.env.NODE_ENV === 'production';
+  const cookie = [
+    `${COOKIE_NAME}=${encodeURIComponent(token)}`,
+    'Path=/',
+    'HttpOnly',
+    'SameSite=Lax',
+    `Max-Age=${SESSION_TTL_SECONDS}`,
+    secure ? 'Secure' : null
+  ]
+    .filter(Boolean)
+    .join('; ');
+  res.setHeader('Set-Cookie', cookie);
+}
+
+function clearSessionCookie(res) {
+  const secure = process.env.NODE_ENV === 'production';
+  const cookie = [
+    `${COOKIE_NAME}=`,
+    'Path=/',
+    'HttpOnly',
+    'SameSite=Lax',
+    'Max-Age=0',
+    secure ? 'Secure' : null
+  ]
+    .filter(Boolean)
+    .join('; ');
+  res.setHeader('Set-Cookie', cookie);
+}
+
+async function requireSession(req, res) {
+  try {
+    const cookies = parseCookies(req);
+    const token = cookies[COOKIE_NAME];
+    if (!token) {
+      res.status(401).json({ error: 'Not authenticated' });
+      return null;
+    }
+    const payload = await verifySessionToken(token);
+    return payload;
+  } catch (error) {
+    res.status(401).json({ error: 'Invalid session' });
+    return null;
+  }
+}
+
+module.exports = {
+  COOKIE_NAME,
+  signSessionToken,
+  verifySessionToken,
+  parseCookies,
+  setSessionCookie,
+  clearSessionCookie,
+  requireSession
+};

--- a/api/_lib/db.js
+++ b/api/_lib/db.js
@@ -1,0 +1,46 @@
+const { sql } = require('@vercel/postgres');
+
+async function getUserByEmail(email) {
+  const result = await sql`
+    SELECT id, username, email, password_hash, role, country, created_at, updated_at
+    FROM users
+    WHERE email = ${email}
+    LIMIT 1
+  `;
+  return result.rows[0] || null;
+}
+
+async function getUserByUsername(username) {
+  const result = await sql`
+    SELECT id, username, email, password_hash, role, country, created_at, updated_at
+    FROM users
+    WHERE username = ${username}
+    LIMIT 1
+  `;
+  return result.rows[0] || null;
+}
+
+async function insertUser({ username, email, passwordHash, role = 'user', country }) {
+  const result = await sql`
+    INSERT INTO users (username, email, password_hash, role, country)
+    VALUES (${username}, ${email}, ${passwordHash}, ${role}, ${country})
+    RETURNING id, username, email, role, country, created_at, updated_at
+  `;
+  return result.rows[0];
+}
+
+async function getUsersForAdminList() {
+  const result = await sql`
+    SELECT id, username, email, role, country, created_at, updated_at
+    FROM users
+    ORDER BY created_at DESC
+  `;
+  return result.rows;
+}
+
+module.exports = {
+  getUserByEmail,
+  getUserByUsername,
+  insertUser,
+  getUsersForAdminList
+};

--- a/api/admin/users.js
+++ b/api/admin/users.js
@@ -1,0 +1,24 @@
+const { requireSession } = require('../_lib/auth');
+const { getUsersForAdminList } = require('../_lib/db');
+
+module.exports = async function handler(req, res) {
+  if (req.method !== 'GET') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const session = await requireSession(req, res);
+  if (!session) return;
+
+  if (session.role !== 'admin') {
+    res.status(403).json({ error: 'Forbidden' });
+    return;
+  }
+
+  try {
+    const users = await getUsersForAdminList();
+    res.status(200).json({ users });
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to load users' });
+  }
+};

--- a/api/auth/login.js
+++ b/api/auth/login.js
@@ -1,0 +1,49 @@
+const bcrypt = require('bcryptjs');
+const { getUserByEmail } = require('../_lib/db');
+const { setSessionCookie, signSessionToken } = require('../_lib/auth');
+
+module.exports = async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  try {
+    const { email, password } = req.body || {};
+    if (!email || !password) {
+      res.status(400).json({ error: 'email and password are required' });
+      return;
+    }
+
+    const normalizedEmail = String(email).trim().toLowerCase();
+    const user = await getUserByEmail(normalizedEmail);
+
+    if (!user || !(await bcrypt.compare(password, user.password_hash))) {
+      res.status(401).json({ error: 'Invalid email or password' });
+      return;
+    }
+
+    const token = await signSessionToken({
+      sub: String(user.id),
+      id: user.id,
+      username: user.username,
+      email: user.email,
+      role: user.role,
+      country: user.country || 'unknown'
+    });
+
+    setSessionCookie(res, token);
+
+    res.status(200).json({
+      user: {
+        id: user.id,
+        username: user.username,
+        email: user.email,
+        role: user.role,
+        country: user.country || 'unknown'
+      }
+    });
+  } catch (error) {
+    res.status(500).json({ error: 'Login failed' });
+  }
+};

--- a/api/auth/logout.js
+++ b/api/auth/logout.js
@@ -1,0 +1,11 @@
+const { clearSessionCookie } = require('../_lib/auth');
+
+module.exports = async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  clearSessionCookie(res);
+  res.status(200).json({ ok: true });
+};

--- a/api/auth/register.js
+++ b/api/auth/register.js
@@ -1,0 +1,66 @@
+const bcrypt = require('bcryptjs');
+const { getUserByEmail, getUserByUsername, insertUser } = require('../_lib/db');
+
+module.exports = async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  try {
+    const { username, email, password } = req.body || {};
+    if (!username || !email || !password) {
+      res.status(400).json({ error: 'username, email and password are required' });
+      return;
+    }
+
+    const normalizedUsername = String(username).trim().toLowerCase();
+    const normalizedEmail = String(email).trim().toLowerCase();
+
+    if (normalizedUsername.length < 3) {
+      res.status(400).json({ error: 'Username must be at least 3 characters' });
+      return;
+    }
+
+    if (String(password).length < 8) {
+      res.status(400).json({ error: 'Password must be at least 8 characters' });
+      return;
+    }
+
+    const existingByEmail = await getUserByEmail(normalizedEmail);
+    if (existingByEmail) {
+      res.status(409).json({ error: 'Email is already registered' });
+      return;
+    }
+
+    const existingByUsername = await getUserByUsername(normalizedUsername);
+    if (existingByUsername) {
+      res.status(409).json({ error: 'Username is already taken' });
+      return;
+    }
+
+    const passwordHash = await bcrypt.hash(password, 12);
+    const countryHeader = req.headers['x-vercel-ip-country'];
+    const country = typeof countryHeader === 'string' && countryHeader.trim() ? countryHeader.trim() : 'unknown';
+
+    const user = await insertUser({
+      username: normalizedUsername,
+      email: normalizedEmail,
+      passwordHash,
+      role: 'user',
+      country
+    });
+
+    res.status(201).json({
+      user: {
+        id: user.id,
+        username: user.username,
+        email: user.email,
+        role: user.role,
+        country: user.country
+      }
+    });
+  } catch (error) {
+    res.status(500).json({ error: 'Registration failed' });
+  }
+};

--- a/api/auth/session.js
+++ b/api/auth/session.js
@@ -1,0 +1,21 @@
+const { requireSession } = require('../_lib/auth');
+
+module.exports = async function handler(req, res) {
+  if (req.method !== 'GET') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const session = await requireSession(req, res);
+  if (!session) return;
+
+  res.status(200).json({
+    user: {
+      id: session.id,
+      username: session.username,
+      email: session.email,
+      role: session.role,
+      country: session.country
+    }
+  });
+};

--- a/index.html
+++ b/index.html
@@ -5,126 +5,320 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>sarcasm.games</title>
   <style>
-    :root{--bg:#0b0c10;--card:#1e1f25;--txt:#eaeaea;--bd:#2f313a;--accent:#4ecca3}
-    
-    body.light-mode {--bg:#f7f7fb;--card:#ffffff;--txt:#111;--bd:#e7e7ef}
-    
-    @media (prefers-color-scheme: light){
-      body:not(.dark-mode) {:root{--bg:#f7f7fb;--card:#ffffff;--txt:#111;--bd:#e7e7ef}}
-    }
+    :root { --bg:#0b0c10; --card:#1e1f25; --txt:#eaeaea; --bd:#2f313a; --accent:#4ecca3; --danger:#ff6b6b; --muted:#9aa0ad; }
+    body.light-mode { --bg:#f7f7fb; --card:#fff; --txt:#111; --bd:#e7e7ef; --muted:#5d6470; }
+    body { margin:0; font:16px/1.4 system-ui, Segoe UI, Roboto, Arial; background:var(--bg); color:var(--txt); min-height:100dvh; }
+    .hidden{display:none!important}
 
-    body{margin:0;font:16px/1.4 system-ui,Segoe UI,Roboto,Arial;background:var(--bg);color:var(--txt);display:flex;flex-direction:column;align-items:center;min-height:100dvh;transition: background 0.3s, color 0.3s;}
-    
-    .auth-bar {width: 100%; background: var(--card); border-bottom: 1px solid var(--bd); padding: 10px; display: flex; justify-content: center; align-items: center; gap: 12px; z-index: 100; min-height: 40px;}
-    .auth-bar input {background: var(--bg); border: 1px solid var(--bd); color: var(--txt); padding: 5px 10px; border-radius: 4px; font-size: 14px; outline: none;}
-    .auth-bar button {background: var(--accent); color: #000; border: none; padding: 5px 15px; border-radius: 4px; cursor: pointer; font-weight: bold;}
-    
-    .theme-toggle { cursor: pointer; font-size: 20px; user-select: none; padding: 0 10px; }
-    .logout-btn { background: #ff4d4d !important; color: white !important; display: none; }
+    .auth-shell{min-height:100dvh;display:grid;place-items:center;padding:24px}
+    .auth-card{width:min(520px,100%);background:var(--card);border:1px solid var(--bd);border-radius:14px;padding:20px;box-sizing:border-box}
+    .auth-title{margin:0 0 8px;font-size:1.6rem}
+    .auth-subtitle{margin:0 0 16px;color:var(--muted)}
+    .auth-tabs{display:flex;gap:8px;margin-bottom:14px;flex-wrap:wrap}
+    .tab-btn{border:1px solid var(--bd);background:transparent;color:var(--txt);border-radius:8px;padding:8px 12px;cursor:pointer}
+    .tab-btn.active{background:var(--accent);color:#111;border-color:var(--accent);font-weight:700}
+    .form-group{margin-bottom:10px}
+    .form-group label{display:block;margin-bottom:4px;font-size:.9rem;color:var(--muted)}
+    input{width:100%;box-sizing:border-box;background:var(--bg);border:1px solid var(--bd);color:var(--txt);padding:10px 12px;border-radius:8px;font-size:14px;outline:none}
+    .btn-row{display:flex;gap:8px;margin-top:12px;flex-wrap:wrap}
+    button{border:0;border-radius:8px;padding:10px 14px;cursor:pointer;font-weight:700}
+    .btn-primary{background:var(--accent);color:#111}
+    .btn-danger{background:var(--danger);color:#fff}
+    .btn-neutral{background:var(--bd);color:var(--txt)}
+    .status-box{margin-top:12px;min-height:20px;color:var(--muted);font-size:.92rem;word-break:break-word}
 
-    .wrap{max-width:860px;width:100%;padding:28px; text-align: center;}
+    .app-shell{display:flex;flex-direction:column;align-items:center;min-height:100dvh}
+    .top-bar{width:100%;background:var(--card);border-bottom:1px solid var(--bd);padding:10px 14px;display:flex;justify-content:space-between;align-items:center;box-sizing:border-box;gap:10px;flex-wrap:wrap}
+    .top-bar .right{display:flex;gap:8px;flex-wrap:wrap}
+    .wrap{max-width:860px;width:100%;padding:28px;text-align:center;box-sizing:border-box}
     h1{margin:0 0 8px;font-size:32px}
-    p{opacity:.8;margin:0 0 24px}
+    p{opacity:.85;margin:0 0 24px}
     .grid{display:grid;gap:12px;grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
-    a{display:block;text-decoration:none;padding:18px 20px;border-radius:12px;background:var(--card);color:inherit;border:1px solid var(--bd);transition:.15s; position: relative;}
+    a{display:block;text-decoration:none;padding:18px 20px;border-radius:12px;background:var(--card);color:inherit;border:1px solid var(--bd);transition:.15s;position:relative}
+    .tooltip-text{visibility:hidden;opacity:0;transition:opacity .3s;position:absolute;top:-35px;left:50%;transform:translateX(-50%);background-color:var(--bd);color:var(--txt);text-align:center;padding:4px 8px;border-radius:6px;font-size:12px;white-space:nowrap;pointer-events:none}
+    a:hover{transform:translateY(-1px);border-color:#767a88}
+    a:hover .tooltip-text{visibility:visible;opacity:1}
 
-    .tooltip-text {
-      visibility: hidden; opacity: 0; transition: opacity 0.3s; position: absolute;
-      top: -35px; left: 50%; transform: translateX(-50%); background-color: var(--bd);
-      color: var(--txt); text-align: center; padding: 4px 8px; border-radius: 6px;
-      font-size: 12px; white-space: nowrap; pointer-events: none;
-    }
-    a:hover {transform: translateY(-1px); border-color: #767a88;}
-    a:hover .tooltip-text {visibility: visible; opacity: 1;}
-
-    #morsdagsContainer { display: none; max-width: 400px; width: 90%; margin: 60px auto; text-align: center; }
-    .morsdag-link { 
-      display: block; background: var(--card); border: 2px solid var(--accent); 
-      padding: 20px; margin: 10px 0; border-radius: 15px; text-decoration: none; 
-      color: var(--txt); font-size: 1.3rem; font-weight: bold; transition: 0.2s;
-    }
-    .morsdag-link:hover { transform: translateY(-3px); box-shadow: 0 5px 15px rgba(0,0,0,0.3); }
+    .season-card,.member-list{margin-top:24px;background:var(--card);border:1px solid var(--bd);border-radius:12px;padding:14px;text-align:left}
+    .season-grid{display:grid;gap:10px;grid-template-columns:repeat(auto-fit,minmax(150px,1fr))}
+    .module-group{border:1px dashed var(--bd);border-radius:10px;padding:10px}
+    .module-group h4{margin:0 0 8px}
   </style>
 </head>
 <body>
+  <div id="authShell" class="auth-shell">
+    <div class="auth-card">
+      <h1 class="auth-title">sarcasm.games login</h1>
+      <p class="auth-subtitle">Databasestyrt innlogging med Vercel + Neon.</p>
 
-<div class="auth-bar" id="authBar">
-  <div class="theme-toggle" onclick="toggleTheme()" id="themeIcon">🌙</div>
-  <div id="loginFields">
-    <input type="text" id="user" placeholder="Brukernavn" autocomplete="off">
-    <input type="password" id="pass" placeholder="Passord">
-    <button onclick="checkLogin()">Logg inn</button>
+      <div class="auth-tabs">
+        <button class="tab-btn active" data-tab="login">Logg inn</button>
+        <button class="tab-btn" data-tab="register">Opprett bruker</button>
+      </div>
+
+      <section id="loginTab" class="tab-content">
+        <div class="form-group">
+          <label for="loginEmail">E-post</label>
+          <input id="loginEmail" type="email" autocomplete="email" />
+        </div>
+        <div class="form-group">
+          <label for="loginPassword">Passord</label>
+          <input id="loginPassword" type="password" autocomplete="current-password" />
+        </div>
+        <div class="btn-row"><button class="btn-primary" id="loginBtn">Logg inn</button></div>
+      </section>
+
+      <section id="registerTab" class="tab-content hidden">
+        <div class="form-group">
+          <label for="registerUser">Bruker-ID</label>
+          <input id="registerUser" type="text" autocomplete="username" />
+        </div>
+        <div class="form-group">
+          <label for="registerEmail">E-post</label>
+          <input id="registerEmail" type="email" autocomplete="email" />
+        </div>
+        <div class="form-group">
+          <label for="registerPassword">Passord</label>
+          <input id="registerPassword" type="password" autocomplete="new-password" />
+        </div>
+        <div class="btn-row"><button class="btn-primary" id="registerBtn">Opprett bruker</button></div>
+      </section>
+
+      <div id="statusBox" class="status-box"></div>
+    </div>
   </div>
-  <button id="logoutBtn" class="logout-btn" onclick="logout()">Logg ut</button>
-</div>
 
-<div class="wrap" id="mainContent">
-  <h1>sarcasm.games</h1>
-  <p>Where do you wanna go?</p>
-  <div class="grid">
-    <a href="/tiermaker/">Tier-maker <span class="tooltip-text">Make your own tier list.</span></a>
-    <a href="/monstercatch/">Monster catcher <span class="tooltip-text">A local game.</span></a>
-    <a href="/achievements/">Life Achievements <span class="tooltip-text">Track accomplishments</span></a>
-    <a href="/poketruefalse/">Pokemon True or False <span class="tooltip-text">Facts game!</span></a>
-    <a href="/lighthousekeeper/">Lighthouse Keeper <span class="tooltip-text">Keep the light on!</span></a>
-    <a href="/CosmicClick/">Cosmic clicker <span class="tooltip-text">Incremental clicker!</span></a>
-    <a href="/orb/">Orb Game <span class="tooltip-text">Race to the finish!</span></a>
-    <a href="/CrystalClick/">Crystal Mining <span class="tooltip-text">Second clicker!</span></a>
-    <a href="/GalacticClick/">Galactic Mining <span class="tooltip-text">Third clicker!</span></a>
-    <a href="/quizapp/">Quiz! <span class="tooltip-text">Generate a quiz</span></a>
-    <a href="/memory/">Guess the mon! <span class="tooltip-text">How fast are you?</span></a>
-    <a href="https://html.itch.zone/html/14908902/index.html">3D Platformer <span class="tooltip-text">Playable in browser</span></a>
+  <div id="appShell" class="app-shell hidden">
+    <div class="top-bar">
+      <strong id="welcomeText">Innlogget</strong>
+      <div class="right">
+        <button class="btn-neutral" id="themeToggle">🌓 Tema</button>
+        <button class="btn-danger" id="logoutBtn">Logg ut</button>
+      </div>
+    </div>
+
+    <div class="wrap">
+      <h1>sarcasm.games</h1>
+      <p>Where do you wanna go?</p>
+      <div class="grid">
+        <a href="/tiermaker/">Tier-maker <span class="tooltip-text">Make your own tier list.</span></a>
+        <a href="/monstercatch/">Monster catcher <span class="tooltip-text">A local game.</span></a>
+        <a href="/achievements/">Life Achievements <span class="tooltip-text">Track accomplishments</span></a>
+        <a href="/poketruefalse/">Pokemon True or False <span class="tooltip-text">Facts game!</span></a>
+        <a href="/lighthousekeeper/">Lighthouse Keeper <span class="tooltip-text">Keep the light on!</span></a>
+        <a href="/CosmicClick/">Cosmic clicker <span class="tooltip-text">Incremental clicker!</span></a>
+        <a href="/orb/">Orb Game <span class="tooltip-text">Race to the finish!</span></a>
+        <a href="/CrystalClick/">Crystal Mining <span class="tooltip-text">Second clicker!</span></a>
+        <a href="/GalacticClick/">Galactic Mining <span class="tooltip-text">Third clicker!</span></a>
+        <a href="/quizapp/">Quiz! <span class="tooltip-text">Generate a quiz</span></a>
+        <a href="/memory/">Guess the mon! <span class="tooltip-text">How fast are you?</span></a>
+        <a href="https://html.itch.zone/html/14908902/index.html">3D Platformer <span class="tooltip-text">Playable in browser</span></a>
+      </div>
+
+      <section class="season-card hidden" id="featureModulesSection">
+        <h3 id="featureModulesTitle">Admin-moduler</h3>
+        <div class="season-grid" id="featureModulesGrid"></div>
+      </section>
+
+      <section id="memberListSection" class="member-list hidden">
+        <h3>Medlemsliste (kun admin)</h3>
+        <ul id="memberList"></ul>
+      </section>
+    </div>
   </div>
-</div>
 
-<div id="morsdagsContainer">
-  <h1 style="color: var(--accent); font-size: 40px;">🌸 Morsdag 2026</h1>
-  <p style="font-size: 18px;">Velkommen! Velg din quiz under:</p>
-  <a href="/Mamma/" class="morsdag-link">👸 Mamma</a>
-  <a href="/Isak/" class="morsdag-link">👦 Isak</a>
-  <a href="/Lilly/" class="morsdag-link">👧 Lilly</a>
-  <a href="/Pappa/" class="morsdag-link">🧔 Pappa</a>
-  <a href="/Karusell/" class="morsdag-link" style="border-color: #767a88; opacity: 0.9;">📸 Karusell</a>
-</div>
+  <script>
+    const FEATURE_MODULES = [
+      {
+        id: 'morsdag-2026',
+        title: '🌸 Morsdag 2026',
+        adminOnly: true,
+        links: [
+          { label: '👸 Mamma', href: '/Mamma/' },
+          { label: '👦 Isak', href: '/Isak/' },
+          { label: '👧 Lilly', href: '/Lilly/' },
+          { label: '🧔 Pappa', href: '/Pappa/' },
+          { label: '📸 Karusell', href: '/Karusell/' }
+        ]
+      }
+      // Add more modules here, e.g. farsquiz:
+      // { id: 'farsquiz-2027', title: '🎉 Farsquiz 2027', adminOnly: true, links: [{ label: 'Start', href: '/farsquiz/' }] }
+    ];
 
-<script>
-  window.onload = function() {
-    if (localStorage.getItem('morsdag_innlogget') === 'true') {
-      visInnloggetState();
+    const statusBox = document.getElementById('statusBox');
+    const authShell = document.getElementById('authShell');
+    const appShell = document.getElementById('appShell');
+    const welcomeText = document.getElementById('welcomeText');
+    const memberListSection = document.getElementById('memberListSection');
+    const memberList = document.getElementById('memberList');
+    const featureModulesSection = document.getElementById('featureModulesSection');
+    const featureModulesTitle = document.getElementById('featureModulesTitle');
+    const featureModulesGrid = document.getElementById('featureModulesGrid');
+
+    function setStatus(message, isError = false) {
+      statusBox.style.color = isError ? 'var(--danger)' : 'var(--muted)';
+      statusBox.textContent = message;
     }
-    if (localStorage.getItem('theme') === 'light') {
-      document.body.classList.add('light-mode');
-      document.getElementById('themeIcon').innerText = '☀️';
+
+    function switchTab(tabName) {
+      document.querySelectorAll('.tab-btn').forEach((btn) => btn.classList.toggle('active', btn.dataset.tab === tabName));
+      document.querySelectorAll('.tab-content').forEach((section) => section.classList.add('hidden'));
+      document.getElementById(`${tabName}Tab`).classList.remove('hidden');
+      setStatus('');
     }
-  };
 
-  function toggleTheme() {
-    const isLight = document.body.classList.toggle('light-mode');
-    document.getElementById('themeIcon').innerText = isLight ? '☀️' : '🌙';
-    localStorage.setItem('theme', isLight ? 'light' : 'dark');
-  }
+    function setThemeFromStorage() {
+      if (localStorage.getItem('theme') === 'light') {
+        document.body.classList.add('light-mode');
+      }
+    }
 
-  function checkLogin() {
-    const u = document.getElementById('user').value.toLowerCase();
-    const p = document.getElementById('pass').value;
-    if(u === 'morsdag' && p === 'mamma2026') {
-      localStorage.setItem('morsdag_innlogget', 'true');
-      visInnloggetState();
-    } else { alert('Feil brukernavn eller passord'); }
-  }
+    function toggleTheme() {
+      const isLight = document.body.classList.toggle('light-mode');
+      localStorage.setItem('theme', isLight ? 'light' : 'dark');
+    }
 
-  function logout() {
-    localStorage.removeItem('morsdag_innlogget');
-    location.reload();
-  }
+    function renderFeatureModules(user) {
+      const visibleModules = FEATURE_MODULES.filter((moduleConfig) => !(moduleConfig.adminOnly && user.role !== 'admin'));
+      if (visibleModules.length === 0) {
+        featureModulesSection.classList.add('hidden');
+        featureModulesGrid.innerHTML = '';
+        return;
+      }
 
-  function visInnloggetState() {
-    document.getElementById('mainContent').style.display = 'none';
-    document.getElementById('loginFields').style.display = 'none';
-    document.getElementById('morsdagsContainer').style.display = 'block';
-    document.getElementById('logoutBtn').style.display = 'block';
-  }
-</script>
+      const containsPublicModules = visibleModules.some((moduleConfig) => !moduleConfig.adminOnly);
+      featureModulesTitle.textContent = containsPublicModules ? 'Ekstra moduler' : 'Admin-moduler';
+      featureModulesGrid.innerHTML = '';
 
+      for (const moduleConfig of visibleModules) {
+        const moduleGroup = document.createElement('div');
+        moduleGroup.className = 'module-group';
+
+        const heading = document.createElement('h4');
+        heading.textContent = moduleConfig.title;
+        moduleGroup.appendChild(heading);
+
+        for (const link of moduleConfig.links) {
+          const anchor = document.createElement('a');
+          anchor.href = link.href;
+          anchor.textContent = link.label;
+          moduleGroup.appendChild(anchor);
+        }
+
+        featureModulesGrid.appendChild(moduleGroup);
+      }
+
+      featureModulesSection.classList.remove('hidden');
+    }
+
+    async function fetchSession() {
+      const response = await fetch('/api/auth/session', { credentials: 'include' });
+      if (!response.ok) return null;
+      const data = await response.json();
+      return data.user || null;
+    }
+
+    async function renderMemberList(user) {
+      if (!user || user.role !== 'admin') {
+        memberListSection.classList.add('hidden');
+        memberList.innerHTML = '';
+        return;
+      }
+
+      const response = await fetch('/api/admin/users', { credentials: 'include' });
+      if (!response.ok) {
+        memberListSection.classList.add('hidden');
+        memberList.innerHTML = '';
+        return;
+      }
+
+      const data = await response.json();
+      memberList.innerHTML = '';
+      for (const member of data.users || []) {
+        const li = document.createElement('li');
+        li.textContent = `${member.username} (${member.email}) - role: ${member.role} - country: ${member.country || 'unknown'}`;
+        memberList.appendChild(li);
+      }
+      memberListSection.classList.remove('hidden');
+    }
+
+    async function showApp(user) {
+      welcomeText.textContent = `Innlogget som ${user.username} (${user.role})`;
+      authShell.classList.add('hidden');
+      appShell.classList.remove('hidden');
+      renderFeatureModules(user);
+      await renderMemberList(user);
+    }
+
+    async function login() {
+      const email = document.getElementById('loginEmail').value.trim().toLowerCase();
+      const password = document.getElementById('loginPassword').value;
+      if (!email || !password) {
+        setStatus('Fyll inn både e-post og passord.', true);
+        return;
+      }
+
+      const response = await fetch('/api/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ email, password })
+      });
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        setStatus(data.error || 'Innlogging feilet.', true);
+        return;
+      }
+
+      const data = await response.json();
+      await showApp(data.user);
+      setStatus('');
+    }
+
+    async function registerUser() {
+      const username = document.getElementById('registerUser').value.trim().toLowerCase();
+      const email = document.getElementById('registerEmail').value.trim().toLowerCase();
+      const password = document.getElementById('registerPassword').value;
+
+      const response = await fetch('/api/auth/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, email, password })
+      });
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        setStatus(data.error || 'Registrering feilet.', true);
+        return;
+      }
+
+      setStatus('Bruker opprettet. Logg inn med e-post og passord.');
+      switchTab('login');
+      document.getElementById('loginEmail').value = email;
+      document.getElementById('loginPassword').value = '';
+    }
+
+    async function logout() {
+      await fetch('/api/auth/logout', { method: 'POST', credentials: 'include' });
+      appShell.classList.add('hidden');
+      authShell.classList.remove('hidden');
+      setStatus('Logget ut.');
+    }
+
+    async function init() {
+      setThemeFromStorage();
+      const user = await fetchSession();
+      if (user) await showApp(user);
+
+      document.querySelectorAll('.tab-btn').forEach((btn) => btn.addEventListener('click', () => switchTab(btn.dataset.tab)));
+      document.getElementById('loginBtn').addEventListener('click', login);
+      document.getElementById('registerBtn').addEventListener('click', registerUser);
+      document.getElementById('logoutBtn').addEventListener('click', logout);
+      document.getElementById('themeToggle').addEventListener('click', toggleTheme);
+    }
+
+    init();
+  </script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "sarcasm-games",
+  "private": true,
+  "version": "1.0.0",
+  "dependencies": {
+    "@vercel/postgres": "^0.10.0",
+    "bcryptjs": "^2.4.3",
+    "jose": "^5.9.6"
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide server-side authentication with signed JWT session cookies and role-based access control backed by Postgres to replace the prior client-only login approach.
- Expose REST endpoints for registration, login, logout and session inspection to support a persistent site login flow and admin user listing.

### Description
- Added `api/_lib/auth.js` which implements JWT signing/verification using `jose`, cookie parsing/setting helpers, and `requireSession` middleware with a `sg_session` cookie and configurable secret via `AUTH_SECRET`/`NEXTAUTH_SECRET`.
- Added `api/_lib/db.js` which provides Postgres helpers via `@vercel/postgres` including `getUserByEmail`, `getUserByUsername`, `insertUser`, and `getUsersForAdminList`.
- Implemented API routes: `api/auth/register.js`, `api/auth/login.js`, `api/auth/logout.js`, and `api/auth/session.js` for user flows and `api/admin/users.js` which enforces admin role checks via `requireSession`.
- Reworked `index.html` to include a login/register UI and client-side JS that calls the new APIs, renders admin-only feature modules and a member list, and added `package.json` with new dependencies (`@vercel/postgres`, `bcryptjs`, `jose`).

### Testing
- No automated tests were added or executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afd46d213883339532de9c5304aab0)