### PR TITLE
Add pagination to quiz categories and remove embedded quiz modal from homepage

### DIFF
--- a/games/quiz/index.html
+++ b/games/quiz/index.html
@@ -124,6 +124,7 @@
       display: grid;
       grid-template-rows: auto 1fr auto;
       gap: 12px;
+      overflow: hidden;
     }
 
     .category-grid-wrap {
@@ -155,6 +156,31 @@
       border: 1px solid var(--bd);
       border-radius: 10px;
       padding: 10px;
+    }
+
+    #categorySection {
+      min-height: 0;
+      display: grid;
+      grid-template-rows: auto 1fr auto;
+      gap: 10px;
+    }
+
+    .category-pager {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 8px;
+    }
+
+    .category-page-label {
+      color: var(--muted);
+      font-size: .9rem;
+      min-width: 90px;
+      text-align: center;
+    }
+
+    .pager-btn {
+      min-width: 84px;
     }
 
     .category-card {
@@ -264,7 +290,12 @@
                 <div class="category-grid-wrap">
                   <div class="category-grid" id="categoryGrid"></div>
                 </div>
-                <div style="margin-top:10px;max-width:220px;">
+                <div class="category-pager">
+                  <button class="btn-neutral pager-btn" id="categoryPrevBtn" type="button">Previous</button>
+                  <span class="category-page-label" id="categoryPageLabel">Page 1/1</span>
+                  <button class="btn-neutral pager-btn" id="categoryNextBtn" type="button">Next</button>
+                </div>
+                <div style="max-width:220px;">
                   <label for="quizQuestionCount">Number of questions</label>
                   <input id="quizQuestionCount" type="number" min="1" value="10" />
                 </div>
@@ -324,7 +355,8 @@
       answers: [],
       index: 0,
       almostRetryUsed: false,
-      isQuestionLocked: false
+      isQuestionLocked: false,
+      categoryPage: 0
     };
 
     function setText(id, text, isError = false) {
@@ -344,6 +376,10 @@
       return state.progressByCategory.find((entry) => entry.category === categoryName) || { total: 0, correct: 0 };
     }
 
+    function getCategoriesPerPage() {
+      return window.innerWidth <= 700 ? 6 : 8;
+    }
+
     function renderModes() {
       const modeGrid = document.getElementById('modeGrid');
       modeGrid.innerHTML = '';
@@ -356,6 +392,7 @@
         button.addEventListener('click', () => {
           state.mode = mode;
           state.selectedCategories = new Set();
+          state.categoryPage = 0;
           renderModes();
           renderCategoryGrid();
           syncSetupState();
@@ -368,6 +405,9 @@
       const section = document.getElementById('categorySection');
       const title = document.getElementById('categoryTitle');
       const grid = document.getElementById('categoryGrid');
+      const prevBtn = document.getElementById('categoryPrevBtn');
+      const nextBtn = document.getElementById('categoryNextBtn');
+      const pageLabel = document.getElementById('categoryPageLabel');
       grid.innerHTML = '';
 
       if (state.mode === 'random10') {
@@ -379,7 +419,13 @@
       title.textContent = isCompletionist ? 'Choose completionist categories' : 'Choose categories';
       section.classList.remove('hidden');
 
-      for (const entry of state.categories) {
+      const perPage = getCategoriesPerPage();
+      const totalPages = Math.max(1, Math.ceil(state.categories.length / perPage));
+      state.categoryPage = Math.min(state.categoryPage, totalPages - 1);
+      const startIndex = state.categoryPage * perPage;
+      const visibleEntries = state.categories.slice(startIndex, startIndex + perPage);
+
+      for (const entry of visibleEntries) {
         const progress = getCategoryProgress(entry.category);
         const isCompleted = isCompletionist && Number(progress.total) > 0 && Number(progress.correct) >= Number(progress.total);
 
@@ -425,6 +471,10 @@
 
         grid.appendChild(card);
       }
+
+      pageLabel.textContent = `Page ${state.categoryPage + 1}/${totalPages}`;
+      prevBtn.disabled = state.categoryPage === 0;
+      nextBtn.disabled = state.categoryPage >= totalPages - 1;
     }
 
     function syncSetupState() {
@@ -691,6 +741,17 @@
       });
 
       document.getElementById('resetAllProgressBtn').addEventListener('click', resetAll);
+      document.getElementById('categoryPrevBtn').addEventListener('click', () => {
+        state.categoryPage = Math.max(0, state.categoryPage - 1);
+        renderCategoryGrid();
+      });
+      document.getElementById('categoryNextBtn').addEventListener('click', () => {
+        state.categoryPage += 1;
+        renderCategoryGrid();
+      });
+      window.addEventListener('resize', () => {
+        if (state.mode !== 'random10') renderCategoryGrid();
+      });
 
       document.getElementById('textAnswer').addEventListener('keydown', (event) => {
         if (event.key === 'Enter') {

--- a/index.html
+++ b/index.html
@@ -10,9 +10,9 @@
     body { margin:0; font:16px/1.4 system-ui, Segoe UI, Roboto, Arial; background:var(--bg); color:var(--txt); min-height:100dvh; }
     .hidden{display:none!important}
 
-    .auth-shell,.quiz-shell{position:fixed;inset:0;padding:24px;display:grid;place-items:center;background:rgba(0,0,0,.55);z-index:2000}
-    .auth-card,.quiz-card{width:min(700px,100%);background:var(--card);border:1px solid var(--bd);border-radius:14px;padding:20px;box-sizing:border-box;position:relative;max-height:88vh;overflow:auto}
-    .auth-close,.quiz-close{position:absolute;top:10px;right:10px;background:transparent;border:1px solid var(--bd);color:var(--txt);padding:6px 10px;border-radius:8px}
+    .auth-shell{position:fixed;inset:0;padding:24px;display:grid;place-items:center;background:rgba(0,0,0,.55);z-index:2000}
+    .auth-card{width:min(700px,100%);background:var(--card);border:1px solid var(--bd);border-radius:14px;padding:20px;box-sizing:border-box;position:relative;max-height:88vh;overflow:auto}
+    .auth-close{position:absolute;top:10px;right:10px;background:transparent;border:1px solid var(--bd);color:var(--txt);padding:6px 10px;border-radius:8px}
     .auth-title{margin:0 0 8px;font-size:1.6rem}
     .auth-subtitle{margin:0 0 16px;color:var(--muted)}
     .auth-tabs{display:flex;gap:8px;margin-bottom:14px;flex-wrap:wrap}
@@ -45,15 +45,6 @@
     .module-group{border:1px dashed var(--bd);border-radius:10px;padding:10px}
     .module-group h4{margin:0 0 8px}
 
-    .quiz-mode-grid{display:grid;gap:10px;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));margin-bottom:14px}
-    .quiz-section{border:1px solid var(--bd);border-radius:12px;padding:12px;margin-bottom:12px}
-    .quiz-category-list{display:grid;gap:8px;max-height:260px;overflow:auto;padding-right:4px}
-    .quiz-category-item{position:relative;display:block;gap:8px;border:1px solid var(--bd);border-radius:8px;padding:12px;cursor:pointer;user-select:none}
-    .quiz-category-item.selected{border-color:var(--accent);box-shadow:0 0 0 1px var(--accent) inset}
-    .quiz-category-item.disabled{opacity:.55;cursor:not-allowed}
-    .quiz-answer-list{display:grid;gap:8px;margin-top:14px}
-    .quiz-progress{margin-top:8px;color:var(--muted)}
-    .quiz-result{font-size:1.1rem;font-weight:700;margin-bottom:10px}
   </style>
 </head>
 <body>
@@ -176,58 +167,6 @@
       </div>
     </div>
 
-    <div id="quizShell" class="quiz-shell hidden">
-      <div class="quiz-card">
-        <button class="quiz-close" id="closeQuizBtn" type="button">✕</button>
-        <h2>NY QUIZ</h2>
-        <div class="form-group" style="max-width:180px;">
-          <label for="quizLanguage">Language</label>
-          <select id="quizLanguage" style="width:100%;background:var(--bg);border:1px solid var(--bd);color:var(--txt);padding:8px;border-radius:8px;">
-            <option value="en" selected>English</option>
-            <option value="no">Norsk</option>
-          </select>
-        </div>
-
-        <section id="quizSetupView">
-          <div class="quiz-mode-grid">
-            <button class="btn-primary" data-quiz-mode="random10">Random 10</button>
-            <button class="btn-neutral" data-quiz-mode="categories">Categories</button>
-            <button class="btn-neutral" data-quiz-mode="completionist">Completionist</button>
-          </div>
-
-          <div class="quiz-section hidden" id="quizCategorySection">
-            <h3 id="quizCategoryTitle">Choose categories</h3>
-            <div class="quiz-category-list" id="quizCategoryList"></div>
-            <div class="form-group">
-              <label for="quizQuestionCount">Number of questions</label>
-              <input id="quizQuestionCount" type="number" min="1" value="10" />
-            </div>
-            <div class="btn-row">
-              <button class="btn-primary" id="startCategoryQuizBtn">Start quiz</button>
-              <button class="btn-danger hidden" id="resetAllProgressBtn" type="button">Reset All Progress</button>
-            </div>
-          </div>
-
-          <div class="status-box" id="quizStatusBox"></div>
-          <div class="form-group hidden">
-            <label for="quizHoneypot">Website</label>
-            <input id="quizHoneypot" type="text" autocomplete="off" tabindex="-1" />
-          </div>
-        </section>
-
-        <section id="quizQuestionView" class="hidden">
-          <h3 id="quizQuestionTitle"></h3>
-          <div class="quiz-progress" id="quizProgress"></div>
-          <div class="quiz-answer-list" id="quizAnswerList"></div>
-          <div class="status-box" id="quizAnswerStatus"></div>
-        </section>
-
-        <section id="quizResultView" class="hidden">
-          <div class="quiz-result" id="quizResultSummary"></div>
-          <button class="btn-primary" id="restartQuizBtn">Back to setup</button>
-        </section>
-      </div>
-    </div>
   </div>
 
   <script>
@@ -249,7 +188,7 @@
         title: '🧠 NY QUIZ',
         adminOnly: true,
         links: [
-          { label: 'Launch NY QUIZ', href: '/games/quiz/' }
+          { label: 'Open NY QUIZ page', href: '/games/quiz/' }
         ]
       }
     ];
@@ -265,18 +204,6 @@
     let failedResetAttempts = 0;
     let currentUser = null;
 
-    const quizState = {
-      mode: null,
-      categories: [],
-      progressByCategory: [],
-      questions: [],
-      answers: [],
-      index: 0,
-      selectedCategories: new Set(),
-      language: 'en',
-      almostRetryUsed: false
-    };
-
     const statusBox = document.getElementById('statusBox');
     const authShell = document.getElementById('authShell');
     const welcomeText = document.getElementById('welcomeText');
@@ -289,18 +216,14 @@
     const resetInfoBtn = document.getElementById('resetInfoBtn');
     const logoutBtn = document.getElementById('logoutBtn');
     const toggleLoginBtn = document.getElementById('toggleLoginBtn');
-    const quizShell = document.getElementById('quizShell');
-    const quizStatusBox = document.getElementById('quizStatusBox');
+
+
 
     function setStatus(message, isError = false) {
       statusBox.style.color = isError ? 'var(--danger)' : 'var(--muted)';
       statusBox.textContent = message;
     }
 
-    function setQuizStatus(message, isError = false) {
-      quizStatusBox.style.color = isError ? 'var(--danger)' : 'var(--muted)';
-      quizStatusBox.textContent = message;
-    }
 
     function toggleLoginPanel() {
       if (currentUser) return;
@@ -521,347 +444,8 @@
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ honeypot: '' })
       });
-      closeQuizModal();
       await applyUserState(null);
       setStatus('Logged out.');
-    }
-
-    function closeQuizModal() {
-      quizShell.classList.add('hidden');
-      document.getElementById('quizSetupView').classList.remove('hidden');
-      document.getElementById('quizQuestionView').classList.add('hidden');
-      document.getElementById('quizResultView').classList.add('hidden');
-      setQuizStatus('');
-    }
-
-    async function openQuizModal() {
-      if (!currentUser || currentUser.role !== 'admin') {
-        setStatus('Only admin users can access NY QUIZ.', true);
-        return;
-      }
-      quizShell.classList.remove('hidden');
-      await loadQuizOverview();
-    }
-
-    async function loadQuizOverview() {
-      setQuizStatus('Loading categories...');
-      const response = await fetch('/api/quiz/overview', { credentials: 'include' });
-      if (!response.ok) {
-        const data = await response.json().catch(() => ({}));
-        setQuizStatus(data.error || 'Could not load quiz overview.', true);
-        return;
-      }
-
-      const data = await response.json();
-      quizState.categories = data.categories || [];
-      quizState.progressByCategory = data.progress || [];
-      renderCategoryOptions('categories');
-      setQuizStatus('Choose a quiz mode to begin.');
-    }
-
-    function getCategoryProgress(categoryName) {
-      return quizState.progressByCategory.find((entry) => entry.category === categoryName) || { total: 0, correct: 0 };
-    }
-
-    function renderCategoryOptions(mode) {
-      const section = document.getElementById('quizCategorySection');
-      const list = document.getElementById('quizCategoryList');
-      const title = document.getElementById('quizCategoryTitle');
-      const resetAllBtn = document.getElementById('resetAllProgressBtn');
-      list.innerHTML = '';
-
-      const isCompletionist = mode === 'completionist';
-      title.textContent = isCompletionist ? 'Completionist category setup' : 'Category setup';
-      resetAllBtn.classList.toggle('hidden', !isCompletionist);
-
-      for (const item of quizState.categories) {
-        const progress = getCategoryProgress(item.category);
-        const isCompleted = isCompletionist && Number(progress.correct) >= Number(progress.total) && Number(progress.total) > 0;
-
-        const wrapper = document.createElement('div');
-        wrapper.className = `quiz-category-item${quizState.selectedCategories.has(item.category) ? ' selected' : ''}${isCompleted ? ' disabled' : ''}`;
-
-        const label = document.createElement('div');
-        label.textContent = isCompletionist
-          ? `${item.category} - Correct: ${progress.correct}/${progress.total}`
-          : `${item.category} (${item.total})`;
-
-        const resetBtn = document.createElement('button');
-        resetBtn.type = 'button';
-        resetBtn.className = 'btn-danger';
-        resetBtn.style.position = 'absolute';
-        resetBtn.style.top = '8px';
-        resetBtn.style.right = '8px';
-        resetBtn.style.padding = '6px 8px';
-        resetBtn.textContent = 'Reset';
-        resetBtn.classList.toggle('hidden', !isCompletionist);
-        resetBtn.addEventListener('click', (event) => {
-          event.stopPropagation();
-          resetCategoryProgress(item.category);
-        });
-
-        wrapper.addEventListener('click', () => {
-          if (isCompleted) return;
-          if (quizState.selectedCategories.has(item.category)) {
-            quizState.selectedCategories.delete(item.category);
-          } else {
-            quizState.selectedCategories.add(item.category);
-          }
-          renderCategoryOptions(mode);
-        });
-
-        wrapper.appendChild(label);
-        wrapper.appendChild(resetBtn);
-        list.appendChild(wrapper);
-      }
-
-      section.classList.remove('hidden');
-    }
-
-    function getSelectedCategories() {
-      return [...quizState.selectedCategories];
-    }
-
-    async function startQuiz(mode) {
-      if (!currentUser || currentUser.role !== 'admin') {
-        setQuizStatus('Only admin users can start NY QUIZ.', true);
-        return;
-      }
-
-      let count = 10;
-      let categories = [];
-
-      if (mode !== 'random10') {
-        categories = getSelectedCategories();
-        if (categories.length === 0) {
-          setQuizStatus('Select at least one category.', true);
-          return;
-        }
-
-        const rawCount = Number(document.getElementById('quizQuestionCount').value);
-        if (!Number.isFinite(rawCount) || rawCount < 1) {
-          setQuizStatus('Enter a valid question count.', true);
-          return;
-        }
-
-        const totalAvailable = categories.reduce((sum, category) => {
-          const categoryInfo = quizState.categories.find((item) => item.category === category);
-          if (!categoryInfo) return sum;
-          if (mode === 'completionist') {
-            const progress = getCategoryProgress(category);
-            return sum + Math.max(0, Number(progress.total) - Number(progress.correct));
-          }
-          return sum + Number(categoryInfo.total || 0);
-        }, 0);
-
-        if (rawCount > totalAvailable) {
-          setQuizStatus(`Count must be between 1 and ${totalAvailable}.`, true);
-          return;
-        }
-
-        count = rawCount;
-      }
-
-      const response = await fetch('/api/quiz/start', {
-        method: 'POST',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          mode,
-          count,
-          categories,
-          honeypot: document.getElementById('quizHoneypot').value
-        })
-      });
-
-      if (!response.ok) {
-        const data = await response.json().catch(() => ({}));
-        setQuizStatus(data.error || 'Failed to start quiz.', true);
-        return;
-      }
-
-      const data = await response.json();
-      if (!Array.isArray(data.questions) || data.questions.length === 0) {
-        setQuizStatus('No questions available for this setup.', true);
-        return;
-      }
-
-      quizState.mode = mode;
-      quizState.questions = data.questions;
-      quizState.answers = [];
-      quizState.index = 0;
-
-      document.getElementById('quizSetupView').classList.add('hidden');
-      document.getElementById('quizResultView').classList.add('hidden');
-      document.getElementById('quizQuestionView').classList.remove('hidden');
-      renderCurrentQuestion();
-    }
-
-    function renderCurrentQuestion() {
-      const question = quizState.questions[quizState.index];
-      if (!question) {
-        showQuizResults();
-        return;
-      }
-
-      const localizedQuestion = quizState.language === 'no' ? question.questionNo : question.questionEn;
-      document.getElementById('quizQuestionTitle').textContent = `${question.category}: ${localizedQuestion}`;
-      document.getElementById('quizProgress').textContent = `Question ${quizState.index + 1} of ${quizState.questions.length}`;
-      document.getElementById('quizAnswerStatus').textContent = '';
-      quizState.almostRetryUsed = false;
-
-      const list = document.getElementById('quizAnswerList');
-      list.innerHTML = '';
-
-      const input = document.createElement('input');
-      input.type = 'text';
-      input.id = 'quizTextAnswer';
-      input.placeholder = quizState.language === 'no' ? 'Skriv svaret ditt' : 'Type your answer';
-      list.appendChild(input);
-
-      const submitBtn = document.createElement('button');
-      submitBtn.className = 'btn-primary';
-      submitBtn.textContent = quizState.language === 'no' ? 'Svar' : 'Submit answer';
-      submitBtn.addEventListener('click', () => submitQuizAnswer(question.id));
-      list.appendChild(submitBtn);
-
-      input.addEventListener('keydown', (event) => {
-        if (event.key === 'Enter') {
-          event.preventDefault();
-          submitQuizAnswer(question.id);
-        }
-      });
-
-      setTimeout(() => input.focus(), 0);
-    }
-
-    async function submitQuizAnswer(questionId) {
-      const input = document.getElementById('quizTextAnswer');
-      const selectedAnswer = input ? input.value : '';
-
-      const response = await fetch('/api/quiz/answer', {
-        method: 'POST',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          questionId,
-          selectedAnswer,
-          language: quizState.language,
-          retryUsed: quizState.almostRetryUsed,
-          honeypot: document.getElementById('quizHoneypot').value
-        })
-      });
-
-      if (!response.ok) {
-        const data = await response.json().catch(() => ({}));
-        document.getElementById('quizAnswerStatus').textContent = data.error || 'Could not submit answer.';
-        return;
-      }
-
-      const data = await response.json();
-
-      if (data.status === 'almost') {
-        quizState.almostRetryUsed = true;
-        document.getElementById('quizAnswerStatus').textContent = quizState.language === 'no'
-          ? 'Nesten! Prøv én gang til.'
-          : 'Almost! Try one more time.';
-        return;
-      }
-
-      if (data.status === 'correct') {
-        quizState.answers.push(true);
-        document.getElementById('quizAnswerStatus').textContent = quizState.language === 'no' ? 'Riktig ✅' : 'Correct ✅';
-        setTimeout(() => {
-          quizState.index += 1;
-          renderCurrentQuestion();
-        }, 450);
-        return;
-      }
-
-      quizState.answers.push(false);
-      const statusBox = document.getElementById('quizAnswerStatus');
-      statusBox.textContent = quizState.language === 'no'
-        ? `Feil ❌ (Riktig svar: ${data.correctAnswer})`
-        : `Incorrect ❌ (Correct answer: ${data.correctAnswer})`;
-
-      const list = document.getElementById('quizAnswerList');
-      const nextBtn = document.createElement('button');
-      nextBtn.className = 'btn-primary';
-      nextBtn.textContent = quizState.language === 'no' ? 'Neste spørsmål' : 'Next question';
-      nextBtn.addEventListener('click', () => {
-        quizState.index += 1;
-        renderCurrentQuestion();
-      });
-      list.appendChild(nextBtn);
-    }
-
-    function showQuizResults() {
-      const correct = quizState.answers.filter(Boolean).length;
-      const total = quizState.answers.length;
-      document.getElementById('quizQuestionView').classList.add('hidden');
-      document.getElementById('quizResultView').classList.remove('hidden');
-      document.getElementById('quizResultSummary').textContent = `Result: ${correct}/${total} correct`;
-      loadQuizOverview();
-    }
-
-    async function resetCategoryProgress(category) {
-      const response = await fetch('/api/quiz/reset-category', {
-        method: 'POST',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ category, honeypot: document.getElementById('quizHoneypot').value })
-      });
-
-      if (!response.ok) {
-        const data = await response.json().catch(() => ({}));
-        setQuizStatus(data.error || 'Could not reset category progress.', true);
-        return;
-      }
-
-      setQuizStatus(`Progress reset for ${category}.`);
-      await loadQuizOverview();
-      renderCategoryOptions('completionist');
-    }
-
-    async function resetAllProgress() {
-      if (!confirm('Are you sure you want to reset ALL quiz progress?')) {
-        return;
-      }
-
-      const response = await fetch('/api/quiz/reset-all', {
-        method: 'POST',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ honeypot: document.getElementById('quizHoneypot').value })
-      });
-
-      if (!response.ok) {
-        const data = await response.json().catch(() => ({}));
-        setQuizStatus(data.error || 'Could not reset all progress.', true);
-        return;
-      }
-
-      setQuizStatus('All progress was reset.');
-      await loadQuizOverview();
-      renderCategoryOptions('completionist');
-    }
-
-    async function showModeSelection(mode) {
-      quizState.mode = mode;
-      quizState.selectedCategories = new Set();
-      const section = document.getElementById('quizCategorySection');
-
-      if (mode === 'random10') {
-        section.classList.add('hidden');
-        await startQuiz('random10');
-        return;
-      }
-
-      renderCategoryOptions(mode);
-      section.classList.remove('hidden');
-      setQuizStatus(mode === 'completionist'
-        ? 'Select categories and amount. Only not-yet-correct questions will be used.'
-        : 'Select categories and amount for your quiz.');
     }
 
     async function init() {
@@ -883,31 +467,12 @@
       document.getElementById('toggleLoginBtn').addEventListener('click', toggleLoginPanel);
       document.getElementById('closeLoginBtn').addEventListener('click', closeLoginPanel);
 
-      document.getElementById('closeQuizBtn').addEventListener('click', closeQuizModal);
-      document.getElementById('quizLanguage').addEventListener('change', (event) => {
-        quizState.language = event.target.value === 'no' ? 'no' : 'en';
-        if (!document.getElementById('quizQuestionView').classList.contains('hidden')) {
-          renderCurrentQuestion();
-        }
-      });
-      document.getElementById('restartQuizBtn').addEventListener('click', () => {
-        document.getElementById('quizResultView').classList.add('hidden');
-        document.getElementById('quizSetupView').classList.remove('hidden');
-        document.getElementById('quizCategorySection').classList.add('hidden');
-        setQuizStatus('Choose a quiz mode to begin.');
-      });
-      document.getElementById('startCategoryQuizBtn').addEventListener('click', () => startQuiz(quizState.mode || 'categories'));
-      document.getElementById('resetAllProgressBtn').addEventListener('click', resetAllProgress);
 
-      document.querySelectorAll('[data-quiz-mode]').forEach((button) => {
-        button.addEventListener('click', () => showModeSelection(button.dataset.quizMode));
-      });
 
       document.addEventListener('keydown', (event) => {
         if (event.key === 'Escape') {
           closeLoginPanel();
-          closeQuizModal();
-        }
+            }
       });
 
       const submitOnEnter = (event) => {


### PR DESCRIPTION
### Motivation

- Improve usability of the quiz category selector by introducing paging for large category lists and making the category grid responsive. 
- Consolidate quiz UI into the dedicated `/games/quiz/` page and remove the old embedded modal implementation from the homepage. 
- Tidy up layout and prevent scroll overflow in setup/category areas.

### Description

- In `games/quiz/index.html` add category pagination UI (previous/next buttons and page label), a responsive `getCategoriesPerPage()` helper, `state.categoryPage`, and pager event handlers including a `resize` listener to re-render pages. 
- Update category rendering to show only the entries for the current page, compute `totalPages`, and enable/disable pager buttons and label accordingly. 
- Add CSS for `.category-pager`, `.category-page-label`, `.pager-btn`, and layout improvements including `overflow: hidden` for `.setup-view-layout` and a structured `#categorySection`. 
- In `index.html` remove the old embedded quiz modal markup and its supporting scripts and state, and update the feature module link label to `Open NY QUIZ page` to point users to the standalone quiz page. 
- Remove modal-specific helpers and event handlers (open/close modal, in-page quiz rendering and state) and adjust `logout()` to no longer reference the removed modal cleanup function. 

### Testing

- No automated tests were added for these UI changes. Manual smoke checks were performed by loading the homepage and the `/games/quiz/` page to verify the pager UI, mode selection, and that the homepage no longer contains the embedded quiz modal.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0597b4eac8333820d982b709e0e12)