### PR TITLE
Add Elemental Garden feature: UI, sync API, weather & production services

### DIFF
--- a/api/_lib/db.js
+++ b/api/_lib/db.js
@@ -169,6 +169,7 @@ async function resetAllUserProgress(userId) {
 }
 
 module.exports = {
+  runQuery,
   getUserByEmail,
   getUserByUsername,
   insertUser,

--- a/api/sync.js
+++ b/api/sync.js
@@ -1,0 +1,27 @@
+const { isRateLimited } = require('./_lib/rate-limit');
+const { requireSession } = require('./_lib/auth');
+const { syncGarden } = require('../lib/server/garden-sync-service');
+
+module.exports = async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  if (isRateLimited(req, 'garden:sync')) {
+    res.status(429).json({ error: 'Too many requests' });
+    return;
+  }
+
+  const session = await requireSession(req, res);
+  if (!session) return;
+
+  try {
+    const payload = await syncGarden(session.id);
+    res.status(200).json(payload);
+  } catch (error) {
+    console.error('[sync] Failed to sync garden:', error.message);
+    res.status(500).json({ error: 'Unable to sync garden right now.' });
+  }
+};

--- a/api/weather.js
+++ b/api/weather.js
@@ -1,0 +1,27 @@
+const { isRateLimited } = require('./_lib/rate-limit');
+const { requireSession } = require('./_lib/auth');
+const { fetchCurrentWeather } = require('../lib/server/weather-service');
+
+module.exports = async function handler(req, res) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  if (isRateLimited(req, 'garden:weather')) {
+    res.status(429).json({ error: 'Too many requests' });
+    return;
+  }
+
+  const session = await requireSession(req, res);
+  if (!session) return;
+
+  try {
+    const weather = await fetchCurrentWeather();
+    res.status(200).json(weather);
+  } catch (error) {
+    console.error('[weather] Failed to fetch weather:', error.message);
+    res.status(500).json({ error: 'Unable to fetch weather right now.' });
+  }
+};

--- a/garden/index.html
+++ b/garden/index.html
@@ -1,0 +1,168 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>The Elemental Garden</title>
+  <style>
+    :root {
+      --bg: #0b1220;
+      --card: #152238;
+      --muted: #9fb3d1;
+      --text: #f3f8ff;
+      --accent: #7dd3fc;
+      --good: #86efac;
+      --border: #244267;
+    }
+    body { margin: 0; font-family: Inter, system-ui, sans-serif; background: radial-gradient(circle at top, #13233b 0%, var(--bg) 55%); color: var(--text); }
+    .app { display: grid; grid-template-columns: 240px 1fr; min-height: 100vh; }
+    .sidebar { border-right: 1px solid var(--border); padding: 20px; background: rgba(11,18,32,.72); }
+    .sidebar h1 { font-size: 1.1rem; margin: 0 0 14px; }
+    .nav { display: grid; gap: 8px; }
+    .nav div { background: var(--card); border: 1px solid var(--border); border-radius: 10px; padding: 10px; color: var(--muted); }
+    .main { padding: 20px; display: grid; gap: 16px; }
+    .topbar { display: grid; grid-template-columns: repeat(4, minmax(150px, 1fr)); gap: 12px; }
+    .chip, .panel { background: rgba(21,34,56,.9); border: 1px solid var(--border); border-radius: 12px; padding: 12px; }
+    .chip p, .panel p { margin: 0; color: var(--muted); font-size: .9rem; }
+    .chip strong { display: block; margin-top: 6px; font-size: 1rem; color: var(--text); }
+    .layout { display: grid; grid-template-columns: 2fr 1fr; gap: 16px; }
+    .slots { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 12px; }
+    .slot { background: var(--card); border: 1px solid var(--border); border-radius: 12px; padding: 10px; min-height: 180px; }
+    .slot img { width: 90px; height: 90px; object-fit: contain; display: block; margin: 6px auto; }
+    .slot h4 { margin: 6px 0; text-align: center; }
+    .muted { color: var(--muted); font-size: .85rem; }
+    .bonus { color: var(--good); }
+    .essences { display: grid; gap: 8px; max-height: 460px; overflow: auto; }
+    .essence-row { display: flex; justify-content: space-between; background: var(--card); border: 1px solid var(--border); border-radius: 10px; padding: 8px 10px; }
+    #status { color: var(--muted); }
+    @media (max-width: 920px) { .app { grid-template-columns: 1fr; } .layout { grid-template-columns: 1fr; } .topbar { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+  </style>
+</head>
+<body>
+  <div class="app">
+    <aside class="sidebar">
+      <h1>🌿 The Elemental Garden</h1>
+      <div class="nav">
+        <div>Garden</div>
+        <div>Collection</div>
+        <div>Lures</div>
+        <div>Research (soon)</div>
+        <div>Daily Tasks (soon)</div>
+        <div>Settings</div>
+      </div>
+    </aside>
+
+    <main class="main">
+      <section class="topbar">
+        <div class="chip"><p>Weather</p><strong id="weatherLabel">Loading…</strong></div>
+        <div class="chip"><p>Boosted types</p><strong id="boostedTypes">-</strong></div>
+        <div class="chip"><p>Total essence/sec</p><strong id="totalPps">0.00</strong></div>
+        <div class="chip"><p>Active lure</p><strong id="lureStatus">No finished lures</strong></div>
+      </section>
+
+      <div class="layout">
+        <section class="panel">
+          <h3>Active Team (max 6)</h3>
+          <p class="muted">Only active Pokémon generate full income.</p>
+          <div class="slots" id="slots"></div>
+        </section>
+
+        <section class="panel">
+          <h3>Essence Pool</h3>
+          <div class="essences" id="essenceList"></div>
+        </section>
+      </div>
+
+      <p id="status">Syncing...</p>
+    </main>
+  </div>
+
+  <script>
+    const essenceList = document.getElementById('essenceList');
+    const slots = document.getElementById('slots');
+
+    function formatNumber(value) {
+      return Number(value || 0).toLocaleString(undefined, { maximumFractionDigits: 2 });
+    }
+
+    function renderSlots(activePokemon) {
+      slots.innerHTML = '';
+      for (let index = 1; index <= 6; index += 1) {
+        const pokemon = (activePokemon || []).find((item) => Number(item.slotIndex) === index);
+        const card = document.createElement('article');
+        card.className = 'slot';
+
+        if (!pokemon) {
+          card.innerHTML = `<h4>Slot ${index}</h4><p class="muted">Empty slot</p>`;
+          slots.appendChild(card);
+          continue;
+        }
+
+        const boostText = pokemon.boostedType
+          ? `<p class="muted bonus">Weather boost: ${pokemon.boostedType} ×${formatNumber(pokemon.weatherMultiplier)}</p>`
+          : '<p class="muted">No weather boost</p>';
+
+        card.innerHTML = `
+          <h4>Slot ${index} · ${pokemon.name}</h4>
+          <img src="${pokemon.spriteUrl || ''}" alt="${pokemon.name}" />
+          <p class="muted">Level ${pokemon.level || 1} · ${pokemon.types.join(', ') || 'unknown'}</p>
+          <p class="muted">Income/sec: ${formatNumber(pokemon.incomePerSecond)}</p>
+          ${boostText}
+        `;
+        slots.appendChild(card);
+      }
+    }
+
+    function renderEssence(resources) {
+      if (!resources) return;
+      essenceList.innerHTML = '';
+
+      const keys = Object.keys(resources)
+        .filter((key) => key.endsWith('_essence'))
+        .sort();
+
+      for (const key of keys) {
+        const row = document.createElement('div');
+        row.className = 'essence-row';
+        const name = key.replace('_essence', '').replaceAll('_', ' ');
+        row.innerHTML = `<span>${name}</span><strong>${formatNumber(resources[key])}</strong>`;
+        essenceList.appendChild(row);
+      }
+    }
+
+    function applyPayload(payload) {
+      document.getElementById('weatherLabel').textContent = `${payload.weather.weatherKey} (${payload.weather.rawCondition})`;
+      document.getElementById('boostedTypes').textContent = payload.weatherBonuses?.join(', ') || 'None';
+      document.getElementById('totalPps').textContent = formatNumber(payload.productionPerSecond || 0);
+      document.getElementById('lureStatus').textContent = payload.finishedLures?.length
+        ? `${payload.finishedLures.length} finished`
+        : 'No finished lures';
+      renderSlots(payload.activePokemon || []);
+      renderEssence(payload.resources || {});
+    }
+
+    async function syncGarden() {
+      const status = document.getElementById('status');
+      status.textContent = 'Syncing...';
+      try {
+        const response = await fetch('/api/sync', { method: 'POST', credentials: 'include' });
+        if (!response.ok) {
+          if (response.status === 401) {
+            status.textContent = 'You must be logged in to access The Elemental Garden.';
+            return;
+          }
+          throw new Error('Sync failed');
+        }
+        const payload = await response.json();
+        applyPayload(payload);
+        status.textContent = `Last sync: ${new Date().toLocaleTimeString()}`;
+      } catch (error) {
+        status.textContent = 'Sync error. Please try again in a few seconds.';
+      }
+    }
+
+    syncGarden();
+    setInterval(syncGarden, 20000);
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -190,6 +190,14 @@
         links: [
           { label: 'Open NY QUIZ page', href: '/games/quiz/' }
         ]
+      },
+      {
+        id: 'elemental-garden',
+        title: '🌿 The Elemental Garden',
+        adminOnly: true,
+        links: [
+          { label: 'Open Elemental Garden', href: '/garden/' }
+        ]
       }
     ];
 

--- a/lib/server/garden-sync-service.js
+++ b/lib/server/garden-sync-service.js
@@ -1,0 +1,152 @@
+const { runQuery } = require('../../api/_lib/db');
+const { fetchCurrentWeather } = require('./weather-service');
+const { computePokemonIncomePerSecond } = require('./pokemon-service');
+const { getFinishedLures } = require('./lure-service');
+
+const ESSENCE_TYPES = [
+  'normal', 'fire', 'water', 'electric', 'grass', 'ice',
+  'fighting', 'poison', 'ground', 'flying', 'psychic', 'bug',
+  'rock', 'ghost', 'dragon', 'dark', 'steel', 'fairy'
+];
+
+function getEssenceColumn(type) {
+  return `${type}_essence`;
+}
+
+function createEmptyEssenceState() {
+  return ESSENCE_TYPES.reduce((acc, type) => {
+    acc[getEssenceColumn(type)] = 0;
+    return acc;
+  }, {});
+}
+
+async function ensureGardenRow(userId) {
+  const result = await runQuery(
+    `INSERT INTO user_gardens (user_id, last_sync_at)
+     VALUES ($1, NOW())
+     ON CONFLICT (user_id) DO UPDATE SET user_id = EXCLUDED.user_id
+     RETURNING *`,
+    [userId]
+  );
+  return result.rows[0] || null;
+}
+
+async function getActivePokemon(userId) {
+  const result = await runQuery(
+    `SELECT id, pokemon_id, name, sprite_url, types, level, base_income, is_active, slot_index
+     FROM user_pokemon
+     WHERE user_id = $1
+       AND is_active = TRUE
+       AND slot_index BETWEEN 1 AND 6
+     ORDER BY slot_index ASC`,
+    [userId]
+  );
+  return result.rows;
+}
+
+function computeProduction(activePokemon, weather) {
+  const totals = {
+    totalPerSecond: 0,
+    byTypePerSecond: createEmptyEssenceState(),
+    pokemon: []
+  };
+
+  for (const pokemon of activePokemon) {
+    const income = computePokemonIncomePerSecond(pokemon.base_income, pokemon.types, weather.multiplierMap);
+    totals.totalPerSecond += income.incomePerSecond;
+
+    for (const type of income.types) {
+      const column = getEssenceColumn(type);
+      if (!(column in totals.byTypePerSecond)) continue;
+      totals.byTypePerSecond[column] += income.incomePerSecond;
+    }
+
+    totals.pokemon.push({
+      id: pokemon.id,
+      pokemonId: pokemon.pokemon_id,
+      name: pokemon.name,
+      spriteUrl: pokemon.sprite_url,
+      level: pokemon.level,
+      slotIndex: pokemon.slot_index,
+      types: income.types,
+      baseIncomePerSecond: income.baseIncomePerSecond,
+      incomePerSecond: income.incomePerSecond,
+      weatherMultiplier: income.weatherMultiplier,
+      boostedType: income.boostedType
+    });
+  }
+
+  return totals;
+}
+
+async function updateGardenResources(userId, secondsSinceLastSync, byTypePerSecond) {
+  const values = ESSENCE_TYPES.map((type) => {
+    const column = getEssenceColumn(type);
+    return byTypePerSecond[column] * secondsSinceLastSync;
+  });
+
+  const assignments = ESSENCE_TYPES.map((type, index) => {
+    const column = getEssenceColumn(type);
+    return `${column} = COALESCE(${column}, 0) + $${index + 2}`;
+  }).join(', ');
+
+  await runQuery(
+    `UPDATE user_gardens
+     SET ${assignments},
+         last_sync_at = NOW(),
+         updated_at = NOW()
+     WHERE user_id = $1`,
+    [userId, ...values]
+  );
+}
+
+async function getGardenEssence(userId) {
+  const selectColumns = ESSENCE_TYPES.map((type) => getEssenceColumn(type)).join(', ');
+  const result = await runQuery(
+    `SELECT ${selectColumns}, last_sync_at
+     FROM user_gardens
+     WHERE user_id = $1
+     LIMIT 1`,
+    [userId]
+  );
+
+  return result.rows[0] || null;
+}
+
+async function syncGarden(userId) {
+  const [weather, garden, activePokemon] = await Promise.all([
+    fetchCurrentWeather(),
+    ensureGardenRow(userId),
+    getActivePokemon(userId)
+  ]);
+
+  const now = Date.now();
+  const lastSync = garden?.last_sync_at ? new Date(garden.last_sync_at).getTime() : now;
+  const secondsSinceLastSync = Math.max(0, Math.floor((now - lastSync) / 1000));
+  const production = computeProduction(activePokemon, weather);
+
+  if (secondsSinceLastSync > 0) {
+    await updateGardenResources(userId, secondsSinceLastSync, production.byTypePerSecond);
+  }
+
+  const [resourceState, finishedLures] = await Promise.all([
+    getGardenEssence(userId),
+    getFinishedLures(userId)
+  ]);
+
+  return {
+    weather,
+    secondsSinceLastSync,
+    productionPerSecond: production.totalPerSecond,
+    activePokemon: production.pokemon,
+    resources: resourceState,
+    weatherBonuses: weather.boostedTypes,
+    finishedLures,
+    claimableRewards: []
+  };
+}
+
+module.exports = {
+  syncGarden,
+  ESSENCE_TYPES
+};

--- a/lib/server/lure-service.js
+++ b/lib/server/lure-service.js
@@ -1,0 +1,22 @@
+const { runQuery } = require('../../api/_lib/db');
+
+async function getFinishedLures(userId) {
+  try {
+    const result = await runQuery(
+      `SELECT id, lure_type, placed_at, expires_at
+       FROM user_lures
+       WHERE user_id = $1
+         AND expires_at <= NOW()
+       ORDER BY expires_at ASC`,
+      [userId]
+    );
+
+    return result.rows;
+  } catch (_error) {
+    return [];
+  }
+}
+
+module.exports = {
+  getFinishedLures
+};

--- a/lib/server/pokemon-service.js
+++ b/lib/server/pokemon-service.js
@@ -1,0 +1,61 @@
+function normalizePokemonTypes(typesValue) {
+  if (!typesValue) return [];
+
+  if (Array.isArray(typesValue)) {
+    return typesValue.map((value) => String(value).toLowerCase());
+  }
+
+  if (typeof typesValue === 'string') {
+    try {
+      const parsed = JSON.parse(typesValue);
+      if (Array.isArray(parsed)) {
+        return parsed.map((value) => String(value).toLowerCase());
+      }
+    } catch (_error) {
+      return typesValue
+        .split(',')
+        .map((value) => value.trim().toLowerCase())
+        .filter(Boolean);
+    }
+  }
+
+  return [];
+}
+
+function resolveWeatherMultiplier(pokemonTypes, weatherMultiplierMap) {
+  let multiplier = 1;
+  let bestBoostedType = null;
+
+  for (const type of pokemonTypes) {
+    const candidate = Number(weatherMultiplierMap[type] || 1);
+    if (candidate > multiplier) {
+      multiplier = candidate;
+      bestBoostedType = type;
+    }
+  }
+
+  return {
+    multiplier,
+    boostedType: bestBoostedType
+  };
+}
+
+function computePokemonIncomePerSecond(baseIncome, types, weatherMultiplierMap) {
+  const normalizedTypes = normalizePokemonTypes(types);
+  const { multiplier, boostedType } = resolveWeatherMultiplier(normalizedTypes, weatherMultiplierMap);
+  const normalizedBaseIncome = Number(baseIncome || 0);
+
+  return {
+    baseIncomePerSecond: normalizedBaseIncome,
+    incomePerSecond: normalizedBaseIncome * multiplier,
+    weatherMultiplier: multiplier,
+    boostedType,
+    types: normalizedTypes
+  };
+}
+
+module.exports = {
+  normalizePokemonTypes,
+  resolveWeatherMultiplier,
+  computePokemonIncomePerSecond
+};

--- a/lib/server/progression-service.js
+++ b/lib/server/progression-service.js
@@ -1,0 +1,8 @@
+function calculateLevelUpCost(level) {
+  const normalizedLevel = Math.max(1, Number(level || 1));
+  return Math.floor(50 * Math.pow(normalizedLevel, 1.35));
+}
+
+module.exports = {
+  calculateLevelUpCost
+};

--- a/lib/server/weather-service.js
+++ b/lib/server/weather-service.js
@@ -1,0 +1,106 @@
+const OPEN_WEATHER_ENDPOINT = 'https://api.openweathermap.org/data/2.5/weather';
+
+const WEATHER_TYPE_MAPPING = {
+  Rain: {
+    weatherKey: 'rain',
+    boostedTypes: ['water'],
+    multipliers: { water: 1.6 }
+  },
+  Clear: {
+    weatherKey: 'clear',
+    boostedTypes: ['grass', 'fire'],
+    multipliers: { grass: 1.35, fire: 1.35 }
+  },
+  Clouds: {
+    weatherKey: 'clouds',
+    boostedTypes: ['electric', 'flying'],
+    multipliers: { electric: 1.3, flying: 1.3 }
+  },
+  Snow: {
+    weatherKey: 'snow',
+    boostedTypes: ['ice'],
+    multipliers: { ice: 2 }
+  },
+  Thunderstorm: {
+    weatherKey: 'thunderstorm',
+    boostedTypes: ['electric'],
+    multipliers: { electric: 1.75 }
+  },
+  Mist: {
+    weatherKey: 'mist',
+    boostedTypes: ['ghost', 'psychic'],
+    multipliers: { ghost: 1.45, psychic: 1.45 }
+  },
+  Fog: {
+    weatherKey: 'mist',
+    boostedTypes: ['ghost', 'psychic'],
+    multipliers: { ghost: 1.45, psychic: 1.45 }
+  }
+};
+
+function toGameWeather(rawCondition) {
+  const normalizedCondition = typeof rawCondition === 'string' ? rawCondition : 'Unknown';
+  const mapping = WEATHER_TYPE_MAPPING[normalizedCondition] || {
+    weatherKey: 'neutral',
+    boostedTypes: [],
+    multipliers: {}
+  };
+
+  return {
+    rawCondition: normalizedCondition,
+    weatherKey: mapping.weatherKey,
+    boostedTypes: mapping.boostedTypes,
+    multiplierMap: mapping.multipliers
+  };
+}
+
+function getOpenWeatherLocationParams() {
+  const city = process.env.OPENWEATHER_CITY;
+  if (city) {
+    return { q: city };
+  }
+
+  const latitude = process.env.OPENWEATHER_LAT;
+  const longitude = process.env.OPENWEATHER_LON;
+  if (latitude && longitude) {
+    return { lat: latitude, lon: longitude };
+  }
+
+  return { q: 'Oslo,NO' };
+}
+
+async function fetchCurrentWeather() {
+  const apiKey = process.env.OPENWEATHER_API_KEY;
+  if (!apiKey) {
+    throw new Error('Missing OPENWEATHER_API_KEY environment variable.');
+  }
+
+  const params = new URLSearchParams({
+    appid: apiKey,
+    units: 'metric',
+    ...getOpenWeatherLocationParams()
+  });
+
+  const response = await fetch(`${OPEN_WEATHER_ENDPOINT}?${params.toString()}`);
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`OpenWeather request failed (${response.status}): ${body.slice(0, 200)}`);
+  }
+
+  const payload = await response.json();
+  const rawCondition = payload?.weather?.[0]?.main || 'Unknown';
+  const mappedWeather = toGameWeather(rawCondition);
+
+  return {
+    ...mappedWeather,
+    source: {
+      city: payload?.name || null,
+      temperatureC: payload?.main?.temp ?? null
+    }
+  };
+}
+
+module.exports = {
+  toGameWeather,
+  fetchCurrentWeather
+};


### PR DESCRIPTION
### Motivation

- Introduce an "Elemental Garden" mini-game that displays a player garden, active Pokémon, essence resources and weather-driven production.
- Provide server-side synchronization and resource accumulation so the garden state can be queried from the client.
- Use live weather to influence production rates and allow finished lures to be shown to the player.
- Expose endpoints with basic rate-limiting and session checks to keep access controlled and prevent abuse.

### Description

- Added a static frontend at `garden/index.html` that renders garden UI, syncs to `/api/sync`, and displays weather, active slots, essence pool and lures. 
- Added API handlers `api/sync.js` (POST) and `api/weather.js` (GET) which use `requireSession` and `isRateLimited`, and call into server services to return payloads or weather data. 
- Implemented server services in `lib/server/*`: `garden-sync-service.js` (sync logic, production computation, state updates), `weather-service.js` (OpenWeather mapping and fetch), `pokemon-service.js` (type normalization and income calculation), `lure-service.js` (finished lure lookup), and `progression-service.js` (level up cost helper). 
- Updated database helper export to include `runQuery` and added DB-backed logic to ensure a `user_gardens` row and to update essence columns over elapsed time when syncing. 
- Wired production calculation using `ESSENCE_TYPES`, per-type columns, and `computePokemonIncomePerSecond` to accumulate resources between syncs, and surfaced `finishedLures` and `weatherBonuses` in the sync payload. 
- Added the garden entry to the main `index.html` feature modules list so the frontend can link to the new UI.

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b06ba109588333b598d42fcbae9755)