### PR TITLE
Add Random10 quiz mode: API endpoints, answer evaluator, frontend and docs

### DIFF
--- a/api/quiz/answer.js
+++ b/api/quiz/answer.js
@@ -1,0 +1,107 @@
+const { runQuery } = require('../_lib/db');
+const { parseCookies, verifySessionToken, COOKIE_NAME } = require('../_lib/auth');
+const { evaluateAnswer } = require('../../lib/server/quiz-answer-evaluator');
+
+function parseBody(body) {
+  if (!body) return {};
+  if (typeof body === 'string') {
+    try {
+      return JSON.parse(body);
+    } catch (error) {
+      return {};
+    }
+  }
+  return typeof body === 'object' ? body : {};
+}
+
+function extractAcceptedAnswers(row) {
+  const candidates = [
+    row.answer_en,
+    row.answer_no,
+    row.answer,
+    row.correct_answer,
+    row.correct_answer_en,
+    row.correct_answer_no
+  ];
+
+  return candidates
+    .filter(Boolean)
+    .flatMap((value) => String(value).split('|').map((part) => part.trim()).filter(Boolean));
+}
+
+async function persistProgress(userId, questionId, isCorrect) {
+  try {
+    await runQuery(
+      `INSERT INTO user_answers (user_id, question_id, is_correct)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (user_id, question_id)
+       DO UPDATE SET is_correct = user_answers.is_correct OR EXCLUDED.is_correct`,
+      [userId, questionId, isCorrect]
+    );
+  } catch (error) {
+    console.warn('[quiz/answer] progress persistence skipped:', error?.message);
+  }
+}
+
+module.exports = async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  try {
+    const body = parseBody(req.body);
+    const questionId = Number(body.questionId);
+    const answer = String(body.answer || '').trim();
+
+    if (!Number.isInteger(questionId) || !answer) {
+      res.status(400).json({ error: 'questionId and answer are required' });
+      return;
+    }
+
+    const questionResult = await runQuery(
+      `SELECT id, answer_en, answer_no, answer, correct_answer, correct_answer_en, correct_answer_no
+       FROM quiz_questions
+       WHERE id = $1
+       LIMIT 1`,
+      [questionId]
+    );
+
+    const question = questionResult.rows[0];
+    if (!question) {
+      res.status(404).json({ error: 'Question not found' });
+      return;
+    }
+
+    const acceptedAnswers = extractAcceptedAnswers(question);
+    const evaluation = evaluateAnswer({
+      userAnswer: answer,
+      acceptedAnswers,
+      retryAvailable: body.retryAvailable !== false
+    });
+
+    let session = null;
+    try {
+      const cookies = parseCookies(req);
+      if (cookies[COOKIE_NAME]) {
+        session = await verifySessionToken(cookies[COOKIE_NAME]);
+      }
+    } catch (error) {
+      session = null;
+    }
+
+    if (session && session.id && (evaluation.status === 'correct' || evaluation.status === 'wrong')) {
+      await persistProgress(session.id, questionId, evaluation.status === 'correct');
+    }
+
+    res.status(200).json({
+      questionId,
+      status: evaluation.status,
+      retryAvailable: evaluation.retryAvailable,
+      acceptedAnswer: evaluation.matchedAnswer || acceptedAnswers[0] || null
+    });
+  } catch (error) {
+    console.error('[quiz/answer] failed:', error?.message);
+    res.status(500).json({ error: 'Failed to evaluate answer' });
+  }
+};

--- a/api/quiz/start.js
+++ b/api/quiz/start.js
@@ -1,0 +1,62 @@
+const { runQuery } = require('../_lib/db');
+
+function parseBody(body) {
+  if (!body) return {};
+  if (typeof body === 'string') {
+    try {
+      return JSON.parse(body);
+    } catch (error) {
+      return {};
+    }
+  }
+  return typeof body === 'object' ? body : {};
+}
+
+function mapQuestion(row, lang) {
+  const prompt = lang === 'no'
+    ? row.question_no || row.question_en || row.question || ''
+    : row.question_en || row.question_no || row.question || '';
+
+  return {
+    id: row.id,
+    category: row.category || 'General',
+    prompt
+  };
+}
+
+module.exports = async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  try {
+    const { mode = 'random10', count = 10, lang = 'en' } = parseBody(req.body);
+
+    if (mode !== 'random10') {
+      res.status(400).json({ error: 'Only random10 mode is enabled right now.' });
+      return;
+    }
+
+    const limit = Math.max(1, Math.min(Number(count) || 10, 50));
+
+    const query = await runQuery(
+      `SELECT id, category, question_en, question_no, question
+       FROM quiz_questions
+       ORDER BY RANDOM()
+       LIMIT $1`,
+      [limit]
+    );
+
+    const questions = query.rows.map((row) => mapQuestion(row, lang));
+
+    res.status(200).json({
+      mode: 'random10',
+      count: questions.length,
+      questions
+    });
+  } catch (error) {
+    console.error('[quiz/start] failed:', error?.message);
+    res.status(500).json({ error: 'Failed to start quiz' });
+  }
+};

--- a/docs/quiz-answer-evaluator.md
+++ b/docs/quiz-answer-evaluator.md
@@ -1,0 +1,36 @@
+# Quiz answer evaluator (shared rules)
+
+This module is meant to be reused across all quiz modes (`random10`, `categories`, `completionist`, and later Pokémon).
+
+## File
+
+- `lib/server/quiz-answer-evaluator.js`
+
+## Behavior
+
+- Normalizes free text (case-insensitive, strips apostrophes/punctuation, ignores extra spaces).
+- Removes common helper words (English + Norwegian stop words).
+- Uses Levenshtein-based fuzzy similarity for text answers.
+- Supports numeric year tolerance (default `10%` difference accepted as correct).
+- Supports **almost** status when close, and allows one retry.
+
+## Suggested API usage
+
+1. First submit:
+   - `retryAvailable = true`
+   - If result is `almost`, return status to client and keep question open.
+2. Second submit:
+   - `retryAvailable = false`
+   - If still not `correct`, mark as final `wrong`.
+
+## Example
+
+```js
+const { evaluateAnswer } = require('../../lib/server/quiz-answer-evaluator');
+
+const evaluation = evaluateAnswer({
+  userAnswer: req.body.answer,
+  acceptedAnswers: [question.answer_en, question.answer_no],
+  retryAvailable: req.body.retryAvailable !== false
+});
+```

--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
         <a href="/CrystalClick/">Crystal Mining <span class="tooltip-text">Second clicker!</span></a>
         <a href="/GalacticClick/">Galactic Mining <span class="tooltip-text">Third clicker!</span></a>
         <a href="/memory/">Guess the mon! <span class="tooltip-text">How fast are you?</span></a>
-        <a href="/quiz-random10/">Random 10 quiz <span class="tooltip-text">Quick 10-question mode</span></a>
+        <a href="/random10/">Random 10 quiz <span class="tooltip-text">Quick 10-question mode</span></a>
         <a href="/quiz-categories/">Quiz categories <span class="tooltip-text">Choose categories and play</span></a>
         <a href="/quiz-quest/">Quiz quest <span class="tooltip-text">Quest mode (placeholder)</span></a>
         <a href="/pokemon-quiz/">Pokémon quiz <span class="tooltip-text">Pokémon mode (placeholder)</span></a>

--- a/lib/server/quiz-answer-evaluator.js
+++ b/lib/server/quiz-answer-evaluator.js
@@ -1,0 +1,187 @@
+const STOP_WORDS = new Set([
+  'a', 'an', 'the', 'and', 'or', 'of', 'to', 'for', 'in', 'on', 'at', 'by', 'from',
+  'with', 'without', 'is', 'are', 'was', 'were',
+  'en', 'et', 'ei', 'den', 'det', 'de', 'og', 'eller', 'av', 'til', 'på', 'med', 'uten',
+  'som', 'er', 'var'
+]);
+
+const DEFAULT_CONFIG = {
+  exactSimilarityThreshold: 0.88,
+  almostSimilarityThreshold: 0.74,
+  yearTolerancePercent: 0.1,
+  yearAlmostMultiplier: 1.5
+};
+
+function normalizeText(text) {
+  return String(text || '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[’'`´]/g, '')
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function tokenize(text) {
+  return normalizeText(text)
+    .split(' ')
+    .filter(Boolean)
+    .filter((token) => !STOP_WORDS.has(token));
+}
+
+function compactText(text) {
+  return tokenize(text).join(' ');
+}
+
+function levenshteinDistance(a, b) {
+  const left = String(a || '');
+  const right = String(b || '');
+
+  if (left === right) return 0;
+  if (!left.length) return right.length;
+  if (!right.length) return left.length;
+
+  const matrix = Array.from({ length: left.length + 1 }, () => new Array(right.length + 1).fill(0));
+
+  for (let i = 0; i <= left.length; i += 1) matrix[i][0] = i;
+  for (let j = 0; j <= right.length; j += 1) matrix[0][j] = j;
+
+  for (let i = 1; i <= left.length; i += 1) {
+    for (let j = 1; j <= right.length; j += 1) {
+      const substitutionCost = left[i - 1] === right[j - 1] ? 0 : 1;
+      matrix[i][j] = Math.min(
+        matrix[i - 1][j] + 1,
+        matrix[i][j - 1] + 1,
+        matrix[i - 1][j - 1] + substitutionCost
+      );
+    }
+  }
+
+  return matrix[left.length][right.length];
+}
+
+function similarityScore(a, b) {
+  const left = compactText(a);
+  const right = compactText(b);
+  if (!left && !right) return 1;
+  if (!left || !right) return 0;
+
+  const distance = levenshteinDistance(left, right);
+  const maxLength = Math.max(left.length, right.length);
+  return 1 - distance / maxLength;
+}
+
+function extractYear(text) {
+  const normalized = normalizeText(text);
+  const match = normalized.match(/\b\d{3,4}\b/);
+  if (!match) return null;
+  return Number.parseInt(match[0], 10);
+}
+
+function evaluateYearAnswer(userAnswer, expectedAnswer, config) {
+  const userYear = extractYear(userAnswer);
+  const expectedYear = extractYear(expectedAnswer);
+  if (userYear === null || expectedYear === null) return null;
+
+  const tolerance = Math.max(1, Math.round(Math.abs(expectedYear) * config.yearTolerancePercent));
+  const diff = Math.abs(userYear - expectedYear);
+
+  if (diff <= tolerance) {
+    return { status: 'correct', reason: 'year_within_tolerance', score: 1, diff, tolerance };
+  }
+
+  if (diff <= Math.round(tolerance * config.yearAlmostMultiplier)) {
+    return { status: 'almost', reason: 'year_near_tolerance', score: 0.5, diff, tolerance };
+  }
+
+  return { status: 'wrong', reason: 'year_outside_tolerance', score: 0, diff, tolerance };
+}
+
+function evaluateAgainstExpected(userAnswer, expectedAnswer, config) {
+  const yearResult = evaluateYearAnswer(userAnswer, expectedAnswer, config);
+  if (yearResult && (yearResult.status === 'correct' || yearResult.status === 'almost')) {
+    return yearResult;
+  }
+
+  const similarity = similarityScore(userAnswer, expectedAnswer);
+
+  if (similarity >= config.exactSimilarityThreshold) {
+    return { status: 'correct', reason: 'fuzzy_match', score: similarity };
+  }
+
+  if (similarity >= config.almostSimilarityThreshold) {
+    return { status: 'almost', reason: 'fuzzy_near_match', score: similarity };
+  }
+
+  return { status: 'wrong', reason: 'no_match', score: similarity };
+}
+
+function evaluateAnswer({ userAnswer, acceptedAnswers, retryAvailable = true, config = {} }) {
+  const mergedConfig = { ...DEFAULT_CONFIG, ...config };
+  const answers = Array.isArray(acceptedAnswers) ? acceptedAnswers.filter(Boolean) : [acceptedAnswers].filter(Boolean);
+
+  if (!answers.length) {
+    return {
+      status: 'wrong',
+      score: 0,
+      reason: 'no_accepted_answers',
+      retryAvailable: false
+    };
+  }
+
+  let best = { status: 'wrong', score: 0, reason: 'no_match' };
+
+  for (const expected of answers) {
+    const result = evaluateAgainstExpected(userAnswer, expected, mergedConfig);
+    if (result.status === 'correct') {
+      return {
+        status: 'correct',
+        score: 1,
+        reason: result.reason,
+        matchedAnswer: expected,
+        retryAvailable: false
+      };
+    }
+
+    if (result.status === 'almost' && best.status !== 'almost') {
+      best = { ...result, matchedAnswer: expected };
+      continue;
+    }
+
+    if (result.score > best.score) {
+      best = { ...result, matchedAnswer: expected };
+    }
+  }
+
+  if (best.status === 'almost' && retryAvailable) {
+    return {
+      status: 'almost',
+      score: 0,
+      reason: best.reason,
+      matchedAnswer: best.matchedAnswer,
+      retryAvailable: true
+    };
+  }
+
+  return {
+    status: 'wrong',
+    score: 0,
+    reason: best.reason,
+    matchedAnswer: best.matchedAnswer,
+    retryAvailable: false
+  };
+}
+
+module.exports = {
+  STOP_WORDS,
+  DEFAULT_CONFIG,
+  normalizeText,
+  tokenize,
+  compactText,
+  levenshteinDistance,
+  similarityScore,
+  extractYear,
+  evaluateYearAnswer,
+  evaluateAnswer
+};

--- a/quiz-random10/index.html
+++ b/quiz-random10/index.html
@@ -2,22 +2,11 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
+  <meta http-equiv="refresh" content="0; url=/random10/" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Random 10 quiz</title>
-  <style>
-    :root { --bg:#0b0c10; --card:#1e1f25; --txt:#eaeaea; --bd:#2f313a; --accent:#4ecca3; --muted:#9aa0ad; }
-    body { margin:0; font:16px/1.4 system-ui, Segoe UI, Roboto, Arial; background:var(--bg); color:var(--txt); min-height:100dvh; display:grid; place-items:center; padding:20px; box-sizing:border-box; }
-    .card { width:min(680px,100%); background:var(--card); border:1px solid var(--bd); border-radius:14px; padding:20px; }
-    h1 { margin:0 0 10px; }
-    p { margin:0 0 14px; color:var(--muted); }
-    a { display:inline-block; text-decoration:none; background:var(--accent); color:#111; border-radius:8px; padding:10px 14px; font-weight:700; }
-  </style>
+  <title>Redirecting to Random10</title>
 </head>
 <body>
-  <main class="card">
-    <h1>Random 10 quiz</h1>
-    <p>This is a placeholder page. We will build this quiz mode step by step.</p>
-    <a href="/">Back to sarcasm.games</a>
-  </main>
+  <p>Redirecting to <a href="/random10/">/random10/</a>...</p>
 </body>
 </html>

--- a/random10/index.html
+++ b/random10/index.html
@@ -1,0 +1,280 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Random10 quiz</title>
+  <style>
+    :root { --bg:#0b0c10; --card:#1e1f25; --txt:#eaeaea; --bd:#2f313a; --accent:#4ecca3; --muted:#9aa0ad; --ok:#80ed99; --warn:#ffd166; --bad:#ff6b6b; }
+    * { box-sizing: border-box; }
+    body { margin:0; font:16px/1.45 system-ui, Segoe UI, Roboto, Arial; background:var(--bg); color:var(--txt); min-height:100dvh; display:grid; place-items:center; padding:24px; }
+    .card { width:min(780px,100%); background:var(--card); border:1px solid var(--bd); border-radius:14px; padding:20px; }
+    h1,h2 { margin:0 0 12px; }
+    p { color:var(--muted); margin:0 0 12px; }
+    .hidden { display:none !important; }
+    .btn-row { display:flex; gap:10px; flex-wrap:wrap; margin-top:12px; }
+    button, .link-btn { border:1px solid var(--bd); border-radius:8px; padding:10px 14px; font-weight:700; cursor:pointer; background:transparent; color:var(--txt); }
+    .btn-primary { background:var(--accent); color:#111; border-color:var(--accent); }
+    .muted { color:var(--muted); }
+    .status { min-height:24px; margin-top:12px; font-weight:700; }
+    .status.ok { color:var(--ok); }
+    .status.almost { color:var(--warn); }
+    .status.wrong { color:var(--bad); }
+    input[type="text"] { width:100%; border:1px solid var(--bd); border-radius:8px; background:var(--bg); color:var(--txt); padding:12px; font-size:16px; }
+    .progress { color:var(--muted); margin-bottom:12px; }
+    .result-list { margin:10px 0 0; padding-left:18px; color:var(--muted); }
+  </style>
+</head>
+<body>
+  <main class="card">
+    <section id="introView">
+      <h1>Random10 quiz</h1>
+      <p>Welcome! On this page you will get 10 random questions from mixed categories.</p>
+      <p>Answer checks follow forgiving rules: punctuation and tiny text differences are tolerated, close answers can become <strong>Almost</strong>, and for years we use tolerance windows. If you get <strong>Almost</strong>, you get one extra try.</p>
+      <div class="btn-row">
+        <button id="startBtn" class="btn-primary">Start Random10 quiz</button>
+        <a class="link-btn" href="/">Back to sarcasm.games</a>
+      </div>
+      <p id="introError" class="status wrong"></p>
+    </section>
+
+    <section id="questionView" class="hidden">
+      <div class="progress" id="progressText"></div>
+      <h2 id="questionTitle">Question</h2>
+      <p id="questionCategory" class="muted"></p>
+      <input id="answerInput" type="text" placeholder="Write your answer here" autocomplete="off" />
+      <div class="btn-row">
+        <button id="submitBtn" class="btn-primary">Submit answer</button>
+        <button id="showAnswerBtn">Show answer</button>
+      </div>
+      <p id="statusText" class="status"></p>
+      <p id="answerReveal" class="muted hidden"></p>
+    </section>
+
+    <section id="resultView" class="hidden">
+      <h2>Quiz complete 🎉</h2>
+      <p id="resultSummary"></p>
+      <ul class="result-list">
+        <li><span id="correctCount">0</span> correct</li>
+        <li><span id="almostCount">0</span> almost (resolved on retry)</li>
+        <li><span id="wrongCount">0</span> wrong</li>
+      </ul>
+      <div class="btn-row">
+        <button id="playAgainBtn" class="btn-primary">Try again</button>
+        <a class="link-btn" href="/">Back to sarcasm.games</a>
+      </div>
+    </section>
+  </main>
+
+  <script>
+    const SAMPLE_QUESTIONS = [
+      { id: 1, category: 'Science', prompt: 'What planet is known as the Red Planet?', answers: ['Mars'] },
+      { id: 2, category: 'History', prompt: 'In which year did World War II end?', answers: ['1945'] },
+      { id: 3, category: 'Geography', prompt: 'What is the capital of Norway?', answers: ['Oslo'] },
+      { id: 4, category: 'Sports', prompt: 'How many players are on the field per team in football (soccer)?', answers: ['11'] },
+      { id: 5, category: 'Movies', prompt: 'Who directed Jurassic Park?', answers: ['Steven Spielberg', 'Spielberg'] },
+      { id: 6, category: 'Music', prompt: 'Which band made the song "Bohemian Rhapsody"?', answers: ['Queen'] },
+      { id: 7, category: 'Tech', prompt: 'What does HTML stand for?', answers: ['HyperText Markup Language', 'Hyper Text Markup Language'] },
+      { id: 8, category: 'Nature', prompt: 'What is the largest mammal in the world?', answers: ['Blue whale', 'The blue whale'] },
+      { id: 9, category: 'Food', prompt: 'Which country is sushi most associated with?', answers: ['Japan'] },
+      { id: 10, category: 'Literature', prompt: 'Who wrote "1984"?', answers: ['George Orwell', 'Orwell'] },
+      { id: 11, category: 'Science', prompt: 'What gas do plants absorb from the atmosphere?', answers: ['Carbon dioxide', 'CO2'] },
+      { id: 12, category: 'History', prompt: 'Who was the first man on the moon?', answers: ['Neil Armstrong', 'Armstrong'] }
+    ];
+
+    const positiveMessages = ['Good!', 'Great job!', 'Nice one!', 'Excellent!', 'Well done!'];
+
+    const introView = document.getElementById('introView');
+    const questionView = document.getElementById('questionView');
+    const resultView = document.getElementById('resultView');
+    const introError = document.getElementById('introError');
+    const progressText = document.getElementById('progressText');
+    const questionTitle = document.getElementById('questionTitle');
+    const questionCategory = document.getElementById('questionCategory');
+    const answerInput = document.getElementById('answerInput');
+    const statusText = document.getElementById('statusText');
+    const answerReveal = document.getElementById('answerReveal');
+
+    const state = {
+      questions: [],
+      index: 0,
+      correct: 0,
+      almostResolved: 0,
+      wrong: 0,
+      awaitingRetry: false
+    };
+
+    function pickPositiveMessage() {
+      return positiveMessages[Math.floor(Math.random() * positiveMessages.length)];
+    }
+
+    function showView(view) {
+      introView.classList.toggle('hidden', view !== 'intro');
+      questionView.classList.toggle('hidden', view !== 'question');
+      resultView.classList.toggle('hidden', view !== 'result');
+    }
+
+    function normalizeQuestion(raw, idx) {
+      const answers = Array.isArray(raw.answers) && raw.answers.length
+        ? raw.answers
+        : [raw.answer, raw.answer_en, raw.answer_no].filter(Boolean);
+
+      return {
+        id: raw.id || `local-${idx}`,
+        category: raw.category || 'General',
+        prompt: raw.prompt || raw.question || raw.question_en || raw.question_no || 'Missing question text',
+        answers
+      };
+    }
+
+    async function loadQuestions() {
+      introError.textContent = '';
+      try {
+        const response = await fetch('/api/quiz/start', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ mode: 'random10', count: 10, lang: 'en' })
+        });
+
+        if (!response.ok) {
+          throw new Error('Could not fetch quiz questions from API.');
+        }
+
+        const payload = await response.json();
+        const questions = (payload.questions || []).map(normalizeQuestion).filter((q) => q.answers.length);
+        if (questions.length < 10) {
+          throw new Error('Not enough API questions available yet.');
+        }
+        return questions.slice(0, 10);
+      } catch (error) {
+        const copy = [...SAMPLE_QUESTIONS].sort(() => Math.random() - 0.5).slice(0, 10).map(normalizeQuestion);
+        introError.textContent = 'Using local fallback questions while API is being wired.';
+        return copy;
+      }
+    }
+
+    function renderQuestion() {
+      const q = state.questions[state.index];
+      progressText.textContent = `Question ${state.index + 1} / ${state.questions.length}`;
+      questionTitle.textContent = q.prompt;
+      questionCategory.textContent = `Category: ${q.category}`;
+      answerInput.value = '';
+      answerInput.focus();
+      state.awaitingRetry = false;
+      statusText.textContent = '';
+      statusText.className = 'status';
+      answerReveal.classList.add('hidden');
+      answerReveal.textContent = `Answer: ${q.answers[0]}`;
+    }
+
+    function moveNextQuestion() {
+      state.index += 1;
+      if (state.index >= state.questions.length) {
+        document.getElementById('correctCount').textContent = String(state.correct);
+        document.getElementById('almostCount').textContent = String(state.almostResolved);
+        document.getElementById('wrongCount').textContent = String(state.wrong);
+        document.getElementById('resultSummary').textContent = `You finished Random10 with ${state.correct} / ${state.questions.length} correct answers.`;
+        showView('result');
+        return;
+      }
+      renderQuestion();
+    }
+
+    async function evaluateAnswer(question, userAnswer, retryAvailable) {
+      try {
+        const response = await fetch('/api/quiz/answer', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            questionId: question.id,
+            answer: userAnswer,
+            retryAvailable,
+            mode: 'random10',
+            lang: 'en'
+          })
+        });
+
+        if (!response.ok) throw new Error('API not ready');
+        const payload = await response.json();
+        if (!payload || !payload.status) throw new Error('Invalid answer payload');
+        return payload;
+      } catch (error) {
+        const expected = question.answers[0] || '';
+        const normalizedGuess = userAnswer.trim().toLowerCase();
+        const normalizedExpected = expected.trim().toLowerCase();
+
+        if (normalizedGuess === normalizedExpected) {
+          return { status: 'correct' };
+        }
+
+        if (retryAvailable && normalizedExpected.includes(normalizedGuess) && normalizedGuess.length > 2) {
+          return { status: 'almost' };
+        }
+
+        return { status: 'wrong' };
+      }
+    }
+
+    async function onSubmitAnswer() {
+      const userAnswer = answerInput.value.trim();
+      if (!userAnswer) return;
+      const question = state.questions[state.index];
+
+      const result = await evaluateAnswer(question, userAnswer, !state.awaitingRetry);
+
+      if (result.status === 'correct') {
+        statusText.className = 'status ok';
+        statusText.textContent = pickPositiveMessage();
+        state.correct += 1;
+        setTimeout(moveNextQuestion, 700);
+        return;
+      }
+
+      if (result.status === 'almost' && !state.awaitingRetry) {
+        state.awaitingRetry = true;
+        statusText.className = 'status almost';
+        statusText.textContent = 'Almost — try again.';
+        answerInput.value = '';
+        answerInput.focus();
+        return;
+      }
+
+      if (state.awaitingRetry) {
+        state.almostResolved += 1;
+      }
+      state.wrong += 1;
+      state.awaitingRetry = false;
+      statusText.className = 'status wrong';
+      statusText.textContent = 'Wrong answer. You can continue when ready.';
+      setTimeout(moveNextQuestion, 900);
+    }
+
+    document.getElementById('startBtn').addEventListener('click', async () => {
+      state.questions = await loadQuestions();
+      state.index = 0;
+      state.correct = 0;
+      state.almostResolved = 0;
+      state.wrong = 0;
+      state.awaitingRetry = false;
+      renderQuestion();
+      showView('question');
+    });
+
+    document.getElementById('submitBtn').addEventListener('click', onSubmitAnswer);
+    answerInput.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        onSubmitAnswer();
+      }
+    });
+
+    document.getElementById('showAnswerBtn').addEventListener('click', () => {
+      answerReveal.classList.toggle('hidden');
+    });
+
+    document.getElementById('playAgainBtn').addEventListener('click', () => {
+      showView('intro');
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a workable Random10 quiz mode with server-side answer evaluation and client UI so users can play a forgiving, retry-capable 10-question quiz.
- Share a reusable answer evaluation implementation that supports fuzzy text matching and year tolerance for multiple quiz modes.
- Track per-user quiz progress when a session is available so correct answers can be persisted.

### Description
- Add API endpoint `POST /api/quiz/start` that returns a randomized set of questions from `quiz_questions` and supports `mode`, `count`, and `lang` in the request body.
- Add API endpoint `POST /api/quiz/answer` that parses and validates the request, loads the question, evaluates the submitted answer using `evaluateAnswer`, and persists progress to `user_answers` when a verified session exists.
- Introduce `lib/server/quiz-answer-evaluator.js` implementing normalization, stop-word removal, Levenshtein-based fuzzy similarity, numeric year tolerance, and the `evaluateAnswer` API used by the answer endpoint.
- Add frontend UI under `random10/index.html`, update `quiz-random10/index.html` to redirect to `/random10/`, and update the main `index.html` link to point to the new route, plus a docs file `docs/quiz-answer-evaluator.md` describing the evaluator behavior.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1d6957200833396ad436fe7a2f7b4)