### PR TITLE
Streng numerisk matching for quiz-svar med 10% "almost"-terskel

### DIFF
--- a/docs/quiz-answer-evaluator.md
+++ b/docs/quiz-answer-evaluator.md
@@ -11,7 +11,8 @@ This module is meant to be reused across all quiz modes (`random10`, `categories
 - Normalizes free text (case-insensitive, strips apostrophes/punctuation, ignores extra spaces).
 - Removes common helper words (English + Norwegian stop words).
 - Uses Levenshtein-based fuzzy similarity for text answers.
-- Supports numeric year tolerance (default `10%` difference accepted as correct).
+- Supports strict numeric matching for numeric answers.
+- Supports **almost** status for numeric answers when input is exact numeric format and within `10%`.
 - Supports **almost** status when close, and allows one retry.
 
 ## Suggested API usage

--- a/lib/server/quiz-answer-evaluator.js
+++ b/lib/server/quiz-answer-evaluator.js
@@ -8,8 +8,7 @@ const STOP_WORDS = new Set([
 const DEFAULT_CONFIG = {
   exactSimilarityThreshold: 0.88,
   almostSimilarityThreshold: 0.74,
-  yearTolerancePercent: 0.1,
-  yearAlmostMultiplier: 1.5
+  numberAlmostPercent: 0.1
 };
 
 function normalizeText(text) {
@@ -72,36 +71,45 @@ function similarityScore(a, b) {
   return 1 - distance / maxLength;
 }
 
-function extractYear(text) {
-  const normalized = normalizeText(text);
-  const match = normalized.match(/\b\d{3,4}\b/);
+function extractExactNumber(text) {
+  const normalized = String(text || '').trim().replace(',', '.');
+  const match = normalized.match(/^[-+]?\d+(?:\.\d+)?$/);
   if (!match) return null;
-  return Number.parseInt(match[0], 10);
+  const value = Number.parseFloat(match[0]);
+  return Number.isFinite(value) ? value : null;
 }
 
-function evaluateYearAnswer(userAnswer, expectedAnswer, config) {
-  const userYear = extractYear(userAnswer);
-  const expectedYear = extractYear(expectedAnswer);
-  if (userYear === null || expectedYear === null) return null;
+function evaluateNumericAnswer(userAnswer, expectedAnswer, config) {
+  const expectedNumber = extractExactNumber(expectedAnswer);
+  if (expectedNumber === null) return null;
 
-  const tolerance = Math.max(1, Math.round(Math.abs(expectedYear) * config.yearTolerancePercent));
-  const diff = Math.abs(userYear - expectedYear);
-
-  if (diff <= tolerance) {
-    return { status: 'correct', reason: 'year_within_tolerance', score: 1, diff, tolerance };
+  const userNumber = extractExactNumber(userAnswer);
+  if (userNumber === null) {
+    return { status: 'wrong', reason: 'numeric_format_mismatch', score: 0 };
   }
 
-  if (diff <= Math.round(tolerance * config.yearAlmostMultiplier)) {
-    return { status: 'almost', reason: 'year_near_tolerance', score: 0.5, diff, tolerance };
+  if (userNumber === expectedNumber) {
+    return { status: 'correct', reason: 'numeric_exact_match', score: 1, diff: 0, percentDiff: 0 };
   }
 
-  return { status: 'wrong', reason: 'year_outside_tolerance', score: 0, diff, tolerance };
+  if (expectedNumber === 0) {
+    return { status: 'wrong', reason: 'numeric_outside_almost', score: 0, diff: Math.abs(userNumber) };
+  }
+
+  const diff = Math.abs(userNumber - expectedNumber);
+  const percentDiff = diff / Math.abs(expectedNumber);
+
+  if (percentDiff <= config.numberAlmostPercent) {
+    return { status: 'almost', reason: 'numeric_within_almost_range', score: 0.5, diff, percentDiff };
+  }
+
+  return { status: 'wrong', reason: 'numeric_outside_almost', score: 0, diff, percentDiff };
 }
 
 function evaluateAgainstExpected(userAnswer, expectedAnswer, config) {
-  const yearResult = evaluateYearAnswer(userAnswer, expectedAnswer, config);
-  if (yearResult && (yearResult.status === 'correct' || yearResult.status === 'almost')) {
-    return yearResult;
+  const numericResult = evaluateNumericAnswer(userAnswer, expectedAnswer, config);
+  if (numericResult) {
+    return numericResult;
   }
 
   const similarity = similarityScore(userAnswer, expectedAnswer);
@@ -149,7 +157,7 @@ function evaluateAnswer({ userAnswer, acceptedAnswers, retryAvailable = true, co
       continue;
     }
 
-    if (result.score > best.score) {
+    if (result.score > best.score || (best.reason === 'no_match' && result.reason !== 'no_match')) {
       best = { ...result, matchedAnswer: expected };
     }
   }
@@ -181,7 +189,7 @@ module.exports = {
   compactText,
   levenshteinDistance,
   similarityScore,
-  extractYear,
-  evaluateYearAnswer,
+  extractExactNumber,
+  evaluateNumericAnswer,
   evaluateAnswer
 };


### PR DESCRIPTION
### Motivation
- Forbedre hvordan numeriske fasitsvar behandles slik at vi ikke godtar «rause» tekstlige svar for tall, men fortsatt gir en `almost`-status når brukersvar er et tall innenfor 10%.

### Description
- Refaktorert år/toleranse-logikk til streng numerisk parsing i `lib/server/quiz-answer-evaluator.js` ved å introdusere `extractExactNumber` og `evaluateNumericAnswer`.
- Numeriske fasitsvar krever eksakt numerisk input for `correct`, og kun gyldig tall innen `10%` (konfigurerbar via `DEFAULT_CONFIG.numberAlmostPercent`) gir `almost`.
- Ikke-numerisk brukersvar mot numerisk fasit returnerer nå `numeric_format_mismatch` (`wrong`) og faller ikke tilbake til fuzzy tekstmatching.
- Justert beste-resultat-logikk slik at en ikke-`no_match`-feil (f.eks. numerisk format) prioriteres over ren `no_match`, og oppdatert eksportnavn og dokumentasjon (`docs/quiz-answer-evaluator.md`).

### Testing
- Kjørte et Node.js smoke-testscript mot `evaluateAnswer` som verifiserte: eksakt tall => `correct`, innen 10% => `almost`, utenfor 10% => `wrong`, og ikke-numerisk input mot numerisk fasit => `wrong`; disse casene bestod.
- Endringene ble committed og filene som ble oppdatert er `lib/server/quiz-answer-evaluator.js` og `docs/quiz-answer-evaluator.md`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b29a114e2483339804162cd96ee795)