### PR TITLE
Strict numeric matching with percent-based 'almost' and Random10 submit guards

### DIFF
--- a/docs/quiz-answer-evaluator.md
+++ b/docs/quiz-answer-evaluator.md
@@ -11,7 +11,8 @@ This module is meant to be reused across all quiz modes (`random10`, `categories
 - Normalizes free text (case-insensitive, strips apostrophes/punctuation, ignores extra spaces).
 - Removes common helper words (English + Norwegian stop words).
 - Uses Levenshtein-based fuzzy similarity for text answers.
-- Supports numeric year tolerance (default `10%` difference accepted as correct).
+- Supports strict numeric matching for numeric answers.
+- Supports **almost** status for numeric answers when input is exact numeric format and within `10%`.
 - Supports **almost** status when close, and allows one retry.
 
 ## Suggested API usage

--- a/lib/server/quiz-answer-evaluator.js
+++ b/lib/server/quiz-answer-evaluator.js
@@ -8,8 +8,7 @@ const STOP_WORDS = new Set([
 const DEFAULT_CONFIG = {
   exactSimilarityThreshold: 0.88,
   almostSimilarityThreshold: 0.74,
-  yearTolerancePercent: 0.1,
-  yearAlmostMultiplier: 1.5
+  numberAlmostPercent: 0.1
 };
 
 function normalizeText(text) {
@@ -72,36 +71,45 @@ function similarityScore(a, b) {
   return 1 - distance / maxLength;
 }
 
-function extractYear(text) {
-  const normalized = normalizeText(text);
-  const match = normalized.match(/\b\d{3,4}\b/);
+function extractExactNumber(text) {
+  const normalized = String(text || '').trim().replace(',', '.');
+  const match = normalized.match(/^[-+]?\d+(?:\.\d+)?$/);
   if (!match) return null;
-  return Number.parseInt(match[0], 10);
+  const value = Number.parseFloat(match[0]);
+  return Number.isFinite(value) ? value : null;
 }
 
-function evaluateYearAnswer(userAnswer, expectedAnswer, config) {
-  const userYear = extractYear(userAnswer);
-  const expectedYear = extractYear(expectedAnswer);
-  if (userYear === null || expectedYear === null) return null;
+function evaluateNumericAnswer(userAnswer, expectedAnswer, config) {
+  const expectedNumber = extractExactNumber(expectedAnswer);
+  if (expectedNumber === null) return null;
 
-  const tolerance = Math.max(1, Math.round(Math.abs(expectedYear) * config.yearTolerancePercent));
-  const diff = Math.abs(userYear - expectedYear);
-
-  if (diff <= tolerance) {
-    return { status: 'correct', reason: 'year_within_tolerance', score: 1, diff, tolerance };
+  const userNumber = extractExactNumber(userAnswer);
+  if (userNumber === null) {
+    return { status: 'wrong', reason: 'numeric_format_mismatch', score: 0 };
   }
 
-  if (diff <= Math.round(tolerance * config.yearAlmostMultiplier)) {
-    return { status: 'almost', reason: 'year_near_tolerance', score: 0.5, diff, tolerance };
+  if (userNumber === expectedNumber) {
+    return { status: 'correct', reason: 'numeric_exact_match', score: 1, diff: 0, percentDiff: 0 };
   }
 
-  return { status: 'wrong', reason: 'year_outside_tolerance', score: 0, diff, tolerance };
+  if (expectedNumber === 0) {
+    return { status: 'wrong', reason: 'numeric_outside_almost', score: 0, diff: Math.abs(userNumber) };
+  }
+
+  const diff = Math.abs(userNumber - expectedNumber);
+  const percentDiff = diff / Math.abs(expectedNumber);
+
+  if (percentDiff <= config.numberAlmostPercent) {
+    return { status: 'almost', reason: 'numeric_within_almost_range', score: 0.5, diff, percentDiff };
+  }
+
+  return { status: 'wrong', reason: 'numeric_outside_almost', score: 0, diff, percentDiff };
 }
 
 function evaluateAgainstExpected(userAnswer, expectedAnswer, config) {
-  const yearResult = evaluateYearAnswer(userAnswer, expectedAnswer, config);
-  if (yearResult && (yearResult.status === 'correct' || yearResult.status === 'almost')) {
-    return yearResult;
+  const numericResult = evaluateNumericAnswer(userAnswer, expectedAnswer, config);
+  if (numericResult) {
+    return numericResult;
   }
 
   const similarity = similarityScore(userAnswer, expectedAnswer);
@@ -149,7 +157,7 @@ function evaluateAnswer({ userAnswer, acceptedAnswers, retryAvailable = true, co
       continue;
     }
 
-    if (result.score > best.score) {
+    if (result.score > best.score || (best.reason === 'no_match' && result.reason !== 'no_match')) {
       best = { ...result, matchedAnswer: expected };
     }
   }
@@ -181,7 +189,7 @@ module.exports = {
   compactText,
   levenshteinDistance,
   similarityScore,
-  extractYear,
-  evaluateYearAnswer,
+  extractExactNumber,
+  evaluateNumericAnswer,
   evaluateAnswer
 };

--- a/random10/index.html
+++ b/random10/index.html
@@ -31,7 +31,7 @@
       <h1>Random10 quiz</h1>
       <p>Welcome! On this page you will get 10 random questions from mixed categories.</p>
       <p>New: you can reveal the answer only after a wrong guess, then move on manually.</p>
-      <p>Answer checks follow forgiving rules: punctuation and tiny text differences are tolerated, close answers can become <strong>Almost</strong>, and for years we use tolerance windows. If you get <strong>Almost</strong>, you get one extra try.</p>
+      <p>Answer checks follow forgiving rules for text answers: punctuation and tiny text differences are tolerated, close answers can become <strong>Almost</strong>. Numeric answers require exact numbers, but values within 10% are marked as <strong>Almost</strong>. If you get <strong>Almost</strong>, you get one extra try.</p>
       <div class="btn-row">
         <button id="startBtn" class="btn-primary">Start Random10 quiz</button>
         <a class="link-btn" href="/">Back to sarcasm.games</a>
@@ -94,7 +94,9 @@
       correct: 0,
       almostResolved: 0,
       wrong: 0,
-      awaitingRetry: false
+      awaitingRetry: false,
+      isSubmitting: false,
+      isAdvancing: false
     };
 
     function pickPositiveMessage() {
@@ -153,8 +155,11 @@
       questionTitle.textContent = q.prompt;
       questionCategory.textContent = `Category: ${q.category}`;
       answerInput.value = '';
+      answerInput.disabled = false;
       answerInput.focus();
       state.awaitingRetry = false;
+      state.isSubmitting = false;
+      state.isAdvancing = false;
       statusText.textContent = '';
       statusText.className = 'status';
       answerReveal.classList.add('hidden');
@@ -204,18 +209,26 @@
     }
 
     async function onSubmitAnswer() {
-      if (submitBtn.disabled) return;
+      if (submitBtn.disabled || state.isSubmitting || state.isAdvancing) return;
 
       const userAnswer = answerInput.value.trim();
       if (!userAnswer) return;
       const question = state.questions[state.index];
+      const submittedIndex = state.index;
+      state.isSubmitting = true;
 
       let result;
       try {
         result = await evaluateAnswer(question, userAnswer, !state.awaitingRetry);
       } catch (error) {
+        state.isSubmitting = false;
         statusText.className = 'status wrong';
         statusText.textContent = 'Could not submit answer. Please try again.';
+        return;
+      }
+
+      if (state.index !== submittedIndex) {
+        state.isSubmitting = false;
         return;
       }
 
@@ -223,12 +236,19 @@
         statusText.className = 'status ok';
         statusText.textContent = pickPositiveMessage();
         state.correct += 1;
-        setTimeout(moveNextQuestion, 700);
+        state.isSubmitting = false;
+        state.isAdvancing = true;
+        submitBtn.disabled = true;
+        answerInput.disabled = true;
+        setTimeout(() => {
+          moveNextQuestion();
+        }, 700);
         return;
       }
 
       if (result.status === 'almost' && !state.awaitingRetry) {
         state.awaitingRetry = true;
+        state.isSubmitting = false;
         statusText.className = 'status almost';
         statusText.textContent = 'Almost — try again.';
         answerInput.value = '';
@@ -241,6 +261,7 @@
       }
       state.wrong += 1;
       state.awaitingRetry = false;
+      state.isSubmitting = false;
       statusText.className = 'status wrong';
       statusText.textContent = 'Wrong answer. You can show answer, then continue.';
       showAnswerBtn.classList.remove('hidden');
@@ -259,6 +280,8 @@
       state.almostResolved = 0;
       state.wrong = 0;
       state.awaitingRetry = false;
+      state.isSubmitting = false;
+      state.isAdvancing = false;
       renderQuestion();
       showView('question');
     });


### PR DESCRIPTION
### Motivation
- Replace year-specific tolerant matching with a general numeric evaluator that supports strict numeric matches and a percent-based "almost" tolerance.
- Prevent duplicate submissions and race conditions in the Random10 UI by disabling inputs and tracking submit/advance state.

### Description
- Replace `extractYear`/`evaluateYearAnswer` with `extractExactNumber` and `evaluateNumericAnswer` that require exact numeric format, treat exact numeric input as `correct`, and mark values within `DEFAULT_CONFIG.numberAlmostPercent` as `almost`.
- Simplify `DEFAULT_CONFIG` by removing year-specific options and adding `numberAlmostPercent: 0.1`, and update module exports and `docs/quiz-answer-evaluator.md` to describe the new numeric behavior.
- Improve selection of best match by preferring non-`no_match` results and keep the existing fuzzy text `similarityScore` thresholds (`exactSimilarityThreshold` and `almostSimilarityThreshold`) for text answers.
- Update `random10/index.html` to clarify numeric rules in the intro text and add `isSubmitting`/`isAdvancing` flags to disable the input/button during validation, prevent double submits, handle race conditions, and control UI transitions (disable input while advancing, reveal/show answer flow).

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b29a114e2483339804162cd96ee795)