### PR TITLE
Prioriter aksepterte svar etter request-språk i quiz/answer API

### DIFF
--- a/api/quiz/answer.js
+++ b/api/quiz/answer.js
@@ -28,8 +28,10 @@ function normalizeAnswerValues(value) {
     .filter(Boolean);
 }
 
-function extractAcceptedAnswers(row) {
-  const candidates = [row.answers_en, row.answers_no];
+function extractAcceptedAnswers(row, lang) {
+  const candidates = lang === 'no'
+    ? [row.answers_no, row.answers_en]
+    : [row.answers_en, row.answers_no];
   const seen = new Set();
 
   return candidates
@@ -64,8 +66,9 @@ module.exports = async function handler(req, res) {
 
   try {
     const body = parseBody(req.body);
-    const questionId = Number(body.questionId);
-    const answer = String(body.answer || '').trim();
+    const { questionId: rawQuestionId, answer: rawAnswer = '', lang = 'en' } = body;
+    const questionId = Number(rawQuestionId);
+    const answer = String(rawAnswer).trim();
 
     if (!Number.isInteger(questionId) || !answer) {
       res.status(400).json({ error: 'questionId and answer are required' });
@@ -86,7 +89,7 @@ module.exports = async function handler(req, res) {
       return;
     }
 
-    const acceptedAnswers = extractAcceptedAnswers(question);
+    const acceptedAnswers = extractAcceptedAnswers(question, lang);
     const evaluation = evaluateAnswer({
       userAnswer: answer,
       acceptedAnswers,


### PR DESCRIPTION
### Motivation
- Gi reveal-tekst (feilsvar) i riktig språk ved å bygge aksepterte svar i språkprioritert rekkefølge. 
- Følge samme parse-mønster som `api/quiz/start.js` for å lese `lang` fra request body. 
- Beholde eksisterende deduplisering og match-logikk samtidig som språkprioritet legges til.

### Description
- Les `lang` fra request body ved å destrukturere `questionId`, `answer` og `lang` fra `parseBody(req.body)` med `lang = 'en'` som standard. 
- Endre `extractAcceptedAnswers` til å ta `lang` og prioritere `[answers_no, answers_en]` når `lang === 'no'`, ellers `[answers_en, answers_no]`. 
- Behold case-insensitiv deduplisering via `Set`, og sørg for at `acceptedAnswer`-fallbacken bruker det språkprioriterte første treffet fra `acceptedAnswers`.

### Testing
- Kjørte en syntaks/parse-sjekk med `node --check api/quiz/answer.js`, som bestod uten feil.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2c76d49a08333af6661657f75f0e4)