### PR TITLE
Shared client quiz language helper and lock runtime language for quiz pages

### DIFF
--- a/lib/client/quiz-language.js
+++ b/lib/client/quiz-language.js
@@ -1,0 +1,24 @@
+const QUIZ_LANGUAGE_KEY = 'quizLanguage';
+const DEFAULT_QUIZ_LANGUAGE = 'en';
+const SUPPORTED_QUIZ_LANGUAGES = new Set(['en', 'no']);
+
+function normalizeQuizLanguage(lang) {
+  if (typeof lang !== 'string') {
+    return DEFAULT_QUIZ_LANGUAGE;
+  }
+
+  const normalized = lang.trim().toLowerCase();
+  return SUPPORTED_QUIZ_LANGUAGES.has(normalized)
+    ? normalized
+    : DEFAULT_QUIZ_LANGUAGE;
+}
+
+export function getQuizLanguage() {
+  return normalizeQuizLanguage(localStorage.getItem(QUIZ_LANGUAGE_KEY));
+}
+
+export function setQuizLanguage(lang) {
+  const normalized = normalizeQuizLanguage(lang);
+  localStorage.setItem(QUIZ_LANGUAGE_KEY, normalized);
+  return normalized;
+}

--- a/quiz-categories/index.html
+++ b/quiz-categories/index.html
@@ -19,5 +19,22 @@
     <p>This is a placeholder page. We will build this quiz mode step by step.</p>
     <a href="/">Back to sarcasm.games</a>
   </main>
+
+  <script type="module">
+    import { getQuizLanguage } from '/lib/client/quiz-language.js';
+
+    // Language is captured at page load and must stay fixed during one active round.
+    const activeLang = getQuizLanguage();
+
+    const runtimeState = {
+      activeLang,
+      quizStarted: false
+    };
+
+    // Placeholder for upcoming API integration:
+    // fetch('/api/quiz/start', { method: 'POST', body: JSON.stringify({ mode: 'quiz-categories', lang: runtimeState.activeLang }) })
+
+    window.quizCategoriesState = runtimeState;
+  </script>
 </body>
 </html>

--- a/quiz-quest/index.html
+++ b/quiz-quest/index.html
@@ -19,5 +19,22 @@
     <p>This is a placeholder page. We will build this quiz mode step by step.</p>
     <a href="/">Back to sarcasm.games</a>
   </main>
+
+  <script type="module">
+    import { getQuizLanguage } from '/lib/client/quiz-language.js';
+
+    // Language is captured at page load and must stay fixed during one active round.
+    const activeLang = getQuizLanguage();
+
+    const runtimeState = {
+      activeLang,
+      quizStarted: false
+    };
+
+    // Placeholder for upcoming API integration:
+    // fetch('/api/quiz/start', { method: 'POST', body: JSON.stringify({ mode: 'quiz-quest', lang: runtimeState.activeLang }) })
+
+    window.quizQuestState = runtimeState;
+  </script>
 </body>
 </html>

--- a/random10/index.html
+++ b/random10/index.html
@@ -79,8 +79,13 @@
     </section>
   </main>
 
-  <script>
+  <script type="module">
+    import { getQuizLanguage } from '/lib/client/quiz-language.js';
+
     const positiveMessages = ['Good!', 'Great job!', 'Nice one!', 'Excellent!', 'Well done!'];
+
+    // Language is locked for this runtime session once loaded.
+    const activeLang = getQuizLanguage();
 
     const introView = document.getElementById('introView');
     const questionView = document.getElementById('questionView');
@@ -111,7 +116,8 @@
       answeredQuestions: [],
       awaitingRetry: false,
       isSubmitting: false,
-      isAdvancing: false
+      isAdvancing: false,
+      quizStarted: false
     };
 
     function pickPositiveMessage() {
@@ -165,7 +171,7 @@
         const response = await fetch('/api/quiz/start', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ mode: 'random10', count: 10, lang: 'en' })
+          body: JSON.stringify({ mode: 'random10', count: 10, lang: activeLang })
         });
 
         if (!response.ok) {
@@ -229,6 +235,7 @@
       state.awaitingRetry = false;
       state.isSubmitting = false;
       state.isAdvancing = false;
+      state.quizStarted = false;
       introError.textContent = '';
       statusText.textContent = '';
       answerReveal.classList.add('hidden');
@@ -245,7 +252,7 @@
           answer: userAnswer,
           retryAvailable,
           mode: 'random10',
-          lang: 'en'
+          lang: activeLang
         })
       });
 
@@ -344,6 +351,7 @@
       state.awaitingRetry = false;
       state.isSubmitting = false;
       state.isAdvancing = false;
+      state.quizStarted = true;
       renderQuestion();
       showView('question');
       setStartLoading(false);


### PR DESCRIPTION
### Motivation
- Gjør quiz-språk konsistent mellom quiz-sider ved å lese `quizLanguage` én gang ved page load og låse det for hele quiz-runden.
- Unngå duplisering ved å tilby en liten delt klient-helper for å lese/lagre quiz-språk fra `localStorage`.
- Sørg for at alle framtidige kall mot quiz-API bruker samme runtime-språk slik at spørsmål og svar er konsistente under en runde.

### Description
- Legg til `lib/client/quiz-language.js` med `getQuizLanguage()` og `setQuizLanguage()` som normaliserer og validerer språk (`en`/`no`) og bruker `localStorage` som backing store.
- Oppdater `random10/index.html` til å importere `getQuizLanguage()`, sette `const activeLang = getQuizLanguage()` ved page load, bruke `activeLang` i API-kallene til `/api/quiz/start` og `/api/quiz/answer`, og introdusere `state.quizStarted` for å markere at språk er låst i aktiv runde.
- Oppdater `quiz-quest/index.html` og `quiz-categories/index.html` med en kort modulskript som importerer `getQuizLanguage()`, setter `activeLang` ved load og plasserer en `runtimeState` (inkl. `quizStarted: false`) for kommende API-integrasjon.
- Endringer berører disse filer: `lib/client/quiz-language.js`, `random10/index.html`, `quiz-quest/index.html`, `quiz-categories/index.html`.

### Testing
- Kjørte `node --check lib/client/quiz-language.js` for syntaksvalidering av modulen, og den returnerte uten feil (suksess).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2c76c48c48333a1e0df9b1e50dff2)