### PR TITLE
Legg til kategori-quizoppsett og backend-støtte for kategorimodus

### DIFF
--- a/api/quiz/categories.js
+++ b/api/quiz/categories.js
@@ -1,0 +1,30 @@
+const { runQuery } = require('../_lib/db');
+
+module.exports = async function handler(req, res) {
+  if (req.method !== 'GET') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  try {
+    const query = await runQuery(
+      `SELECT category, COUNT(*)::int AS question_count
+       FROM quiz_questions
+       WHERE category IS NOT NULL AND TRIM(category) <> ''
+       GROUP BY category
+       ORDER BY category ASC`
+    );
+
+    const categories = query.rows
+      .map((row) => ({
+        name: row.category,
+        count: Number(row.question_count) || 0
+      }))
+      .filter((category) => category.count > 0);
+
+    res.status(200).json({ categories });
+  } catch (error) {
+    console.error('[quiz/categories] failed:', error?.message);
+    res.status(500).json({ error: 'Failed to load categories' });
+  }
+};

--- a/api/quiz/start.js
+++ b/api/quiz/start.js
@@ -55,6 +55,21 @@ function mapQuestion(row, lang) {
   };
 }
 
+function parseCategoryList(value) {
+  if (!Array.isArray(value)) return [];
+
+  const seen = new Set();
+  return value
+    .map((entry) => String(entry || '').trim())
+    .filter(Boolean)
+    .filter((entry) => {
+      const key = entry.toLowerCase();
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+}
+
 module.exports = async function handler(req, res) {
   if (req.method !== 'POST') {
     res.status(405).json({ error: 'Method not allowed' });
@@ -62,29 +77,44 @@ module.exports = async function handler(req, res) {
   }
 
   try {
-    const { mode = 'random10', count = 10, lang = 'en' } = parseBody(req.body);
-
-    if (mode !== 'random10') {
-      res.status(400).json({ error: 'Only random10 mode is enabled right now.' });
-      return;
-    }
-
+    const { mode = 'random10', count = 10, lang = 'en', categories: rawCategories } = parseBody(req.body);
     const limit = Math.max(1, Math.min(Number(count) || 10, 50));
 
-    const query = await runQuery(
-      `SELECT id, category, question_en, question_no, answers_en, answers_no
-       FROM quiz_questions
-       ORDER BY RANDOM()
-       LIMIT $1`,
-      [limit]
-    );
+    let query;
+    if (mode === 'random10') {
+      query = await runQuery(
+        `SELECT id, category, question_en, question_no, answers_en, answers_no
+         FROM quiz_questions
+         ORDER BY RANDOM()
+         LIMIT $1`,
+        [limit]
+      );
+    } else if (mode === 'categories') {
+      const categories = parseCategoryList(rawCategories);
+      if (!categories.length) {
+        res.status(400).json({ error: 'At least one category must be selected.' });
+        return;
+      }
+
+      query = await runQuery(
+        `SELECT id, category, question_en, question_no, answers_en, answers_no
+         FROM quiz_questions
+         WHERE category = ANY($1::text[])
+         ORDER BY RANDOM()
+         LIMIT $2`,
+        [categories, limit]
+      );
+    } else {
+      res.status(400).json({ error: 'Unsupported quiz mode.' });
+      return;
+    }
 
     const questions = query.rows
       .map((row) => mapQuestion(row, lang))
       .filter((row) => row.prompt && row.answers.length);
 
     res.status(200).json({
-      mode: 'random10',
+      mode,
       count: questions.length,
       questions
     });

--- a/quiz-categories/index.html
+++ b/quiz-categories/index.html
@@ -5,36 +5,519 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Quiz categories</title>
   <style>
-    :root { --bg:#0b0c10; --card:#1e1f25; --txt:#eaeaea; --bd:#2f313a; --accent:#4ecca3; --muted:#9aa0ad; }
-    body { margin:0; font:16px/1.4 system-ui, Segoe UI, Roboto, Arial; background:var(--bg); color:var(--txt); min-height:100dvh; display:grid; place-items:center; padding:20px; box-sizing:border-box; }
-    .card { width:min(680px,100%); background:var(--card); border:1px solid var(--bd); border-radius:14px; padding:20px; }
-    h1 { margin:0 0 10px; }
-    p { margin:0 0 14px; color:var(--muted); }
-    a { display:inline-block; text-decoration:none; background:var(--accent); color:#111; border-radius:8px; padding:10px 14px; font-weight:700; }
+    :root { --bg:#0b0c10; --card:#1e1f25; --txt:#eaeaea; --bd:#2f313a; --accent:#4ecca3; --muted:#9aa0ad; --ok:#80ed99; --warn:#ffd166; --bad:#ff6b6b; }
+    * { box-sizing: border-box; }
+    body { margin:0; font:16px/1.45 system-ui, Segoe UI, Roboto, Arial; background:var(--bg); color:var(--txt); min-height:100dvh; display:grid; place-items:center; padding:24px; }
+    .card { width:min(780px,100%); background:var(--card); border:1px solid var(--bd); border-radius:14px; padding:20px; }
+    h1,h2 { margin:0 0 12px; }
+    p { color:var(--muted); margin:0 0 12px; }
+    .hidden { display:none !important; }
+    .btn-row { display:flex; gap:10px; flex-wrap:wrap; margin-top:12px; }
+    button, .link-btn { border:1px solid var(--bd); border-radius:8px; padding:10px 14px; font-weight:700; cursor:pointer; background:transparent; color:var(--txt); text-decoration:none; }
+    .btn-primary { background:var(--accent); color:#111; border-color:var(--accent); }
+    .muted { color:var(--muted); }
+    .status { min-height:24px; margin-top:12px; font-weight:700; }
+    .status.ok { color:var(--ok); }
+    .status.almost { color:var(--warn); }
+    .status.wrong { color:var(--bad); }
+    input[type="text"], input[type="number"] { width:100%; border:1px solid var(--bd); border-radius:8px; background:var(--bg); color:var(--txt); padding:12px; font-size:16px; }
+    .progress { color:var(--muted); margin-bottom:12px; }
+    .result-list { margin:10px 0 0; padding-left:18px; color:var(--muted); }
+    .category-grid { display:grid; gap:10px; grid-template-columns:repeat(auto-fit, minmax(180px, 1fr)); margin:12px 0; }
+    .category-card { border:1px solid var(--bd); border-radius:10px; padding:12px; background:#17181e; display:flex; justify-content:space-between; gap:10px; align-items:flex-start; cursor:pointer; }
+    .category-card input { margin-top:3px; }
+    .category-meta { color:var(--muted); font-size:14px; }
+    .setup-row { margin-top:12px; }
+    .count-hint { margin-top:8px; }
   </style>
 </head>
 <body>
   <main class="card">
-    <h1>Quiz categories</h1>
-    <p>This is a placeholder page. We will build this quiz mode step by step.</p>
-    <a href="/">Back to sarcasm.games</a>
+    <section id="introView">
+      <h1>Quiz categories</h1>
+      <p id="introLead">Choose one or more categories and how many questions you want.</p>
+      <p id="introHint">Then start the quiz with the same flow as Random10.</p>
+      <div id="categoriesContainer" class="category-grid"></div>
+      <p id="categoryStatus" class="muted"></p>
+      <div class="setup-row">
+        <label for="questionCountInput" id="countLabel">Number of questions</label>
+        <input id="questionCountInput" type="number" min="1" step="1" value="1" />
+        <p id="countHint" class="count-hint muted"></p>
+      </div>
+      <div class="btn-row">
+        <button id="startBtn" class="btn-primary" disabled>Start category quiz</button>
+        <a class="link-btn" href="/">Back to sarcasm.games</a>
+      </div>
+      <p id="introError" class="status wrong"></p>
+    </section>
+
+    <section id="questionView" class="hidden">
+      <div class="progress" id="progressText"></div>
+      <div class="btn-row" style="margin-top:0; margin-bottom:12px;">
+        <button id="abortQuizBtn" type="button">Abort quiz</button>
+      </div>
+      <div id="abortConfirmRow" class="btn-row hidden" style="margin-top:0; margin-bottom:12px;">
+        <span class="muted">Abort current quiz?</span>
+        <button id="confirmAbortBtn" type="button">Yes, abort</button>
+        <button id="cancelAbortBtn" type="button" class="btn-primary">Continue quiz</button>
+      </div>
+      <h2 id="questionTitle">Question</h2>
+      <p id="questionCategory" class="muted"></p>
+      <form id="answerForm">
+        <input id="answerInput" type="text" placeholder="Write your answer here" autocomplete="off" />
+        <div class="btn-row">
+          <button id="submitBtn" type="submit" class="btn-primary">Submit answer</button>
+          <button id="showAnswerBtn" type="button" class="hidden">Show answer</button>
+          <button id="nextQuestionBtn" type="button" class="hidden">Next question</button>
+        </div>
+      </form>
+      <p id="statusText" class="status"></p>
+      <p id="answerReveal" class="muted hidden"></p>
+    </section>
+
+    <section id="resultView" class="hidden">
+      <h2>Quiz complete 🎉</h2>
+      <p id="resultSummary"></p>
+      <ul class="result-list">
+        <li><span id="correctCount">0</span> correct</li>
+        <li><span id="wrongCount">0</span> wrong</li>
+      </ul>
+      <h3>Answered questions</h3>
+      <ul id="answeredQuestionsList" class="result-list"></ul>
+      <div class="btn-row">
+        <button id="playAgainBtn" class="btn-primary">Try again</button>
+        <a class="link-btn" href="/">Back to sarcasm.games</a>
+      </div>
+    </section>
   </main>
 
   <script type="module">
-    import { getQuizLanguage } from '/lib/client/quiz-language.js';
+    import { getQuizLanguage as readQuizLanguage } from '/lib/client/quiz-language.js';
 
-    // Language is captured at page load and must stay fixed during one active round.
-    const activeLang = getQuizLanguage();
+    const fallbackLanguage = 'en';
+    const copy = {
+      en: {
+        title: 'Quiz categories', introLead: 'Choose one or more categories and how many questions you want.', introHint: 'Then start the quiz with the same flow as Random10.',
+        startQuiz: 'Start category quiz', loading: 'Loading…', backHome: 'Back to sarcasm.games', abortQuiz: 'Abort quiz', abortConfirm: 'Abort current quiz?', abortYes: 'Yes, abort', abortNo: 'Continue quiz',
+        questionTitle: 'Question', answerPlaceholder: 'Write your answer here', submitAnswer: 'Submit answer', showAnswer: 'Show answer', nextQuestion: 'Next question',
+        resultTitle: 'Quiz complete 🎉', resultSummary: 'You got {correct} / {total} correct.', correctCount: 'correct', wrongCount: 'wrong', answeredQuestionsHeading: 'Answered questions', playAgain: 'Try again',
+        progress: 'Question {current} of {total}', category: 'Category: {category}', answerPrefix: 'Answer: {answer}', countLabel: 'Number of questions',
+        availableCount: '{count} questions available in selected categories', noCategories: 'Select at least one category to start.', invalidCount: 'Choose a valid number between 1 and {max}.',
+        loadCategoriesError: 'Could not load categories right now.', loadingError: 'Could not start quiz now. Try again.', notEnoughQuestions: 'Not enough questions available.',
+        answerValidateError: 'Could not validate answer.', invalidPayloadError: 'Invalid server response.', answerSubmitError: 'Could not submit answer. Try again.', almostStatus: 'Almost! Try once more.', wrongStatus: 'Not quite. You can reveal the answer and move on.',
+        categoryCount: '{count} questions', positiveMessages: ['Great!', 'Nice!', 'Correct!', 'Awesome!', 'Well done!']
+      },
+      no: {
+        title: 'Quizkategorier', introLead: 'Velg én eller flere kategorier og hvor mange spørsmål du vil ha.', introHint: 'Deretter starter du quizen med samme flyt som Random10.',
+        startQuiz: 'Start kategori-quiz', loading: 'Laster…', backHome: 'Tilbake til sarcasm.games', abortQuiz: 'Avbryt quiz', abortConfirm: 'Avbryte nåværende quiz?', abortYes: 'Ja, avbryt', abortNo: 'Fortsett quiz',
+        questionTitle: 'Spørsmål', answerPlaceholder: 'Skriv svaret ditt her', submitAnswer: 'Send svar', showAnswer: 'Vis fasit', nextQuestion: 'Neste spørsmål',
+        resultTitle: 'Quiz fullført 🎉', resultSummary: 'Du fikk {correct} / {total} riktige.', correctCount: 'riktige', wrongCount: 'feil', answeredQuestionsHeading: 'Besvarte spørsmål', playAgain: 'Prøv igjen',
+        progress: 'Spørsmål {current} av {total}', category: 'Kategori: {category}', answerPrefix: 'Fasit: {answer}', countLabel: 'Antall spørsmål',
+        availableCount: '{count} spørsmål tilgjengelig i valgte kategorier', noCategories: 'Velg minst én kategori for å starte.', invalidCount: 'Velg et gyldig antall mellom 1 og {max}.',
+        loadCategoriesError: 'Kunne ikke laste kategorier akkurat nå.', loadingError: 'Klarte ikke starte quiz nå. Prøv igjen.', notEnoughQuestions: 'Ikke nok spørsmål tilgjengelig.',
+        answerValidateError: 'Kunne ikke validere svar.', invalidPayloadError: 'Ugyldig svar fra server.', answerSubmitError: 'Kunne ikke sende svar. Prøv igjen.', almostStatus: 'Nesten! Prøv én gang til.', wrongStatus: 'Ikke helt. Du kan vise fasit og gå videre.',
+        categoryCount: '{count} spørsmål', positiveMessages: ['Bra!', 'Godt jobba!', 'Nice!', 'Supert!', 'Flott!']
+      }
+    };
 
-    const runtimeState = {
-      activeLang,
+    const activeLang = readQuizLanguage();
+    const introView = document.getElementById('introView');
+    const questionView = document.getElementById('questionView');
+    const resultView = document.getElementById('resultView');
+    const categoriesContainer = document.getElementById('categoriesContainer');
+    const categoryStatus = document.getElementById('categoryStatus');
+    const questionCountInput = document.getElementById('questionCountInput');
+    const countLabel = document.getElementById('countLabel');
+    const countHint = document.getElementById('countHint');
+    const introError = document.getElementById('introError');
+    const answerForm = document.getElementById('answerForm');
+    const progressText = document.getElementById('progressText');
+    const questionTitle = document.getElementById('questionTitle');
+    const questionCategory = document.getElementById('questionCategory');
+    const answerInput = document.getElementById('answerInput');
+    const statusText = document.getElementById('statusText');
+    const answerReveal = document.getElementById('answerReveal');
+    const showAnswerBtn = document.getElementById('showAnswerBtn');
+    const nextQuestionBtn = document.getElementById('nextQuestionBtn');
+    const submitBtn = document.getElementById('submitBtn');
+    const startBtn = document.getElementById('startBtn');
+    const abortQuizBtn = document.getElementById('abortQuizBtn');
+    const abortConfirmRow = document.getElementById('abortConfirmRow');
+    const confirmAbortBtn = document.getElementById('confirmAbortBtn');
+    const cancelAbortBtn = document.getElementById('cancelAbortBtn');
+    const answeredQuestionsList = document.getElementById('answeredQuestionsList');
+    const backLinks = document.querySelectorAll('a.link-btn');
+    const introHeading = introView.querySelector('h1');
+    const introLead = document.getElementById('introLead');
+    const introHint = document.getElementById('introHint');
+    const abortConfirmText = abortConfirmRow.querySelector('.muted');
+    const questionSectionHeading = questionView.querySelector('h2');
+    const resultHeading = resultView.querySelector('h2');
+    const resultCounterItems = resultView.querySelectorAll('ul.result-list li');
+    const answeredQuestionsHeading = resultView.querySelector('h3');
+    const playAgainBtn = document.getElementById('playAgainBtn');
+
+    const state = {
+      language: fallbackLanguage,
+      categories: [],
+      selectedCategories: new Set(),
+      questions: [],
+      index: 0,
+      correct: 0,
+      wrong: 0,
+      answeredQuestions: [],
+      awaitingRetry: false,
+      isSubmitting: false,
+      isAdvancing: false,
       quizStarted: false
     };
 
-    // Placeholder for upcoming API integration:
-    // fetch('/api/quiz/start', { method: 'POST', body: JSON.stringify({ mode: 'quiz-categories', lang: runtimeState.activeLang }) })
+    function getStoredQuizLanguage() { return readQuizLanguage(); }
+    function syncLanguageFromStorage() { state.language = getStoredQuizLanguage(); }
+    function uiCopy() { return copy[state.language] || copy[fallbackLanguage]; }
+    function pickPositiveMessage() {
+      const messages = uiCopy().positiveMessages;
+      return messages[Math.floor(Math.random() * messages.length)];
+    }
+    function showView(view) {
+      introView.classList.toggle('hidden', view !== 'intro');
+      questionView.classList.toggle('hidden', view !== 'question');
+      resultView.classList.toggle('hidden', view !== 'result');
+    }
 
-    window.quizCategoriesState = runtimeState;
+    function selectedQuestionTotal() {
+      return state.categories
+        .filter((category) => state.selectedCategories.has(category.name))
+        .reduce((sum, category) => sum + category.count, 0);
+    }
+
+    function updateCountBounds() {
+      const max = selectedQuestionTotal();
+      questionCountInput.min = '1';
+      questionCountInput.max = String(Math.max(max, 1));
+
+      const current = Number(questionCountInput.value) || 1;
+      if (max === 0) {
+        questionCountInput.value = '1';
+      } else if (current > max) {
+        questionCountInput.value = String(max);
+      } else if (current < 1) {
+        questionCountInput.value = '1';
+      }
+    }
+
+    function isCountValid() {
+      const max = selectedQuestionTotal();
+      const count = Number(questionCountInput.value);
+      return Number.isInteger(count) && count >= 1 && count <= max;
+    }
+
+    function renderSetupState() {
+      const c = uiCopy();
+      const available = selectedQuestionTotal();
+      countHint.textContent = c.availableCount.replace('{count}', String(available));
+
+      if (state.selectedCategories.size === 0) {
+        categoryStatus.textContent = c.noCategories;
+        startBtn.disabled = true;
+        return;
+      }
+
+      if (!isCountValid()) {
+        categoryStatus.textContent = c.invalidCount.replace('{max}', String(Math.max(available, 1)));
+        startBtn.disabled = true;
+        return;
+      }
+
+      categoryStatus.textContent = '';
+      startBtn.disabled = false;
+    }
+
+    function renderCategories() {
+      const c = uiCopy();
+      categoriesContainer.innerHTML = '';
+
+      state.categories.forEach((category) => {
+        const label = document.createElement('label');
+        label.className = 'category-card';
+
+        const textWrapper = document.createElement('div');
+        textWrapper.innerHTML = `<div>${category.name}</div><div class="category-meta">${c.categoryCount.replace('{count}', String(category.count))}</div>`;
+
+        const checkbox = document.createElement('input');
+        checkbox.type = 'checkbox';
+        checkbox.checked = state.selectedCategories.has(category.name);
+        checkbox.addEventListener('change', () => {
+          if (checkbox.checked) {
+            state.selectedCategories.add(category.name);
+          } else {
+            state.selectedCategories.delete(category.name);
+          }
+          updateCountBounds();
+          renderSetupState();
+        });
+
+        label.appendChild(textWrapper);
+        label.appendChild(checkbox);
+        categoriesContainer.appendChild(label);
+      });
+
+      updateCountBounds();
+      renderSetupState();
+    }
+
+    function setStartLoading(isLoading) {
+      startBtn.disabled = isLoading;
+      startBtn.textContent = isLoading ? uiCopy().loading : uiCopy().startQuiz;
+    }
+
+    async function loadCategories() {
+      introError.textContent = '';
+      try {
+        const response = await fetch('/api/quiz/categories');
+        if (!response.ok) throw new Error('Failed to fetch categories');
+        const payload = await response.json();
+        state.categories = (payload.categories || []).filter((item) => item.name && item.count > 0);
+        state.selectedCategories = new Set(state.categories.map((category) => category.name));
+        renderCategories();
+      } catch (_error) {
+        introError.textContent = uiCopy().loadCategoriesError;
+      }
+    }
+
+    function renderAnsweredQuestions() {
+      answeredQuestionsList.innerHTML = '';
+      for (const entry of state.answeredQuestions) {
+        const item = document.createElement('li');
+        if (entry.status === 'correct') {
+          item.textContent = `✅ ${entry.prompt}`;
+        } else {
+          const answerPart = entry.acceptedAnswer ? ` (${uiCopy().answerPrefix.replace('{answer}', entry.acceptedAnswer)})` : '';
+          item.textContent = `❌ ${entry.prompt}${answerPart}`;
+        }
+        answeredQuestionsList.appendChild(item);
+      }
+    }
+
+    function normalizeQuestion(raw, idx) {
+      const answers = Array.isArray(raw.answers) && raw.answers.length ? raw.answers : [raw.answer, raw.answer_en, raw.answer_no].filter(Boolean);
+      return { id: raw.id || `api-${idx}`, category: raw.category || 'General', prompt: raw.prompt || raw.question || 'Missing question text', answers };
+    }
+
+    async function loadQuestions() {
+      introError.textContent = '';
+      try {
+        const requestedCount = Number(questionCountInput.value);
+        const response = await fetch('/api/quiz/start', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            mode: 'categories',
+            categories: Array.from(state.selectedCategories),
+            count: requestedCount,
+            lang: activeLang
+          })
+        });
+
+        if (!response.ok) throw new Error('Could not load questions');
+        const payload = await response.json();
+        const questions = (payload.questions || []).map(normalizeQuestion).filter((q) => q.answers.length);
+        if (questions.length < requestedCount) throw new Error(uiCopy().notEnoughQuestions);
+        return questions.slice(0, requestedCount);
+      } catch (_error) {
+        introError.textContent = uiCopy().loadingError;
+        return [];
+      }
+    }
+
+    function renderQuestion() {
+      const q = state.questions[state.index];
+      progressText.textContent = uiCopy().progress.replace('{current}', String(state.index + 1)).replace('{total}', String(state.questions.length));
+      questionTitle.textContent = q.prompt;
+      questionCategory.textContent = uiCopy().category.replace('{category}', q.category);
+      answerInput.value = '';
+      answerInput.disabled = false;
+      answerInput.focus();
+      state.awaitingRetry = false;
+      state.isSubmitting = false;
+      state.isAdvancing = false;
+      statusText.textContent = '';
+      statusText.className = 'status';
+      answerReveal.classList.add('hidden');
+      answerReveal.textContent = uiCopy().answerPrefix.replace('{answer}', q.answers[0]);
+      showAnswerBtn.classList.add('hidden');
+      nextQuestionBtn.classList.add('hidden');
+      abortConfirmRow.classList.add('hidden');
+      submitBtn.disabled = false;
+    }
+
+    function moveNextQuestion() {
+      state.index += 1;
+      if (state.index >= state.questions.length) {
+        document.getElementById('correctCount').textContent = String(state.correct);
+        document.getElementById('wrongCount').textContent = String(state.wrong);
+        renderAnsweredQuestions();
+        document.getElementById('resultSummary').textContent = uiCopy().resultSummary.replace('{correct}', String(state.correct)).replace('{total}', String(state.questions.length));
+        showView('result');
+        return;
+      }
+      renderQuestion();
+    }
+
+    function resetQuizState() {
+      state.questions = [];
+      state.index = 0;
+      state.correct = 0;
+      state.wrong = 0;
+      state.answeredQuestions = [];
+      state.awaitingRetry = false;
+      state.isSubmitting = false;
+      state.isAdvancing = false;
+      state.quizStarted = false;
+      introError.textContent = '';
+      statusText.textContent = '';
+      answerReveal.classList.add('hidden');
+      abortConfirmRow.classList.add('hidden');
+      setStartLoading(false);
+      renderSetupState();
+    }
+
+    async function evaluateAnswer(question, userAnswer, retryAvailable) {
+      const response = await fetch('/api/quiz/answer', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ questionId: question.id, answer: userAnswer, retryAvailable, mode: 'categories', lang: activeLang })
+      });
+      if (!response.ok) throw new Error(uiCopy().answerValidateError);
+      const payload = await response.json();
+      if (!payload || !payload.status) throw new Error(uiCopy().invalidPayloadError);
+      return payload;
+    }
+
+    async function onSubmitAnswer() {
+      if (submitBtn.disabled || state.isSubmitting || state.isAdvancing) return;
+      const userAnswer = answerInput.value.trim();
+      if (!userAnswer) return;
+
+      const question = state.questions[state.index];
+      const submittedIndex = state.index;
+      state.isSubmitting = true;
+
+      let result;
+      try {
+        result = await evaluateAnswer(question, userAnswer, !state.awaitingRetry);
+      } catch (_error) {
+        state.isSubmitting = false;
+        statusText.className = 'status wrong';
+        statusText.textContent = uiCopy().answerSubmitError;
+        return;
+      }
+
+      if (state.index !== submittedIndex) {
+        state.isSubmitting = false;
+        return;
+      }
+
+      if (result.status === 'correct') {
+        statusText.className = 'status ok';
+        statusText.textContent = pickPositiveMessage();
+        state.correct += 1;
+        state.answeredQuestions.push({ prompt: question.prompt, status: 'correct' });
+        state.isSubmitting = false;
+        state.isAdvancing = true;
+        submitBtn.disabled = true;
+        answerInput.disabled = true;
+        setTimeout(() => moveNextQuestion(), 700);
+        return;
+      }
+
+      if (result.status === 'almost' && !state.awaitingRetry) {
+        state.awaitingRetry = true;
+        state.isSubmitting = false;
+        statusText.className = 'status almost';
+        statusText.textContent = uiCopy().almostStatus;
+        answerInput.value = '';
+        answerInput.focus();
+        return;
+      }
+
+      state.wrong += 1;
+      state.answeredQuestions.push({ prompt: question.prompt, status: 'wrong', acceptedAnswer: result.acceptedAnswer || null });
+      state.awaitingRetry = false;
+      state.isSubmitting = false;
+      statusText.className = 'status wrong';
+      statusText.textContent = uiCopy().wrongStatus;
+      showAnswerBtn.classList.remove('hidden');
+      nextQuestionBtn.classList.remove('hidden');
+      submitBtn.disabled = true;
+    }
+
+    function applyCopy() {
+      const c = uiCopy();
+      document.title = c.title;
+      introHeading.textContent = c.title;
+      introLead.textContent = c.introLead;
+      introHint.textContent = c.introHint;
+      countLabel.textContent = c.countLabel;
+      startBtn.textContent = c.startQuiz;
+      for (const link of backLinks) link.textContent = c.backHome;
+      abortQuizBtn.textContent = c.abortQuiz;
+      abortConfirmText.textContent = c.abortConfirm;
+      confirmAbortBtn.textContent = c.abortYes;
+      cancelAbortBtn.textContent = c.abortNo;
+      questionSectionHeading.textContent = c.questionTitle;
+      answerInput.placeholder = c.answerPlaceholder;
+      submitBtn.textContent = c.submitAnswer;
+      showAnswerBtn.textContent = c.showAnswer;
+      nextQuestionBtn.textContent = c.nextQuestion;
+      resultHeading.textContent = c.resultTitle;
+      resultCounterItems[0].lastChild.textContent = ` ${c.correctCount}`;
+      resultCounterItems[1].lastChild.textContent = ` ${c.wrongCount}`;
+      answeredQuestionsHeading.textContent = c.answeredQuestionsHeading;
+      playAgainBtn.textContent = c.playAgain;
+      renderCategories();
+    }
+
+    startBtn.addEventListener('click', async () => {
+      if (startBtn.disabled) return;
+      syncLanguageFromStorage();
+      applyCopy();
+      setStartLoading(true);
+      state.questions = await loadQuestions();
+      if (state.questions.length < 1) {
+        setStartLoading(false);
+        renderSetupState();
+        return;
+      }
+      state.index = 0;
+      state.correct = 0;
+      state.wrong = 0;
+      state.answeredQuestions = [];
+      state.awaitingRetry = false;
+      state.isSubmitting = false;
+      state.isAdvancing = false;
+      state.quizStarted = true;
+      renderQuestion();
+      showView('question');
+      setStartLoading(false);
+    });
+
+    questionCountInput.addEventListener('input', () => {
+      updateCountBounds();
+      renderSetupState();
+    });
+
+    abortQuizBtn.addEventListener('click', () => abortConfirmRow.classList.remove('hidden'));
+    confirmAbortBtn.addEventListener('click', () => { resetQuizState(); showView('intro'); });
+    cancelAbortBtn.addEventListener('click', () => { abortConfirmRow.classList.add('hidden'); answerInput.focus(); });
+    answerForm.addEventListener('submit', (event) => { event.preventDefault(); onSubmitAnswer(); });
+    showAnswerBtn.addEventListener('click', () => answerReveal.classList.toggle('hidden'));
+    nextQuestionBtn.addEventListener('click', () => moveNextQuestion());
+    playAgainBtn.addEventListener('click', () => { resetQuizState(); showView('intro'); });
+
+    syncLanguageFromStorage();
+    applyCopy();
+    loadCategories();
   </script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Gi brukeren samme visuelle kort-stil og quiz-flyt for kategoribasert quiz som eksisterende `random10` for konsistent UX.
- La brukeren velge én eller flere kategorier og angi antall spørsmål med sanntidsbegrensning basert på tilgjengelige spørsmål.
- Sørge for at quiz-start sender korrekte parametre (`mode: "categories"`, `categories`, `count`, `lang`) til backend.
- Eksponere et enkelt API for å hente kategorier med antall spørsmål fra databasen.

### Description
- Erstattet placeholder i `quiz-categories/index.html` med full setup-/question-/result-view som gjenbruker logikk og stil fra `random10/index.html` og renderer ett kort per kategori.
- Implementert klientlogikk som henter kategorier fra `GET /api/quiz/categories`, pre-selekterer alle kategorier, oppdaterer `min`/`max` for `input[type="number"]` dynamisk og validerer start-knappens enabled/disabled-tilstand.
- Endret start-flow til å poste `{ mode: 'categories', categories: [...], count, lang }` til `/api/quiz/start` og gjenbruke samme spørsmålsvisning/resultatlogikk som `random10`.
- Lagt til ny endpoint `api/quiz/categories.js` som returnerer `{ categories: [{ name, count }, ...] }` og utvidet `api/quiz/start.js` med støtte for `mode === 'categories'` ved å parse og dedupe kategori-listen og kjøre en filtrert SQL-spørring `WHERE category = ANY($1::text[])`.

### Testing
- Kjørte syntakssjekk med `node --check api/quiz/start.js && node --check api/quiz/categories.js` som fullførte uten feil.
- Genererte et automatisk skjermbilde av den nye `quiz-categories`-siden via Playwright mot en lokal statisk server, og artefaktet ble produsert; HTTP API-kall feilet i den statiske-server-konteksten (forventet), så skjermen viste klient-UI riktig men ikke backend-interaksjon i den kjøringen.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2e34faee88333a339ada2df7220d8)