### PR TITLE
Legg til kategori-filter (mode: categories) for quiz-start

### DIFF
--- a/api/quiz/start.js
+++ b/api/quiz/start.js
@@ -62,10 +62,75 @@ module.exports = async function handler(req, res) {
   }
 
   try {
-    const { mode = 'random10', count = 10, lang = 'en' } = parseBody(req.body);
+    const {
+      mode = 'random10',
+      categories,
+      count = 10,
+      lang = 'en'
+    } = parseBody(req.body);
+
+    if (mode === 'categories') {
+      if (!Array.isArray(categories) || !categories.length) {
+        res.status(400).json({ error: 'categories must be a non-empty array of strings.' });
+        return;
+      }
+
+      const selectedCategories = categories
+        .map((category) => (typeof category === 'string' ? category.trim() : ''))
+        .filter(Boolean);
+
+      if (!selectedCategories.length || selectedCategories.length !== categories.length) {
+        res.status(400).json({ error: 'categories must be a non-empty array of strings.' });
+        return;
+      }
+
+      const uniqueCategories = [...new Set(selectedCategories)];
+
+      const countResult = await runQuery(
+        `SELECT COUNT(*)::int AS total
+         FROM quiz_questions
+         WHERE category = ANY($1)`,
+        [uniqueCategories]
+      );
+
+      const totalAvailable = Number(countResult.rows[0]?.total || 0);
+
+      if (totalAvailable < 1) {
+        res.status(400).json({ error: 'No questions available for selected categories.' });
+        return;
+      }
+
+      const requestedCount = Number(count);
+      if (!Number.isInteger(requestedCount) || requestedCount < 1 || requestedCount > totalAvailable) {
+        res.status(400).json({ error: `count must be an integer between 1 and ${totalAvailable}.` });
+        return;
+      }
+
+      const query = await runQuery(
+        `SELECT id, category, question_en, question_no, answers_en, answers_no
+         FROM quiz_questions
+         WHERE category = ANY($1)
+         ORDER BY RANDOM()
+         LIMIT $2`,
+        [uniqueCategories, requestedCount]
+      );
+
+      const questions = query.rows
+        .map((row) => mapQuestion(row, lang))
+        .filter((row) => row.prompt && row.answers.length);
+
+      res.status(200).json({
+        mode: 'categories',
+        count: requestedCount,
+        totalAvailable,
+        selectedCategories: uniqueCategories,
+        questions
+      });
+      return;
+    }
 
     if (mode !== 'random10') {
-      res.status(400).json({ error: 'Only random10 mode is enabled right now.' });
+      res.status(400).json({ error: 'Only random10 and categories modes are supported.' });
       return;
     }
 


### PR DESCRIPTION
### Motivation
- Gi klienten mulighet til å starte quiz kun fra utvalgte kategorier og få totalt antall tilgjengelige spørsmål for UI-visning.
- Beholde eksisterende `random10`-flyt uendret for bakoverkompatibilitet.

### Description
- Utvider request-parsingen i `api/quiz/start.js` til å lese `mode`, `categories`, `count` og `lang` fra body.
- Legger til `mode === 'categories'`-flyt som validerer at `categories` er en ikke-tom array av strenger, fjerner tomme/whitespace entries og deduperer valg.
- Henter totalt antall spørsmål for valgte kategorier med `SELECT COUNT(*) ... WHERE category = ANY($1)` og validerer at `count` er et heltall i `1..totalAvailable`.
- Henter tilfeldige spørsmål med kategorifilter via `SELECT ... WHERE category = ANY($1) ORDER BY RANDOM() LIMIT $2` og gjenbruker eksisterende `mapQuestion` for språk-fallback og answers-normalisering; returnerer payload med `mode`, `count`, `totalAvailable`, `selectedCategories` og `questions`.
- Beholder `random10`-flyten uendret og oppdaterer feilmeldingen for ukjent mode til å nevne begge støttede modi.

### Testing
- Kjørte `node --check api/quiz/start.js` for syntaks-sjekk, og den kjørte uten feil.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2e3c9d50883338b6a677f10275266)