### PR TITLE
Fiks regresjon i random10-endepunktet og gjenopprett visning av quiz-kategorier

### DIFF
--- a/api/quiz/start.js
+++ b/api/quiz/start.js
@@ -149,6 +149,13 @@ module.exports = async function handler(req, res) {
       return;
     }
 
+    const query = await runQuery(
+      `SELECT id, category, question_en, question_no, answers_en, answers_no
+       FROM quiz_questions
+       ORDER BY RANDOM()
+       LIMIT 10`
+    );
+
     const questions = query.rows
       .map((row) => mapQuestion(row, lang))
       .filter((row) => row.prompt && row.answers.length);

--- a/quiz-categories/index.html
+++ b/quiz-categories/index.html
@@ -157,7 +157,7 @@
   <script type="module">
     import { getQuizLanguage as readQuizLanguage } from '/lib/client/quiz-language.js';
 
-    const activeLang = getQuizLanguage();
+    const activeLang = readQuizLanguage();
     const categoryGrid = document.getElementById('categoryGrid');
     const statusEl = document.getElementById('status');
     const countInput = document.getElementById('questionCount');


### PR DESCRIPTION
### Motivation
- En nylig endring fjernet den faktiske database-spørringen for `random10` i `api/quiz/start.js`, som gjorde at koden brukte en udefinert `query` og returnerte ingen spørsmål.
- Quiz-kategorier-siden forsøkte å kalle `getQuizLanguage()` selv om importen ble aliaset som `readQuizLanguage`, noe som forårsaket en runtime-feil og hindret kategoriene i å vises.

### Description
- Legg tilbake DB-spørring for `random10` ved å legge til `await runQuery(...)` som henter 10 tilfeldige rader i `api/quiz/start.js`.
- Rett initialisering av språkvariabel i `quiz-categories/index.html` ved å endre `const activeLang = getQuizLanguage();` til `const activeLang = readQuizLanguage();`.

### Testing
- Kjørte `node --check api/quiz/start.js` for syntaksvalidering av API-filen, og sjekken bestod.
- Kjørte en automatisert filinnholdssjekk med `node -e` for å verifisere at `quiz-categories/index.html` inneholder `const activeLang = readQuizLanguage();`, og sjekken bestod.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2e7b950588333a8c659782449a755)