### PR TITLE
Valider sessions mot DB for å tilbakekalle slettede brukere

### DIFF
--- a/api/_lib/auth.js
+++ b/api/_lib/auth.js
@@ -1,4 +1,5 @@
 const { SignJWT, jwtVerify } = require('jose');
+const { getUserById } = require('./db');
 
 const COOKIE_NAME = 'sg_session';
 const SESSION_TTL_SECONDS = 60 * 60 * 24 * 7;
@@ -75,9 +76,33 @@ async function requireSession(req, res) {
       res.status(401).json({ error: 'Not authenticated' });
       return null;
     }
+
     const payload = await verifySessionToken(token);
-    return payload;
+    const userId = Number(payload.id || payload.sub);
+    if (!Number.isInteger(userId)) {
+      clearSessionCookie(res);
+      res.status(401).json({ error: 'Invalid session' });
+      return null;
+    }
+
+    const user = await getUserById(userId);
+    if (!user) {
+      clearSessionCookie(res);
+      res.status(401).json({ error: 'Invalid session' });
+      return null;
+    }
+
+    return {
+      ...payload,
+      id: user.id,
+      sub: String(user.id),
+      username: user.username,
+      email: user.email,
+      role: user.role,
+      country: user.country || 'unknown'
+    };
   } catch (error) {
+    clearSessionCookie(res);
     res.status(401).json({ error: 'Invalid session' });
     return null;
   }

--- a/api/_lib/db.js
+++ b/api/_lib/db.js
@@ -32,6 +32,17 @@ async function getUserByUsername(username) {
   return result.rows[0] || null;
 }
 
+async function getUserById(id) {
+  const result = await runQuery(
+    `SELECT id, username, email, password_hash, role, country, created_at, updated_at
+     FROM users
+     WHERE id = $1
+     LIMIT 1`,
+    [id]
+  );
+  return result.rows[0] || null;
+}
+
 async function insertUser({ username, email, passwordHash, role = 'user', country }) {
   const result = await runQuery(
     `INSERT INTO users (username, email, password_hash, role, country)
@@ -65,6 +76,7 @@ module.exports = {
   runQuery,
   getUserByEmail,
   getUserByUsername,
+  getUserById,
   insertUser,
   updatePasswordByUserId,
   getUsersForAdminList


### PR DESCRIPTION
### Motivation
- En gyldig JWT kunne fremdeles gi tilgang etter at en bruker var slettet, så serveren må sjekke at brukeren fortsatt finnes uten å belaste klienten med hyppige kall.
- Rolleendringer og andre brukeroppdateringer bør slå inn umiddelbart på beskyttede endepunkter.

### Description
- La til `getUserById` i `api/_lib/db.js` for direkte oppslag av brukere fra session-payload.
- Oppdaterte `requireSession` i `api/_lib/auth.js` til å verifisere JWT, hente `id`/`sub` fra payload og slå opp brukeren i databasen.
- Hvis payload er ugyldig eller brukeren ikke finnes, ryddes session-cookien via `clearSessionCookie(res)` og requesten returnerer `401 Invalid session`.
- `requireSession` returnerer nå canonical brukerdata fra DB (inkludert `role`, `email`, `username`, `country`) slik at rolleendringer trer i kraft umiddelbart.

### Testing
- Kjørt syntaks-sjekk for endrede filer med `node --check api/_lib/auth.js` og `node --check api/_lib/db.js`, som begge fullførte uten feil.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b336d15ac48333a6d51614c3d7eb34)