### PR TITLE
Unngå ORDER BY RANDOM() i quiz-endepunkter — sampling i applikasjonslaget

### DIFF
--- a/api/quiz/index_recommendations.sql
+++ b/api/quiz/index_recommendations.sql
@@ -1,0 +1,11 @@
+-- Recommended indexes for quiz question selection endpoints.
+-- These support category filtering, deterministic id scan/order, and user answer exclusion joins.
+
+CREATE INDEX IF NOT EXISTS idx_quiz_questions_category_id
+  ON quiz_questions (category, id);
+
+CREATE INDEX IF NOT EXISTS idx_user_answers_user_question_correct
+  ON user_answers (user_id, question_id, is_correct);
+
+CREATE INDEX IF NOT EXISTS idx_user_answers_question_user
+  ON user_answers (question_id, user_id);

--- a/api/quiz/quest.js
+++ b/api/quiz/quest.js
@@ -99,6 +99,71 @@ function isQuestionValid(question) {
   return Boolean(question && question.prompt && Array.isArray(question.answers) && question.answers.length);
 }
 
+async function pickRandomQuestion({ categories, userId, solvedQuestionIds }) {
+  if (userId) {
+    const countResult = await runQuery(
+      `SELECT COUNT(*)::int AS total
+       FROM quiz_questions q
+       WHERE q.category = ANY($1)
+         AND NOT EXISTS (
+           SELECT 1
+           FROM user_answers ua
+           WHERE ua.user_id = $2
+             AND ua.question_id = q.id
+             AND ua.is_correct = TRUE
+         )`,
+      [categories, userId]
+    );
+
+    const total = Number(countResult.rows[0]?.total) || 0;
+    if (total < 1) return null;
+
+    const offset = Math.floor(Math.random() * total);
+    const query = await runQuery(
+      `SELECT q.id, q.category, q.question_en, q.question_no, q.answers_en, q.answers_no
+       FROM quiz_questions q
+       WHERE q.category = ANY($1)
+         AND NOT EXISTS (
+           SELECT 1
+           FROM user_answers ua
+           WHERE ua.user_id = $2
+             AND ua.question_id = q.id
+             AND ua.is_correct = TRUE
+         )
+       ORDER BY q.id ASC
+       LIMIT 1 OFFSET $3`,
+      [categories, userId, offset]
+    );
+
+    return query.rows[0] || null;
+  }
+
+  const excludedIds = solvedQuestionIds.length ? solvedQuestionIds : [0];
+  const countResult = await runQuery(
+    `SELECT COUNT(*)::int AS total
+     FROM quiz_questions q
+     WHERE q.category = ANY($1)
+       AND NOT (q.id = ANY($2::int[]))`,
+    [categories, excludedIds]
+  );
+
+  const total = Number(countResult.rows[0]?.total) || 0;
+  if (total < 1) return null;
+
+  const offset = Math.floor(Math.random() * total);
+  const query = await runQuery(
+    `SELECT q.id, q.category, q.question_en, q.question_no, q.answers_en, q.answers_no
+     FROM quiz_questions q
+     WHERE q.category = ANY($1)
+       AND NOT (q.id = ANY($2::int[]))
+     ORDER BY q.id ASC
+     LIMIT 1 OFFSET $3`,
+    [categories, excludedIds, offset]
+  );
+
+  return query.rows[0] || null;
+}
+
 async function getOverview({ userId, solvedQuestionIds }) {
   if (userId) {
     const result = await runQuery(
@@ -185,34 +250,10 @@ module.exports = async function handler(req, res) {
         return;
       }
 
-      const query = userId
-        ? await runQuery(
-          `SELECT q.id, q.category, q.question_en, q.question_no, q.answers_en, q.answers_no
-           FROM quiz_questions q
-           LEFT JOIN user_answers ua
-             ON ua.question_id = q.id
-            AND ua.user_id = $2
-           WHERE q.category = ANY($1)
-             AND COALESCE(ua.is_correct, FALSE) = FALSE
-           ORDER BY RANDOM()
-           LIMIT 50`,
-          [categories, userId]
-        )
-        : await runQuery(
-          `SELECT q.id, q.category, q.question_en, q.question_no, q.answers_en, q.answers_no
-           FROM quiz_questions q
-           WHERE q.category = ANY($1)
-             AND NOT (q.id = ANY($2::int[]))
-           ORDER BY RANDOM()
-           LIMIT 50`,
-          [categories, solvedQuestionIds.length ? solvedQuestionIds : [0]]
-        );
+      const candidate = await pickRandomQuestion({ categories, userId, solvedQuestionIds });
+      const question = candidate ? mapQuestion(candidate, lang) : null;
 
-      const question = query.rows
-        .map((row) => mapQuestion(row, lang))
-        .find((entry) => isQuestionValid(entry));
-
-      if (!question) {
+      if (!isQuestionValid(question)) {
         res.status(200).json({ question: null });
         return;
       }

--- a/api/quiz/start.js
+++ b/api/quiz/start.js
@@ -55,23 +55,25 @@ function mapQuestion(row, lang) {
   };
 }
 
-function parseCategoryList(value) {
-  if (!Array.isArray(value)) return [];
-
-  const seen = new Set();
-  return value
-    .map((entry) => String(entry || '').trim())
-    .filter(Boolean)
-    .filter((entry) => {
-      const key = entry.toLowerCase();
-      if (seen.has(key)) return false;
-      seen.add(key);
-      return true;
-    });
-}
-
 function randomIndex(max) {
   return Math.floor(Math.random() * max);
+}
+
+function shuffleInPlace(values) {
+  for (let index = values.length - 1; index > 0; index -= 1) {
+    const targetIndex = randomIndex(index + 1);
+    [values[index], values[targetIndex]] = [values[targetIndex], values[index]];
+  }
+  return values;
+}
+
+function sampleWithoutReplacement(values, count) {
+  if (count <= 0 || !values.length) return [];
+  if (count >= values.length) return [...values];
+
+  const shuffled = [...values];
+  shuffleInPlace(shuffled);
+  return shuffled.slice(0, count);
 }
 
 function allocateQuestionsPerCategory(availableByCategory, requestedCount) {
@@ -114,6 +116,15 @@ function allocateQuestionsPerCategory(availableByCategory, requestedCount) {
   }
 
   return allocation;
+}
+
+function orderRowsByIdList(rows, orderedIds) {
+  const indexById = new Map(orderedIds.map((id, index) => [Number(id), index]));
+  return [...rows].sort((left, right) => {
+    const leftRank = indexById.get(Number(left.id)) ?? Number.MAX_SAFE_INTEGER;
+    const rightRank = indexById.get(Number(right.id)) ?? Number.MAX_SAFE_INTEGER;
+    return leftRank - rightRank;
+  });
 }
 
 module.exports = async function handler(req, res) {
@@ -180,34 +191,42 @@ module.exports = async function handler(req, res) {
       }
 
       const categoryAllocation = allocateQuestionsPerCategory(availableByCategory, requestedCount);
-      const allocationJson = JSON.stringify(categoryAllocation);
-
-      const query = await runQuery(
-        `WITH limits AS (
-           SELECT key::text AS category, value::int AS max_count
-           FROM jsonb_each_text($1::jsonb)
-         ),
-         ranked_questions AS (
-           SELECT
-             q.id,
-             q.category,
-             q.question_en,
-             q.question_no,
-             q.answers_en,
-             q.answers_no,
-             l.max_count,
-             ROW_NUMBER() OVER (PARTITION BY q.category ORDER BY RANDOM()) AS category_rank
-           FROM quiz_questions q
-           INNER JOIN limits l ON l.category = q.category
-         )
-         SELECT id, category, question_en, question_no, answers_en, answers_no
-         FROM ranked_questions
-         WHERE category_rank <= max_count
-         ORDER BY RANDOM()`,
-        [allocationJson]
+      const candidateQuery = await runQuery(
+        `SELECT id, category
+         FROM quiz_questions
+         WHERE category = ANY($1)
+         ORDER BY category ASC, id ASC`,
+        [uniqueCategories]
       );
 
-      const questions = query.rows
+      const idsByCategory = new Map(uniqueCategories.map((category) => [category, []]));
+      for (const row of candidateQuery.rows) {
+        const category = String(row.category || '');
+        if (!idsByCategory.has(category)) continue;
+        idsByCategory.get(category).push(Number(row.id));
+      }
+
+      const selectedIds = [];
+      for (const category of uniqueCategories) {
+        const targetCount = Number(categoryAllocation[category] || 0);
+        if (targetCount < 1) continue;
+        const candidates = idsByCategory.get(category) || [];
+        selectedIds.push(...sampleWithoutReplacement(candidates, targetCount));
+      }
+
+      shuffleInPlace(selectedIds);
+
+      const query = selectedIds.length
+        ? await runQuery(
+          `SELECT id, category, question_en, question_no, answers_en, answers_no
+           FROM quiz_questions
+           WHERE id = ANY($1::int[])`,
+          [selectedIds]
+        )
+        : { rows: [] };
+
+      const orderedRows = orderRowsByIdList(query.rows, selectedIds);
+      const questions = orderedRows
         .map((row) => mapQuestion(row, lang))
         .filter((row) => row.prompt && row.answers.length);
 
@@ -227,14 +246,28 @@ module.exports = async function handler(req, res) {
       return;
     }
 
-    const query = await runQuery(
-      `SELECT id, category, question_en, question_no, answers_en, answers_no
+    const candidates = await runQuery(
+      `SELECT id
        FROM quiz_questions
-       ORDER BY RANDOM()
-       LIMIT 10`
+       ORDER BY id ASC`
     );
 
-    const questions = query.rows
+    const selectedIds = sampleWithoutReplacement(
+      candidates.rows.map((row) => Number(row.id)),
+      10
+    );
+
+    const query = selectedIds.length
+      ? await runQuery(
+        `SELECT id, category, question_en, question_no, answers_en, answers_no
+         FROM quiz_questions
+         WHERE id = ANY($1::int[])`,
+        [selectedIds]
+      )
+      : { rows: [] };
+
+    const orderedRows = orderRowsByIdList(query.rows, selectedIds);
+    const questions = orderedRows
       .map((row) => mapQuestion(row, lang))
       .filter((row) => row.prompt && row.answers.length);
 


### PR DESCRIPTION
### Motivation
- Fjerne tunge `ORDER BY RANDOM()`-spørringer som sorterer store tabeller per request for å redusere DB-kostnad og forbedre skalerbarhet. 
- Gi deterministisk og effektiv henting av kandidat-IDer (prefiltert på `category`/progresjon) og gjøre den tilfeldige trekken i applikasjonslaget eller via lettvekts DB-operasjoner.

### Description
- Refaktorert `api/quiz/start.js` for å fjerne `ORDER BY RANDOM()` i både `random10` og `categories` modes ved å hente kandidat-IDer (`SELECT id ... ORDER BY id ASC`) og gjøre sampling i app-laget med nye hjelpere `shuffleInPlace` og `sampleWithoutReplacement`.
- Endret `start -> mode=categories` til å: allokere nøyaktig antall per kategori med `allocateQuestionsPerCategory`, hente kandidat-IDer per kategori, sample ID-er per kategori i applikasjonen, og deretter hente kun de valgte radene; dette leverer eksakt `count` uten global random-sortering.
- Implementert `pickRandomQuestion(...)` i `api/quiz/quest.js` og oppdatert `action=next` til å returnere nøyaktig én kandidat per kall ved å først `COUNT(*)` for kandidatmengden og deretter hente én rad med en tilfeldig `OFFSET`, både for autentiserte brukere (ekskludere riktige `user_answers`) og gjester (ekskludere `solvedQuestionIds`).
- Lagt til `api/quiz/index_recommendations.sql` med anbefalte indekser for vanlige filtre/joins (`(category, id)` på `quiz_questions` og indekser for `user_answers`), uten å automatisk anvende migrasjoner.

### Testing
- Syntaks-sjekk med `node --check api/quiz/start.js` og `node --check api/quiz/quest.js` ble kjørt og returnerte uten feil.
- Søk for resterende `ORDER BY RANDOM()` med `rg -n "ORDER BY RANDOM\(\)" api/quiz/start.js api/quiz/quest.js` ble kjørt og fant ingen treff.
- Endringene ble committed (lokalt) og inkluderer filen `api/quiz/index_recommendations.sql` for DB-administratorer å anvende etter behov.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3b5d31e7c8333a91d6e19f36ab738)