### PR TITLE
Optimize guest quest progress transport with token + deltas

### DIFF
--- a/api/quiz/quest.js
+++ b/api/quiz/quest.js
@@ -1,5 +1,9 @@
+const crypto = require('crypto');
 const { runQuery } = require('../_lib/db');
 const { parseCookies, verifySessionToken, COOKIE_NAME } = require('../_lib/auth');
+
+const GUEST_PROGRESS_TTL_MS = 1000 * 60 * 60 * 12;
+const guestProgressStore = new Map();
 
 function parseBody(body) {
   if (!body) return {};
@@ -99,6 +103,77 @@ function isQuestionValid(question) {
   return Boolean(question && question.prompt && Array.isArray(question.answers) && question.answers.length);
 }
 
+function pruneGuestProgressStore() {
+  const expiresBefore = Date.now() - GUEST_PROGRESS_TTL_MS;
+  for (const [token, entry] of guestProgressStore.entries()) {
+    if (!entry || entry.updatedAt < expiresBefore) {
+      guestProgressStore.delete(token);
+    }
+  }
+}
+
+function createGuestProgressToken() {
+  let token = crypto.randomBytes(9).toString('base64url');
+  while (guestProgressStore.has(token)) {
+    token = crypto.randomBytes(9).toString('base64url');
+  }
+  return token;
+}
+
+function loadGuestProgress(body) {
+  pruneGuestProgressStore();
+
+  const legacySolvedIds = parseSolvedQuestionIds(body.solvedQuestionIds);
+  const solvedDeltas = parseSolvedQuestionIds(body.solvedQuestionIdDeltas);
+  const requestedToken = typeof body.guestProgressToken === 'string' ? body.guestProgressToken.trim() : '';
+
+  let token = null;
+  let solvedSet = new Set();
+  let shouldPersist = false;
+
+  if (requestedToken) {
+    const existing = guestProgressStore.get(requestedToken);
+    if (existing) {
+      token = requestedToken;
+      solvedSet = new Set(existing.solvedQuestionIds);
+    }
+  }
+
+  if (legacySolvedIds.length) {
+    shouldPersist = true;
+    for (const id of legacySolvedIds) solvedSet.add(id);
+  }
+
+  if (solvedDeltas.length) {
+    shouldPersist = true;
+    for (const id of solvedDeltas) solvedSet.add(id);
+  }
+
+  const shouldIssueToken = Boolean(requestedToken || legacySolvedIds.length || solvedDeltas.length);
+
+  if (!token && shouldIssueToken) {
+    token = createGuestProgressToken();
+  }
+
+  if (token && (shouldPersist || !guestProgressStore.has(token))) {
+    guestProgressStore.set(token, {
+      solvedQuestionIds: [...solvedSet],
+      updatedAt: Date.now()
+    });
+  } else if (token) {
+    const existing = guestProgressStore.get(token);
+    if (existing) {
+      existing.updatedAt = Date.now();
+      guestProgressStore.set(token, existing);
+    }
+  }
+
+  return {
+    token,
+    solvedQuestionIds: [...solvedSet]
+  };
+}
+
 async function getOverview({ userId, solvedQuestionIds }) {
   if (userId) {
     const result = await runQuery(
@@ -167,13 +242,14 @@ module.exports = async function handler(req, res) {
     const lang = body.lang === 'no' ? 'no' : 'en';
     const session = await tryGetSession(req);
     const userId = session && Number.isInteger(Number(session.id)) ? Number(session.id) : null;
-    const solvedQuestionIds = parseSolvedQuestionIds(body.solvedQuestionIds);
+    const guestProgress = userId ? { token: null, solvedQuestionIds: [] } : loadGuestProgress(body);
 
     if (action === 'overview') {
-      const categories = await getOverview({ userId, solvedQuestionIds });
+      const categories = await getOverview({ userId, solvedQuestionIds: guestProgress.solvedQuestionIds });
       res.status(200).json({
         mode: userId ? 'authenticated' : 'guest',
-        categories
+        categories,
+        ...(guestProgress.token ? { guestProgressToken: guestProgress.token } : {})
       });
       return;
     }
@@ -205,7 +281,7 @@ module.exports = async function handler(req, res) {
              AND NOT (q.id = ANY($2::int[]))
            ORDER BY RANDOM()
            LIMIT 50`,
-          [categories, solvedQuestionIds.length ? solvedQuestionIds : [0]]
+          [categories, guestProgress.solvedQuestionIds.length ? guestProgress.solvedQuestionIds : [0]]
         );
 
       const question = query.rows
@@ -213,11 +289,17 @@ module.exports = async function handler(req, res) {
         .find((entry) => isQuestionValid(entry));
 
       if (!question) {
-        res.status(200).json({ question: null });
+        res.status(200).json({
+          question: null,
+          ...(guestProgress.token ? { guestProgressToken: guestProgress.token } : {})
+        });
         return;
       }
 
-      res.status(200).json({ question });
+      res.status(200).json({
+        question,
+        ...(guestProgress.token ? { guestProgressToken: guestProgress.token } : {})
+      });
       return;
     }
 

--- a/quiz-quest/index.html
+++ b/quiz-quest/index.html
@@ -233,6 +233,7 @@
 
     const activeLang = getQuizLanguage() === 'no' ? 'no' : 'en';
     const GUEST_PROGRESS_KEY = 'quizQuestGuestProgress';
+    const GUEST_PROGRESS_TOKEN_KEY = 'quizQuestGuestProgressToken';
 
     const copy = {
       en: {
@@ -310,6 +311,8 @@
       isLoadingQuestion: false,
       isSubmitting: false,
       guestProgress: readGuestProgress(),
+      guestProgressToken: readGuestProgressToken(),
+      pendingSolvedQuestionIds: [],
       roundTarget: 0,
       roundAnswered: 0,
       isQuestActive: false
@@ -372,6 +375,26 @@
       localStorage.setItem(GUEST_PROGRESS_KEY, JSON.stringify(state.guestProgress));
     }
 
+    function readGuestProgressToken() {
+      try {
+        const token = localStorage.getItem(GUEST_PROGRESS_TOKEN_KEY);
+        return typeof token === 'string' && token.trim() ? token.trim() : null;
+      } catch (error) {
+        return null;
+      }
+    }
+
+    function writeGuestProgressToken(token) {
+      const normalized = typeof token === 'string' && token.trim() ? token.trim() : null;
+      state.guestProgressToken = normalized;
+
+      if (normalized) {
+        localStorage.setItem(GUEST_PROGRESS_TOKEN_KEY, normalized);
+      } else {
+        localStorage.removeItem(GUEST_PROGRESS_TOKEN_KEY);
+      }
+    }
+
     function getGuestSolvedQuestionIds() {
       return Object.values(state.guestProgress).flat();
     }
@@ -388,22 +411,49 @@
     }
 
     async function questApi(action, payload = {}) {
+      const requestPayload = {
+        action,
+        lang: activeLang,
+        ...payload
+      };
+      let deltas = [];
+
+      if (!state.session) {
+        if (state.guestProgressToken) {
+          requestPayload.guestProgressToken = state.guestProgressToken;
+        }
+
+        if (state.pendingSolvedQuestionIds.length) {
+          deltas = [...new Set(state.pendingSolvedQuestionIds)];
+          requestPayload.solvedQuestionIdDeltas = deltas;
+          state.pendingSolvedQuestionIds = [];
+        }
+
+        if (!requestPayload.guestProgressToken && !requestPayload.solvedQuestionIdDeltas) {
+          requestPayload.solvedQuestionIds = getGuestSolvedQuestionIds();
+        }
+      }
+
       const response = await fetch('/api/quiz/quest', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          action,
-          lang: activeLang,
-          solvedQuestionIds: getGuestSolvedQuestionIds(),
-          ...payload
-        })
+        body: JSON.stringify(requestPayload)
       });
 
       if (!response.ok) {
+        if (!state.session && deltas.length) {
+          state.pendingSolvedQuestionIds = [...deltas, ...state.pendingSolvedQuestionIds];
+        }
         throw new Error('request_failed');
       }
 
-      return response.json();
+      const responsePayload = await response.json();
+
+      if (!state.session && responsePayload && typeof responsePayload.guestProgressToken === 'string') {
+        writeGuestProgressToken(responsePayload.guestProgressToken);
+      }
+
+      return responsePayload;
     }
 
     function selectedCategories() {
@@ -555,6 +605,7 @@
 
       if (!state.guestProgress[question.category].includes(question.id)) {
         state.guestProgress[question.category].push(question.id);
+        state.pendingSolvedQuestionIds.push(question.id);
         writeGuestProgress();
       }
     }
@@ -751,6 +802,8 @@
           setupStatus.textContent = ui().resetUserDone;
         } else {
           delete state.guestProgress[category];
+          state.pendingSolvedQuestionIds = [];
+          writeGuestProgressToken(null);
           writeGuestProgress();
           setupStatus.className = 'status ok';
           setupStatus.textContent = ui().resetGuestDone;


### PR DESCRIPTION
### Motivation
- Reduce client-to-server payload for guest users by avoiding sending the full list of solved IDs on every request while keeping a backward-compatible migration path.
- Keep guest progress lightweight and server-side without writing to the DB, and make the client resilient to transient network failures.

### Description
- Client changes in `quiz-quest/index.html`: added local storage key `quizQuestGuestProgressToken`, a `pendingSolvedQuestionIds` buffer, and functions `readGuestProgressToken` / `writeGuestProgressToken` to persist a short token.
- Refactored `questApi(action, payload)` to send minimal metadata for guests: `guestProgressToken` when present, `solvedQuestionIdDeltas` (deduplicated pending IDs) for incremental updates, and fall back to legacy `solvedQuestionIds` when no token/deltas exist; the client also re-queues deltas on failed requests and writes server-issued token from responses.
- Guest flow changes: `markGuestSolved` now appends to pending deltas instead of repeatedly sending the full list, and guest `reset` clears the token and pending queue prior to refreshing the overview.
- Server changes in `api/quiz/quest.js`: added an in-memory `guestProgressStore` keyed by a short `base64url` token with TTL pruning (12h), `loadGuestProgress` that accepts legacy `solvedQuestionIds` or the new `guestProgressToken` + `solvedQuestionIdDeltas`, and responses include `guestProgressToken` for guests so clients can switch to incremental mode; `overview` and `next` use token-backed solved sets when available.

### Testing
- `node --check api/quiz/quest.js` ran successfully and reported no syntax errors for the server file.
- Attempted `node --check quiz-quest/index.html` but this environment cannot `--check` `.html` files with Node, so HTML syntax check was skipped for that reason.
- Ran `git diff --check` which reported no whitespace or diff issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3b63942508333accb6d4d90c9eb4a)