### PR TITLE
Protect quiz endpoints with scoped rate limits

### DIFF
--- a/api/_lib/quiz-rate-limit-response.js
+++ b/api/_lib/quiz-rate-limit-response.js
@@ -1,0 +1,13 @@
+const QUIZ_RATE_LIMIT_ERROR = {
+  code: 'RATE_LIMITED',
+  message: 'Too many quiz requests. Please wait a moment and try again.'
+};
+
+function sendQuizRateLimited(res) {
+  res.setHeader('Retry-After', '10');
+  res.status(429).json({ error: QUIZ_RATE_LIMIT_ERROR });
+}
+
+module.exports = {
+  sendQuizRateLimited
+};

--- a/api/_lib/rate-limit.js
+++ b/api/_lib/rate-limit.js
@@ -1,5 +1,33 @@
-const WINDOW_MS = 60 * 1000;
-const MAX_REQUESTS_PER_WINDOW = 5;
+const DEFAULT_WINDOW_MS = 60 * 1000;
+const DEFAULT_MAX_REQUESTS_PER_WINDOW = 5;
+
+// Recommended starting thresholds (tune from production telemetry):
+// - auth: strict to slow down brute-force attempts.
+// - quiz:*: higher sustained rates than auth, plus short burst caps to dampen spikes.
+const SCOPE_LIMITS = {
+  auth: {
+    windowMs: DEFAULT_WINDOW_MS,
+    maxRequests: DEFAULT_MAX_REQUESTS_PER_WINDOW
+  },
+  'quiz:start': {
+    windowMs: 60 * 1000,
+    maxRequests: 60,
+    burstWindowMs: 10 * 1000,
+    burstMaxRequests: 12
+  },
+  'quiz:quest': {
+    windowMs: 60 * 1000,
+    maxRequests: 120,
+    burstWindowMs: 10 * 1000,
+    burstMaxRequests: 24
+  },
+  'quiz:answer': {
+    windowMs: 60 * 1000,
+    maxRequests: 180,
+    burstWindowMs: 10 * 1000,
+    burstMaxRequests: 36
+  }
+};
 
 const requestBuckets = new Map();
 
@@ -17,21 +45,47 @@ function getClientIp(req) {
   return 'unknown-ip';
 }
 
+function getScopeConfig(scope) {
+  return SCOPE_LIMITS[scope] || SCOPE_LIMITS.auth;
+}
+
 function isRateLimited(req, scope = 'auth') {
   const now = Date.now();
   const ip = getClientIp(req);
   const key = `${scope}:${ip}`;
+  const config = getScopeConfig(scope);
 
-  const bucket = requestBuckets.get(key) || [];
-  const fresh = bucket.filter((timestamp) => now - timestamp < WINDOW_MS);
+  const bucket = requestBuckets.get(key) || { windowTimestamps: [], burstTimestamps: [] };
 
-  if (fresh.length >= MAX_REQUESTS_PER_WINDOW) {
-    requestBuckets.set(key, fresh);
+  const freshWindow = bucket.windowTimestamps.filter((timestamp) => now - timestamp < config.windowMs);
+  if (freshWindow.length >= config.maxRequests) {
+    requestBuckets.set(key, {
+      windowTimestamps: freshWindow,
+      burstTimestamps: bucket.burstTimestamps
+    });
     return true;
   }
 
-  fresh.push(now);
-  requestBuckets.set(key, fresh);
+  let freshBurst = bucket.burstTimestamps;
+  if (config.burstWindowMs && config.burstMaxRequests) {
+    freshBurst = bucket.burstTimestamps.filter((timestamp) => now - timestamp < config.burstWindowMs);
+    if (freshBurst.length >= config.burstMaxRequests) {
+      requestBuckets.set(key, {
+        windowTimestamps: freshWindow,
+        burstTimestamps: freshBurst
+      });
+      return true;
+    }
+
+    freshBurst.push(now);
+  }
+
+  freshWindow.push(now);
+  requestBuckets.set(key, {
+    windowTimestamps: freshWindow,
+    burstTimestamps: freshBurst
+  });
+
   return false;
 }
 

--- a/api/quiz/answer.js
+++ b/api/quiz/answer.js
@@ -1,6 +1,8 @@
 const { runQuery } = require('../_lib/db');
 const { parseCookies, verifySessionToken, COOKIE_NAME } = require('../_lib/auth');
 const { evaluateAnswer } = require('../../lib/server/quiz-answer-evaluator');
+const { isRateLimited } = require('../_lib/rate-limit');
+const { sendQuizRateLimited } = require('../_lib/quiz-rate-limit-response');
 
 function parseBody(body) {
   if (!body) return {};
@@ -61,6 +63,11 @@ async function persistProgress(userId, questionId, isCorrect) {
 module.exports = async function handler(req, res) {
   if (req.method !== 'POST') {
     res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  if (isRateLimited(req, 'quiz:answer')) {
+    sendQuizRateLimited(res);
     return;
   }
 

--- a/api/quiz/quest.js
+++ b/api/quiz/quest.js
@@ -1,5 +1,7 @@
 const { runQuery } = require('../_lib/db');
 const { parseCookies, verifySessionToken, COOKIE_NAME } = require('../_lib/auth');
+const { isRateLimited } = require('../_lib/rate-limit');
+const { sendQuizRateLimited } = require('../_lib/quiz-rate-limit-response');
 
 function parseBody(body) {
   if (!body) return {};
@@ -158,6 +160,11 @@ async function getOverview({ userId, solvedQuestionIds }) {
 module.exports = async function handler(req, res) {
   if (req.method !== 'POST') {
     res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  if (isRateLimited(req, 'quiz:quest')) {
+    sendQuizRateLimited(res);
     return;
   }
 

--- a/api/quiz/start.js
+++ b/api/quiz/start.js
@@ -1,4 +1,6 @@
 const { runQuery } = require('../_lib/db');
+const { isRateLimited } = require('../_lib/rate-limit');
+const { sendQuizRateLimited } = require('../_lib/quiz-rate-limit-response');
 
 function parseBody(body) {
   if (!body) return {};
@@ -119,6 +121,11 @@ function allocateQuestionsPerCategory(availableByCategory, requestedCount) {
 module.exports = async function handler(req, res) {
   if (req.method !== 'POST') {
     res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  if (isRateLimited(req, 'quiz:start')) {
+    sendQuizRateLimited(res);
     return;
   }
 


### PR DESCRIPTION
### Motivation
- Forhindre overbelastning og brute-force mot quiz-endepunktene ved å gjenbruke/utvide eksisterende rate-limit-logikk og gi quiz-APIene egne scope-nøkler.
- Avvise raskt med HTTP 429 før tunge database- eller sesjonsoperasjoner for å spare ressurser og redusere utsatt angrepsflate.
- Tillate høyere gjennomstrømning for quiz-ruter enn for auth, men legge inn burst-beskyttelse for å dempe kortvarige spikes.
- Gi en konsistent feilmelding og `Retry-After`-header for alle quiz-rate-limit-svar og dokumentere anbefalte terskler i koden for videre tuning.

### Description
- Utvidet `api/_lib/rate-limit.js` til å støtte scope-spesifikke konfigurasjoner (`quiz:start`, `quiz:quest`, `quiz:answer`) med per-window threshhold og valgfri burst-window, og la inn kommentarene med anbefalte startterskler.
- La til en delt 429-respons i `api/_lib/quiz-rate-limit-response.js` som returnerer et konsistent JSON-feilobjekt (`error.code` og `error.message`) og setter `Retry-After`.
- Innførte tidlig sjekk av rate-limit i starten av `api/quiz/start.js`, `api/quiz/quest.js` og `api/quiz/answer.js` ved å kalle `isRateLimited(req, '<scope>')` og respondere med `sendQuizRateLimited(res)` før DB-/session-logikk.
- Implementasjonen bruker eksisterende tilnærming for å hente klient-IP fra `x-forwarded-for`/`x-real-ip` og lagrer tidsstempler i minnekart for enkle per-ip buckets.

### Testing
- Kjørte syntaktisk sjekk med `node --check api/_lib/rate-limit.js`, `node --check api/_lib/quiz-rate-limit-response.js`, `node --check api/quiz/start.js`, `node --check api/quiz/quest.js` og `node --check api/quiz/answer.js`, og alle sjekker bestod.
- Endringene er minimale og gjør tidlig avvisning; funksjonell load-testing bør utføres i staging for å finjustere tersklene før produksjonsutrulling.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3b64bcfec8333a16b89def7a22dcb)