### PR TITLE
Avoid expensive ORDER BY RANDOM() for quiz 'next' and fix guest solved IDs handling

### DIFF
--- a/api/quiz/quest.js
+++ b/api/quiz/quest.js
@@ -105,6 +105,73 @@ function isQuestionValid(question) {
   return Boolean(question && question.prompt && Array.isArray(question.answers) && question.answers.length);
 }
 
+
+function randomIndex(max) {
+  return Math.floor(Math.random() * max);
+}
+
+async function getNextQuestionCandidateCount({ userId, categories, solvedQuestionIds }) {
+  if (userId) {
+    const result = await runQuery(
+      `SELECT COUNT(*)::int AS total
+       FROM quiz_questions q
+       LEFT JOIN user_answers ua
+         ON ua.question_id = q.id
+        AND ua.user_id = $2
+       WHERE q.category = ANY($1)
+         AND COALESCE(ua.is_correct, FALSE) = FALSE`,
+      [categories, userId]
+    );
+
+    return Number(result.rows[0]?.total) || 0;
+  }
+
+  const excludedIds = solvedQuestionIds.length ? solvedQuestionIds : [0];
+  const result = await runQuery(
+    `SELECT COUNT(*)::int AS total
+     FROM quiz_questions q
+     WHERE q.category = ANY($1)
+       AND NOT (q.id = ANY($2::int[]))`,
+    [categories, excludedIds]
+  );
+
+  return Number(result.rows[0]?.total) || 0;
+}
+
+async function getNextQuestionCandidateAtOffset({ userId, categories, solvedQuestionIds, offset }) {
+  if (userId) {
+    const result = await runQuery(
+      `SELECT q.id, q.category, q.question_en, q.question_no, q.answers_en, q.answers_no
+       FROM quiz_questions q
+       LEFT JOIN user_answers ua
+         ON ua.question_id = q.id
+        AND ua.user_id = $2
+       WHERE q.category = ANY($1)
+         AND COALESCE(ua.is_correct, FALSE) = FALSE
+       ORDER BY q.id ASC
+       OFFSET $3
+       LIMIT 1`,
+      [categories, userId, offset]
+    );
+
+    return result.rows[0] || null;
+  }
+
+  const excludedIds = solvedQuestionIds.length ? solvedQuestionIds : [0];
+  const result = await runQuery(
+    `SELECT q.id, q.category, q.question_en, q.question_no, q.answers_en, q.answers_no
+     FROM quiz_questions q
+     WHERE q.category = ANY($1)
+       AND NOT (q.id = ANY($2::int[]))
+     ORDER BY q.id ASC
+     OFFSET $3
+     LIMIT 1`,
+    [categories, excludedIds, offset]
+  );
+
+  return result.rows[0] || null;
+}
+
 function pruneGuestProgressStore() {
   const expiresBefore = Date.now() - GUEST_PROGRESS_TTL_MS;
   for (const [token, entry] of guestProgressStore.entries()) {
@@ -268,32 +335,38 @@ module.exports = async function handler(req, res) {
         return;
       }
 
-      const query = userId
-        ? await runQuery(
-          `SELECT q.id, q.category, q.question_en, q.question_no, q.answers_en, q.answers_no
-           FROM quiz_questions q
-           LEFT JOIN user_answers ua
-             ON ua.question_id = q.id
-            AND ua.user_id = $2
-           WHERE q.category = ANY($1)
-             AND COALESCE(ua.is_correct, FALSE) = FALSE
-           ORDER BY RANDOM()
-           LIMIT 50`,
-          [categories, userId]
-        )
-        : await runQuery(
-          `SELECT q.id, q.category, q.question_en, q.question_no, q.answers_en, q.answers_no
-           FROM quiz_questions q
-           WHERE q.category = ANY($1)
-             AND NOT (q.id = ANY($2::int[]))
-           ORDER BY RANDOM()
-           LIMIT 50`,
-          [categories, guestProgress.solvedQuestionIds.length ? guestProgress.solvedQuestionIds : [0]]
-        );
+      const totalCandidates = await getNextQuestionCandidateCount({
+        userId,
+        categories,
+        solvedQuestionIds: guestProgress.solvedQuestionIds
+      });
 
-      const question = query.rows
-        .map((row) => mapQuestion(row, lang))
-        .find((entry) => isQuestionValid(entry));
+      if (totalCandidates < 1) {
+        res.status(200).json({
+          question: null,
+          ...(guestProgress.token ? { guestProgressToken: guestProgress.token } : {})
+        });
+        return;
+      }
+
+      const maxAttempts = Math.min(totalCandidates, 3);
+      let question = null;
+
+      for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+        const offset = randomIndex(totalCandidates);
+        const row = await getNextQuestionCandidateAtOffset({
+          userId,
+          categories,
+          solvedQuestionIds: guestProgress.solvedQuestionIds,
+          offset
+        });
+
+        if (!row) continue;
+        const mapped = mapQuestion(row, lang);
+        if (!isQuestionValid(mapped)) continue;
+        question = mapped;
+        break;
+      }
 
       if (!question) {
         res.status(200).json({

--- a/quiz-quest/index.html
+++ b/quiz-quest/index.html
@@ -429,7 +429,7 @@
           state.pendingSolvedQuestionIds = [];
         }
 
-        if (!requestPayload.guestProgressToken && !requestPayload.solvedQuestionIdDeltas) {
+        if (!requestPayload.solvedQuestionIdDeltas) {
           requestPayload.solvedQuestionIds = getGuestSolvedQuestionIds();
         }
       }


### PR DESCRIPTION
### Motivation

- Reduce database cost and nondeterminism caused by `ORDER BY RANDOM()` when selecting the next quiz question.
- Make question selection uniform and scalable by sampling via random offsets instead of fetching large random result sets.
- Ensure guest progress (solved question ids) is sent more consistently from the client so server can respect guest state.

### Description

- Added `randomIndex`, `getNextQuestionCandidateCount`, and `getNextQuestionCandidateAtOffset` helpers to count candidates and fetch a single candidate by offset. 
- Replaced the previous `ORDER BY RANDOM() LIMIT 50` logic in the `next` action with a count + up-to-3-attempts random-offset sampling loop and validation via `mapQuestion`/`isQuestionValid`.
- Kept separate query paths for authenticated users (joins against `user_answers`) and guests (excluding solved ids) while avoiding full random scans.
- Adjusted client logic in `quiz-quest/index.html` to include `solvedQuestionIds` whenever there are no `solvedQuestionIdDeltas`, removing the prior dependency on `guestProgressToken` presence.

### Testing

- Ran the backend test suite with `npm test`, and all tests passed.
- Exercised the `/api/quiz/quest` `next` and `overview` flows with integration checks, and responses matched expected shapes (no regressions).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3c61470e8833391a59b5910094ac2)