### PR TITLE
Fjern Morsdag-modul fra forsiden

### DIFF
--- a/index.html
+++ b/index.html
@@ -275,20 +275,7 @@
       }
     };
 
-    const FEATURE_MODULES = [
-      {
-        id: 'morsdag-2026',
-        title: '🌸 Morsdag 2026',
-        adminOnly: true,
-        links: [
-          { label: '👸 Mamma', href: '/Mamma/' },
-          { label: '👦 Isak', href: '/Isak/' },
-          { label: '👧 Lilly', href: '/Lilly/' },
-          { label: '🧔 Pappa', href: '/Pappa/' },
-          { label: '📸 Karusell', href: '/Karusell/' }
-        ]
-      }
-    ];
+    const FEATURE_MODULES = [];
 
     let currentCaptcha = null;
     let failedResetAttempts = 0;


### PR DESCRIPTION
### Motivation
- Fjernet alle referanser til den midlertidige «Morsdag 2026»-modulen slik at forsiden ikke viser lenkene til Mamma/Isak/Lilly/Pappa/Karusell.

### Description
- Endret `index.html` ved å sette `FEATURE_MODULES` til en tom liste (`const FEATURE_MODULES = [];`) for å deaktivere rendring av Morsdag-modulen.

### Testing
- Sjekket at tekst og labels er fjernet ved å kjøre `rg -n "morsdag|Morsdag|Mamma|Pappa|Isak|Lilly|Karusell" index.html` og bekreftet ingen treff; test besto.
- Startet en lokal server med `python3 -m http.server 4173` og tok en automatisk Playwright-skjermdump av `http://127.0.0.1:4173/` for visuell verifikasjon; skjermdump ble generert uten Morsdag-modulen.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4818c95f8833394ace7219028053c)