### PR TITLE
Add Quiz Scaling Assessment and Load Testing Plan

### DIFF
--- a/docs/quiz-1000-questions-plan.md
+++ b/docs/quiz-1000-questions-plan.md
@@ -1,0 +1,143 @@
+# Quiz Scaling Assessment
+
+## Goal
+Ensure the quiz system maintains stable, predictable performance as the following grow:
+
+- number of active users
+- number of quiz questions
+- number of concurrent quiz sessions
+- burst traffic in a serverless environment
+
+The objective is not merely to support a fixed dataset size, but to ensure that quiz endpoints scale predictably with both traffic and dataset growth.
+
+## Scaling dimensions
+System behavior must be validated along two independent axes.
+
+### 1) Dataset scale
+The system should behave consistently as the dataset grows.
+
+Test scenarios should include:
+
+- 1k questions
+- 5k questions
+- 10k questions
+- 50k questions
+
+Additional dataset variables:
+
+- increasing category count
+- growing `user_answers` history
+- uneven category distribution
+
+The goal is to ensure that query performance does not degrade linearly with dataset size.
+
+### 2) Traffic scale
+The system must remain stable under increasing concurrency.
+
+Test scenarios should include:
+
+- increasing concurrent quiz sessions
+- higher request rates for `start`, `quest`, and `answer`
+- burst traffic followed by idle periods
+- multiple serverless instances executing in parallel
+
+The system should behave correctly even when requests are distributed across multiple warm instances.
+
+## Service Level Objectives (SLO)
+Latency targets should be evaluated under defined load conditions.
+
+| Endpoint | Target |
+| --- | --- |
+| `quiz/start` | p95 <= 300 ms |
+| `quiz/quest` | p95 <= 250 ms |
+| `quiz/answer` | p95 <= 200 ms |
+
+Measured under conditions such as:
+
+- 200+ concurrent quiz sessions
+- 10k+ questions
+- sustained request load and burst scenarios
+
+Additional requirements:
+
+- error rate < 0.5% over 24h
+- no database connection saturation at 3x expected peak load
+
+## Core architecture principles
+The system should follow these scaling principles:
+
+- Requests must not become significantly more expensive as data volume grows.
+
+This implies avoiding patterns such as:
+
+- fetching all candidates and filtering in application memory
+- `COUNT + OFFSET` based random selection
+- queries that degrade linearly with table size
+- relying on local in-memory state for cross-instance correctness
+
+Serverless execution requires that all correctness-critical state be externalized.
+
+## Implementation priorities
+Work should be prioritized in the following order.
+
+### 1) Correctness under serverless scaling
+Move shared state out of local memory:
+
+- rate limiting
+- guest progress
+- session consistency
+
+Introduce a shared store (Redis/KV/Postgres) with TTL and cleanup policies.
+
+### 2) Query patterns that scale with dataset growth
+Improve query paths in hot endpoints:
+
+- remove full-ID fetch patterns
+- remove `COUNT + OFFSET` random selection
+- verify indexes and query plans
+
+All critical queries should be validated with:
+
+- `EXPLAIN (ANALYZE, BUFFERS)`
+
+### 3) Database connection strategy
+Ensure serverless fan-out does not exhaust database connections.
+
+Verify:
+
+- pooled connection usage
+- connection limits
+- behavior under load tests with multiple concurrent instances
+
+### 4) Caching of low-churn data
+Cache frequently accessed metadata:
+
+- categories
+- quiz overview data
+- category counts
+- other low-churn quiz metadata
+
+Caching should reduce database load but must not be relied upon to compensate for inefficient query patterns.
+
+## Capacity model
+Define an approximate system capacity model.
+
+Example targets:
+
+- X concurrent quiz sessions
+- Y `quest` requests per minute
+- Z `answer` requests per minute
+- A total questions in dataset
+- B categories
+- C average progress per user
+
+This model provides a concrete baseline for load testing and scaling decisions.
+
+## Definition of Done
+The system is considered ready when:
+
+- SLO targets are met under defined dataset and traffic conditions
+- no correctness issues occur when multiple serverless instances handle requests
+- hot query paths avoid full scans or linear degradation
+- database connection usage remains within safe limits under peak load
+- scaling behavior is measured and documented


### PR DESCRIPTION
### Motivation

- Provide a formal plan to validate quiz endpoints as dataset size and concurrent traffic grow to ensure stable, predictable performance.
- Define clear SLOs and scaling dimensions (dataset and traffic) to guide development and testing decisions for serverless deployments.
- Highlight architecture and query patterns to avoid (e.g., full scans, `COUNT + OFFSET`) and prioritize correctness when scaling across instances.

### Description

- Add a new documentation file `docs/quiz-1000-questions-plan.md` that defines goals, scaling dimensions, SLOs, architecture principles, implementation priorities, a capacity model, and a definition of done.
- Specify dataset scale scenarios (1k, 5k, 10k, 50k questions) and traffic scale scenarios including burst traffic and multiple serverless instances.
- Define p95 latency targets for endpoints `quiz/start`, `quiz/quest`, and `quiz/answer` and additional targets such as error rate and DB connection behavior.
- Recommend concrete implementation actions including externalizing shared state (Redis/KV/Postgres with TTL), removing inefficient query patterns, validating queries with `EXPLAIN (ANALYZE, BUFFERS)`, and introducing caching for low-churn metadata.

### Testing

- This change is documentation-only and does not modify application code or unit/integration tests. 
- Documentation checks and linting for markdown were exercised in CI and completed successfully. 
- No automated backend tests were added or changed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b49a6fadd883339a864babb221d3e4)