### PR TITLE
Add observability, DB-backed rate-limiter and guest progress store; instrument quiz endpoints

### DIFF
--- a/api/_lib/db.js
+++ b/api/_lib/db.js
@@ -1,4 +1,5 @@
 const { createPool } = require('@vercel/postgres');
+const { nowInMs, createQueryMetric } = require('./observability');
 
 const DB_POOL_KEY = Symbol.for('sarcasm.games.db.pool');
 const DB_POOL_LOGGER_KEY = Symbol.for('sarcasm.games.db.poolLoggerAttached');
@@ -70,10 +71,15 @@ function getPool() {
 
 async function runQuery(text, params = []) {
   const pool = getPool();
+  const startedAtMs = nowInMs();
+  const flushQueryMetric = createQueryMetric(text, startedAtMs);
 
   try {
-    return await pool.query(text, params);
+    const result = await pool.query(text, params);
+    flushQueryMetric({ rowCount: result?.rowCount || 0 });
+    return result;
   } catch (error) {
+    flushQueryMetric({ error });
     console.error('[db] Query failed', serializeDbError(error));
     throw error;
   }

--- a/api/_lib/guest-progress-store.js
+++ b/api/_lib/guest-progress-store.js
@@ -1,0 +1,88 @@
+const { runQuery } = require('./db');
+
+const DEFAULT_TTL_SECONDS = 60 * 60 * 12;
+let hasAttemptedSchemaInit = false;
+
+async function ensureGuestProgressSchema() {
+  if (hasAttemptedSchemaInit) return;
+  hasAttemptedSchemaInit = true;
+
+  await runQuery(
+    `CREATE TABLE IF NOT EXISTS quiz_guest_progress (
+      token TEXT PRIMARY KEY,
+      solved_question_ids INTEGER[] NOT NULL DEFAULT '{}',
+      expires_at TIMESTAMPTZ NOT NULL,
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )`
+  );
+
+  await runQuery(
+    `CREATE INDEX IF NOT EXISTS quiz_guest_progress_expires_at_idx
+     ON quiz_guest_progress (expires_at)`
+  );
+}
+
+function normalizeSolvedQuestionIds(values) {
+  if (!Array.isArray(values)) return [];
+  const seen = new Set();
+
+  return values
+    .map((value) => Number(value))
+    .filter((value) => Number.isInteger(value) && value > 0)
+    .filter((value) => {
+      if (seen.has(value)) return false;
+      seen.add(value);
+      return true;
+    });
+}
+
+async function pruneExpiredGuestProgress() {
+  await ensureGuestProgressSchema();
+  await runQuery('DELETE FROM quiz_guest_progress WHERE expires_at <= NOW()');
+}
+
+async function getGuestProgress(token) {
+  await ensureGuestProgressSchema();
+
+  const result = await runQuery(
+    `SELECT token, solved_question_ids
+     FROM quiz_guest_progress
+     WHERE token = $1
+       AND expires_at > NOW()
+     LIMIT 1`,
+    [token]
+  );
+
+  const row = result.rows[0];
+  if (!row) return null;
+
+  return {
+    token: row.token,
+    solvedQuestionIds: normalizeSolvedQuestionIds(row.solved_question_ids)
+  };
+}
+
+async function saveGuestProgress(token, solvedQuestionIds, ttlSeconds = DEFAULT_TTL_SECONDS) {
+  await ensureGuestProgressSchema();
+
+  const normalizedIds = normalizeSolvedQuestionIds(solvedQuestionIds);
+  const safeTtlSeconds = Number.isInteger(ttlSeconds) && ttlSeconds > 0 ? ttlSeconds : DEFAULT_TTL_SECONDS;
+
+  await runQuery(
+    `INSERT INTO quiz_guest_progress (token, solved_question_ids, expires_at, updated_at)
+     VALUES ($1, $2::int[], NOW() + ($3::text || ' seconds')::interval, NOW())
+     ON CONFLICT (token)
+     DO UPDATE SET
+       solved_question_ids = EXCLUDED.solved_question_ids,
+       expires_at = EXCLUDED.expires_at,
+       updated_at = NOW()`,
+    [token, normalizedIds, safeTtlSeconds]
+  );
+}
+
+module.exports = {
+  getGuestProgress,
+  saveGuestProgress,
+  pruneExpiredGuestProgress,
+  normalizeSolvedQuestionIds
+};

--- a/api/_lib/observability.js
+++ b/api/_lib/observability.js
@@ -1,0 +1,77 @@
+function nowInMs() {
+  return Number(process.hrtime.bigint()) / 1_000_000;
+}
+
+function getClientIp(req) {
+  const forwarded = req.headers['x-forwarded-for'];
+  if (typeof forwarded === 'string' && forwarded.trim()) {
+    return forwarded.split(',')[0].trim();
+  }
+
+  const realIp = req.headers['x-real-ip'];
+  if (typeof realIp === 'string' && realIp.trim()) {
+    return realIp.trim();
+  }
+
+  return 'unknown-ip';
+}
+
+function createEndpointMetric(req, res, endpoint) {
+  const startedAtMs = nowInMs();
+  let flushed = false;
+
+  return function flushEndpointMetric(error = null) {
+    if (flushed) return;
+    flushed = true;
+
+    const durationMs = Math.max(0, nowInMs() - startedAtMs);
+    const payload = {
+      metric: 'endpoint_latency',
+      endpoint,
+      method: req.method,
+      statusCode: Number(res.statusCode) || 0,
+      durationMs: Number(durationMs.toFixed(2)),
+      isError: Boolean(error),
+      clientIp: getClientIp(req),
+      instance: process.env.VERCEL_REGION || process.env.NODE_ENV || 'unknown'
+    };
+
+    if (error && error.message) {
+      payload.errorMessage = error.message;
+    }
+
+    console.info('[metrics]', payload);
+  };
+}
+
+function summarizeQuery(text) {
+  return String(text || '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 140);
+}
+
+function createQueryMetric(queryText, startedAtMs) {
+  let flushed = false;
+
+  return function flushQueryMetric({ error = null, rowCount = 0 } = {}) {
+    if (flushed) return;
+    flushed = true;
+
+    const durationMs = Math.max(0, nowInMs() - startedAtMs);
+
+    console.info('[metrics]', {
+      metric: 'db_query',
+      query: summarizeQuery(queryText),
+      durationMs: Number(durationMs.toFixed(2)),
+      rowCount: Number(rowCount) || 0,
+      isError: Boolean(error)
+    });
+  };
+}
+
+module.exports = {
+  nowInMs,
+  createEndpointMetric,
+  createQueryMetric
+};

--- a/api/_lib/rate-limit.js
+++ b/api/_lib/rate-limit.js
@@ -1,9 +1,8 @@
+const { runQuery } = require('./db');
+
 const DEFAULT_WINDOW_MS = 60 * 1000;
 const DEFAULT_MAX_REQUESTS_PER_WINDOW = 5;
 
-// Recommended starting thresholds (tune from production telemetry):
-// - auth: strict to slow down brute-force attempts.
-// - quiz:*: higher sustained rates than auth, plus short burst caps to dampen spikes.
 const SCOPE_LIMITS = {
   auth: {
     windowMs: DEFAULT_WINDOW_MS,
@@ -29,7 +28,8 @@ const SCOPE_LIMITS = {
   }
 };
 
-const requestBuckets = new Map();
+const localFallbackBuckets = new Map();
+let hasAttemptedSchemaInit = false;
 
 function getClientIp(req) {
   const forwarded = req.headers['x-forwarded-for'];
@@ -49,17 +49,99 @@ function getScopeConfig(scope) {
   return SCOPE_LIMITS[scope] || SCOPE_LIMITS.auth;
 }
 
-function isRateLimited(req, scope = 'auth') {
+async function ensureRateLimitSchema() {
+  if (hasAttemptedSchemaInit) return;
+  hasAttemptedSchemaInit = true;
+
+  await runQuery(
+    `CREATE TABLE IF NOT EXISTS quiz_rate_limits (
+      scope TEXT NOT NULL,
+      client_ip TEXT NOT NULL,
+      window_bucket BIGINT NOT NULL,
+      window_count INTEGER NOT NULL,
+      burst_bucket BIGINT,
+      burst_count INTEGER NOT NULL DEFAULT 0,
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      PRIMARY KEY (scope, client_ip)
+    )`
+  );
+
+  await runQuery(
+    `CREATE INDEX IF NOT EXISTS quiz_rate_limits_updated_at_idx
+     ON quiz_rate_limits (updated_at)`
+  );
+}
+
+async function isRateLimitedInSharedStore(req, scope) {
+  await ensureRateLimitSchema();
+
+  const now = Date.now();
+  const ip = getClientIp(req);
+  const config = getScopeConfig(scope);
+
+  const windowBucket = Math.floor(now / config.windowMs);
+  const burstBucket = (config.burstWindowMs && config.burstMaxRequests)
+    ? Math.floor(now / config.burstWindowMs)
+    : null;
+
+  const result = await runQuery(
+    `INSERT INTO quiz_rate_limits (
+       scope, client_ip, window_bucket, window_count, burst_bucket, burst_count, updated_at
+     )
+     VALUES ($1, $2, $3, 1, $4, CASE WHEN $4 IS NULL THEN 0 ELSE 1 END, NOW())
+     ON CONFLICT (scope, client_ip)
+     DO UPDATE SET
+       window_bucket = CASE
+         WHEN quiz_rate_limits.window_bucket = EXCLUDED.window_bucket
+         THEN quiz_rate_limits.window_bucket
+         ELSE EXCLUDED.window_bucket
+       END,
+       window_count = CASE
+         WHEN quiz_rate_limits.window_bucket = EXCLUDED.window_bucket
+         THEN quiz_rate_limits.window_count + 1
+         ELSE 1
+       END,
+       burst_bucket = CASE
+         WHEN EXCLUDED.burst_bucket IS NULL THEN NULL
+         WHEN quiz_rate_limits.burst_bucket = EXCLUDED.burst_bucket THEN quiz_rate_limits.burst_bucket
+         ELSE EXCLUDED.burst_bucket
+       END,
+       burst_count = CASE
+         WHEN EXCLUDED.burst_bucket IS NULL THEN 0
+         WHEN quiz_rate_limits.burst_bucket = EXCLUDED.burst_bucket THEN quiz_rate_limits.burst_count + 1
+         ELSE 1
+       END,
+       updated_at = NOW()
+     RETURNING window_count, burst_count`,
+    [scope, ip, windowBucket, burstBucket]
+  );
+
+  const row = result.rows[0] || {};
+  const windowCount = Number(row.window_count) || 0;
+  const burstCount = Number(row.burst_count) || 0;
+
+  if (windowCount > config.maxRequests) {
+    return true;
+  }
+
+  if (config.burstMaxRequests && burstCount > config.burstMaxRequests) {
+    return true;
+  }
+
+  return false;
+}
+
+function isRateLimitedInMemory(req, scope = 'auth') {
   const now = Date.now();
   const ip = getClientIp(req);
   const key = `${scope}:${ip}`;
   const config = getScopeConfig(scope);
 
-  const bucket = requestBuckets.get(key) || { windowTimestamps: [], burstTimestamps: [] };
+  const bucket = localFallbackBuckets.get(key) || { windowTimestamps: [], burstTimestamps: [] };
 
   const freshWindow = bucket.windowTimestamps.filter((timestamp) => now - timestamp < config.windowMs);
   if (freshWindow.length >= config.maxRequests) {
-    requestBuckets.set(key, {
+    localFallbackBuckets.set(key, {
       windowTimestamps: freshWindow,
       burstTimestamps: bucket.burstTimestamps
     });
@@ -70,7 +152,7 @@ function isRateLimited(req, scope = 'auth') {
   if (config.burstWindowMs && config.burstMaxRequests) {
     freshBurst = bucket.burstTimestamps.filter((timestamp) => now - timestamp < config.burstWindowMs);
     if (freshBurst.length >= config.burstMaxRequests) {
-      requestBuckets.set(key, {
+      localFallbackBuckets.set(key, {
         windowTimestamps: freshWindow,
         burstTimestamps: freshBurst
       });
@@ -81,12 +163,21 @@ function isRateLimited(req, scope = 'auth') {
   }
 
   freshWindow.push(now);
-  requestBuckets.set(key, {
+  localFallbackBuckets.set(key, {
     windowTimestamps: freshWindow,
     burstTimestamps: freshBurst
   });
 
   return false;
+}
+
+async function isRateLimited(req, scope = 'auth') {
+  try {
+    return await isRateLimitedInSharedStore(req, scope);
+  } catch (error) {
+    console.warn('[rate-limit] Shared store unavailable, using in-memory fallback:', error?.message);
+    return isRateLimitedInMemory(req, scope);
+  }
 }
 
 module.exports = {

--- a/api/auth/login.js
+++ b/api/auth/login.js
@@ -19,7 +19,7 @@ module.exports = async function handler(req, res) {
     return;
   }
 
-  if (isRateLimited(req, 'auth:login')) {
+  if (await isRateLimited(req, 'auth:login')) {
     res.status(429).json({ error: 'Too many requests. Please wait a minute.' });
     return;
   }

--- a/api/auth/logout.js
+++ b/api/auth/logout.js
@@ -19,7 +19,7 @@ module.exports = async function handler(req, res) {
     return;
   }
 
-  if (isRateLimited(req, 'auth:logout')) {
+  if (await isRateLimited(req, 'auth:logout')) {
     res.status(429).json({ error: 'Too many requests. Please wait a minute.' });
     return;
   }

--- a/api/auth/register.js
+++ b/api/auth/register.js
@@ -19,7 +19,7 @@ module.exports = async function handler(req, res) {
     return;
   }
 
-  if (isRateLimited(req, 'auth:register')) {
+  if (await isRateLimited(req, 'auth:register')) {
     res.status(429).json({ error: 'Too many requests. Please wait a minute.' });
     return;
   }

--- a/api/auth/self-reset.js
+++ b/api/auth/self-reset.js
@@ -34,7 +34,7 @@ module.exports = async function handler(req, res) {
     return;
   }
 
-  if (isRateLimited(req, 'auth:self-reset')) {
+  if (await isRateLimited(req, 'auth:self-reset')) {
     res.status(429).json({ error: 'Too many requests. Please wait a minute.' });
     return;
   }

--- a/api/auth/session.js
+++ b/api/auth/session.js
@@ -6,7 +6,7 @@ module.exports = async function handler(req, res) {
     return;
   }
 
-  if (isRateLimited(req, 'auth:session')) {
+  if (await isRateLimited(req, 'auth:session')) {
     res.status(429).json({ error: 'Too many requests. Please wait a minute.' });
     return;
   }

--- a/api/quiz/answer.js
+++ b/api/quiz/answer.js
@@ -3,6 +3,7 @@ const { parseCookies, verifySessionToken, COOKIE_NAME } = require('../_lib/auth'
 const { evaluateAnswer } = require('../../lib/server/quiz-answer-evaluator');
 const { isRateLimited } = require('../_lib/rate-limit');
 const { sendQuizRateLimited } = require('../_lib/quiz-rate-limit-response');
+const { createEndpointMetric } = require('../_lib/observability');
 
 function parseBody(body) {
   if (!body) return {};
@@ -61,13 +62,16 @@ async function persistProgress(userId, questionId, isCorrect) {
 }
 
 module.exports = async function handler(req, res) {
+  const flushEndpointMetric = createEndpointMetric(req, res, 'quiz/answer');
   if (req.method !== 'POST') {
     res.status(405).json({ error: 'Method not allowed' });
+    flushEndpointMetric();
     return;
   }
 
-  if (isRateLimited(req, 'quiz:answer')) {
+  if (await isRateLimited(req, 'quiz:answer')) {
     sendQuizRateLimited(res);
+    flushEndpointMetric();
     return;
   }
 
@@ -128,5 +132,7 @@ module.exports = async function handler(req, res) {
   } catch (error) {
     console.error('[quiz/answer] failed:', error?.message);
     res.status(500).json({ error: 'Failed to evaluate answer' });
+  } finally {
+    flushEndpointMetric();
   }
 };

--- a/api/quiz/quest.js
+++ b/api/quiz/quest.js
@@ -3,9 +3,15 @@ const { runQuery } = require('../_lib/db');
 const { parseCookies, verifySessionToken, COOKIE_NAME } = require('../_lib/auth');
 const { isRateLimited } = require('../_lib/rate-limit');
 const { sendQuizRateLimited } = require('../_lib/quiz-rate-limit-response');
+const { createEndpointMetric } = require('../_lib/observability');
+const {
+  getGuestProgress,
+  saveGuestProgress,
+  pruneExpiredGuestProgress,
+  normalizeSolvedQuestionIds
+} = require('../_lib/guest-progress-store');
 
-const GUEST_PROGRESS_TTL_MS = 1000 * 60 * 60 * 12;
-const guestProgressStore = new Map();
+const GUEST_PROGRESS_TTL_SECONDS = 60 * 60 * 12;
 
 function parseBody(body) {
   if (!body) return {};
@@ -17,20 +23,6 @@ function parseBody(body) {
     }
   }
   return typeof body === 'object' ? body : {};
-}
-
-function parseSolvedQuestionIds(value) {
-  if (!Array.isArray(value)) return [];
-  const seen = new Set();
-
-  return value
-    .map((entry) => Number(entry))
-    .filter((entry) => Number.isInteger(entry) && entry > 0)
-    .filter((entry) => {
-      if (seen.has(entry)) return false;
-      seen.add(entry);
-      return true;
-    });
 }
 
 function parseCategoryList(value) {
@@ -110,10 +102,10 @@ function randomIndex(max) {
   return Math.floor(Math.random() * max);
 }
 
-async function getNextQuestionCandidateCount({ userId, categories, solvedQuestionIds }) {
+async function getNextQuestionBounds({ userId, categories, solvedQuestionIds }) {
   if (userId) {
     const result = await runQuery(
-      `SELECT COUNT(*)::int AS total
+      `SELECT MIN(q.id)::int AS min_id, MAX(q.id)::int AS max_id
        FROM quiz_questions q
        LEFT JOIN user_answers ua
          ON ua.question_id = q.id
@@ -123,35 +115,60 @@ async function getNextQuestionCandidateCount({ userId, categories, solvedQuestio
       [categories, userId]
     );
 
-    return Number(result.rows[0]?.total) || 0;
+    const row = result.rows[0] || {};
+    return {
+      minId: Number(row.min_id) || null,
+      maxId: Number(row.max_id) || null
+    };
   }
 
   const excludedIds = solvedQuestionIds.length ? solvedQuestionIds : [0];
   const result = await runQuery(
-    `SELECT COUNT(*)::int AS total
+    `SELECT MIN(q.id)::int AS min_id, MAX(q.id)::int AS max_id
      FROM quiz_questions q
      WHERE q.category = ANY($1)
        AND NOT (q.id = ANY($2::int[]))`,
     [categories, excludedIds]
   );
 
-  return Number(result.rows[0]?.total) || 0;
+  const row = result.rows[0] || {};
+  return {
+    minId: Number(row.min_id) || null,
+    maxId: Number(row.max_id) || null
+  };
 }
 
-async function getNextQuestionCandidateAtOffset({ userId, categories, solvedQuestionIds, offset }) {
+async function getNextQuestionCandidateFromPivot({ userId, categories, solvedQuestionIds, pivotId }) {
   if (userId) {
     const result = await runQuery(
-      `SELECT q.id, q.category, q.question_en, q.question_no, q.answers_en, q.answers_no
-       FROM quiz_questions q
-       LEFT JOIN user_answers ua
-         ON ua.question_id = q.id
-        AND ua.user_id = $2
-       WHERE q.category = ANY($1)
-         AND COALESCE(ua.is_correct, FALSE) = FALSE
-       ORDER BY q.id ASC
-       OFFSET $3
+      `WITH preferred AS (
+         SELECT q.id, q.category, q.question_en, q.question_no, q.answers_en, q.answers_no
+         FROM quiz_questions q
+         LEFT JOIN user_answers ua
+           ON ua.question_id = q.id
+          AND ua.user_id = $2
+         WHERE q.category = ANY($1)
+           AND COALESCE(ua.is_correct, FALSE) = FALSE
+           AND q.id >= $3
+         ORDER BY q.id ASC
+         LIMIT 1
+       ), fallback AS (
+         SELECT q.id, q.category, q.question_en, q.question_no, q.answers_en, q.answers_no
+         FROM quiz_questions q
+         LEFT JOIN user_answers ua
+           ON ua.question_id = q.id
+          AND ua.user_id = $2
+         WHERE q.category = ANY($1)
+           AND COALESCE(ua.is_correct, FALSE) = FALSE
+           AND q.id < $3
+         ORDER BY q.id ASC
+         LIMIT 1
+       )
+       SELECT * FROM preferred
+       UNION ALL
+       SELECT * FROM fallback
        LIMIT 1`,
-      [categories, userId, offset]
+      [categories, userId, pivotId]
     );
 
     return result.rows[0] || null;
@@ -159,64 +176,57 @@ async function getNextQuestionCandidateAtOffset({ userId, categories, solvedQues
 
   const excludedIds = solvedQuestionIds.length ? solvedQuestionIds : [0];
   const result = await runQuery(
-    `SELECT q.id, q.category, q.question_en, q.question_no, q.answers_en, q.answers_no
-     FROM quiz_questions q
-     WHERE q.category = ANY($1)
-       AND NOT (q.id = ANY($2::int[]))
-     ORDER BY q.id ASC
-     OFFSET $3
+    `WITH preferred AS (
+       SELECT q.id, q.category, q.question_en, q.question_no, q.answers_en, q.answers_no
+       FROM quiz_questions q
+       WHERE q.category = ANY($1)
+         AND NOT (q.id = ANY($2::int[]))
+         AND q.id >= $3
+       ORDER BY q.id ASC
+       LIMIT 1
+     ), fallback AS (
+       SELECT q.id, q.category, q.question_en, q.question_no, q.answers_en, q.answers_no
+       FROM quiz_questions q
+       WHERE q.category = ANY($1)
+         AND NOT (q.id = ANY($2::int[]))
+         AND q.id < $3
+       ORDER BY q.id ASC
+       LIMIT 1
+     )
+     SELECT * FROM preferred
+     UNION ALL
+     SELECT * FROM fallback
      LIMIT 1`,
-    [categories, excludedIds, offset]
+    [categories, excludedIds, pivotId]
   );
 
   return result.rows[0] || null;
 }
 
-function pruneGuestProgressStore() {
-  const expiresBefore = Date.now() - GUEST_PROGRESS_TTL_MS;
-  for (const [token, entry] of guestProgressStore.entries()) {
-    if (!entry || entry.updatedAt < expiresBefore) {
-      guestProgressStore.delete(token);
-    }
-  }
-}
-
 function createGuestProgressToken() {
-  let token = crypto.randomBytes(9).toString('base64url');
-  while (guestProgressStore.has(token)) {
-    token = crypto.randomBytes(9).toString('base64url');
-  }
-  return token;
+  return crypto.randomBytes(18).toString('base64url');
 }
 
-function loadGuestProgress(body) {
-  pruneGuestProgressStore();
+async function loadGuestProgress(body) {
+  await pruneExpiredGuestProgress();
 
-  const legacySolvedIds = parseSolvedQuestionIds(body.solvedQuestionIds);
-  const solvedDeltas = parseSolvedQuestionIds(body.solvedQuestionIdDeltas);
+  const legacySolvedIds = normalizeSolvedQuestionIds(body.solvedQuestionIds);
+  const solvedDeltas = normalizeSolvedQuestionIds(body.solvedQuestionIdDeltas);
   const requestedToken = typeof body.guestProgressToken === 'string' ? body.guestProgressToken.trim() : '';
 
   let token = null;
   let solvedSet = new Set();
-  let shouldPersist = false;
 
   if (requestedToken) {
-    const existing = guestProgressStore.get(requestedToken);
+    const existing = await getGuestProgress(requestedToken);
     if (existing) {
-      token = requestedToken;
+      token = existing.token;
       solvedSet = new Set(existing.solvedQuestionIds);
     }
   }
 
-  if (legacySolvedIds.length) {
-    shouldPersist = true;
-    for (const id of legacySolvedIds) solvedSet.add(id);
-  }
-
-  if (solvedDeltas.length) {
-    shouldPersist = true;
-    for (const id of solvedDeltas) solvedSet.add(id);
-  }
+  for (const id of legacySolvedIds) solvedSet.add(id);
+  for (const id of solvedDeltas) solvedSet.add(id);
 
   const shouldIssueToken = Boolean(requestedToken || legacySolvedIds.length || solvedDeltas.length);
 
@@ -224,17 +234,8 @@ function loadGuestProgress(body) {
     token = createGuestProgressToken();
   }
 
-  if (token && (shouldPersist || !guestProgressStore.has(token))) {
-    guestProgressStore.set(token, {
-      solvedQuestionIds: [...solvedSet],
-      updatedAt: Date.now()
-    });
-  } else if (token) {
-    const existing = guestProgressStore.get(token);
-    if (existing) {
-      existing.updatedAt = Date.now();
-      guestProgressStore.set(token, existing);
-    }
+  if (token) {
+    await saveGuestProgress(token, [...solvedSet], GUEST_PROGRESS_TTL_SECONDS);
   }
 
   return {
@@ -300,13 +301,16 @@ async function getOverview({ userId, solvedQuestionIds }) {
 }
 
 module.exports = async function handler(req, res) {
+  const flushEndpointMetric = createEndpointMetric(req, res, 'quiz/quest');
   if (req.method !== 'POST') {
     res.status(405).json({ error: 'Method not allowed' });
+    flushEndpointMetric();
     return;
   }
 
-  if (isRateLimited(req, 'quiz:quest')) {
+  if (await isRateLimited(req, 'quiz:quest')) {
     sendQuizRateLimited(res);
+    flushEndpointMetric();
     return;
   }
 
@@ -316,7 +320,7 @@ module.exports = async function handler(req, res) {
     const lang = body.lang === 'no' ? 'no' : 'en';
     const session = await tryGetSession(req);
     const userId = session && Number.isInteger(Number(session.id)) ? Number(session.id) : null;
-    const guestProgress = userId ? { token: null, solvedQuestionIds: [] } : loadGuestProgress(body);
+    const guestProgress = userId ? { token: null, solvedQuestionIds: [] } : await loadGuestProgress(body);
 
     if (action === 'overview') {
       const categories = await getOverview({ userId, solvedQuestionIds: guestProgress.solvedQuestionIds });
@@ -335,13 +339,13 @@ module.exports = async function handler(req, res) {
         return;
       }
 
-      const totalCandidates = await getNextQuestionCandidateCount({
+      const bounds = await getNextQuestionBounds({
         userId,
         categories,
         solvedQuestionIds: guestProgress.solvedQuestionIds
       });
 
-      if (totalCandidates < 1) {
+      if (!Number.isInteger(bounds.minId) || !Number.isInteger(bounds.maxId) || bounds.minId > bounds.maxId) {
         res.status(200).json({
           question: null,
           ...(guestProgress.token ? { guestProgressToken: guestProgress.token } : {})
@@ -349,16 +353,17 @@ module.exports = async function handler(req, res) {
         return;
       }
 
-      const maxAttempts = Math.min(totalCandidates, 3);
+      const span = bounds.maxId - bounds.minId + 1;
+      const maxAttempts = Math.min(5, Math.max(1, span));
       let question = null;
 
       for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
-        const offset = randomIndex(totalCandidates);
-        const row = await getNextQuestionCandidateAtOffset({
+        const pivotId = bounds.minId + randomIndex(span);
+        const row = await getNextQuestionCandidateFromPivot({
           userId,
           categories,
           solvedQuestionIds: guestProgress.solvedQuestionIds,
-          offset
+          pivotId
         });
 
         if (!row) continue;
@@ -413,5 +418,7 @@ module.exports = async function handler(req, res) {
   } catch (error) {
     console.error('[quiz/quest] failed:', error?.message);
     res.status(500).json({ error: 'Failed to process quiz quest request' });
+  } finally {
+    flushEndpointMetric();
   }
 };

--- a/api/quiz/start.js
+++ b/api/quiz/start.js
@@ -1,6 +1,7 @@
 const { runQuery } = require('../_lib/db');
 const { isRateLimited } = require('../_lib/rate-limit');
 const { sendQuizRateLimited } = require('../_lib/quiz-rate-limit-response');
+const { createEndpointMetric } = require('../_lib/observability');
 
 function parseBody(body) {
   if (!body) return {};
@@ -130,13 +131,16 @@ function orderRowsByIdList(rows, orderedIds) {
 }
 
 module.exports = async function handler(req, res) {
+  const flushEndpointMetric = createEndpointMetric(req, res, 'quiz/start');
   if (req.method !== 'POST') {
     res.status(405).json({ error: 'Method not allowed' });
+    flushEndpointMetric();
     return;
   }
 
-  if (isRateLimited(req, 'quiz:start')) {
+  if (await isRateLimited(req, 'quiz:start')) {
     sendQuizRateLimited(res);
+    flushEndpointMetric();
     return;
   }
 
@@ -286,5 +290,7 @@ module.exports = async function handler(req, res) {
   } catch (error) {
     console.error('[quiz/start] failed:', error?.message);
     res.status(500).json({ error: 'Failed to start quiz' });
+  } finally {
+    flushEndpointMetric();
   }
 };

--- a/docs/quiz-1000-questions-tasks.md
+++ b/docs/quiz-1000-questions-tasks.md
@@ -4,11 +4,12 @@ This backlog translates the scaling plan into concrete implementation and valida
 
 ## Milestone 1 - Baseline and observability
 
-- [ ] **QZ-001: Define test environments and dataset profiles**
+- [x] **QZ-001: Define test environments and dataset profiles**
   - Create standard profiles for 1k, 5k, 10k, and 50k questions.
   - Define category skew scenarios and `user_answers` growth scenarios.
   - Document fixed runtime/database settings used during tests.
   - **Done when:** a reproducible test matrix exists in docs and can be reused by all later load tests.
+  - Deliverable: `docs/quiz-scaling-test-matrix.md` with standardized environment, dataset, and traffic profiles.
 
 - [ ] **QZ-002: Add endpoint-level latency and error instrumentation**
   - Track p50/p95/p99 latency for `quiz/start`, `quiz/quest`, `quiz/answer`.

--- a/docs/quiz-scaling-test-matrix.md
+++ b/docs/quiz-scaling-test-matrix.md
@@ -1,0 +1,89 @@
+# Quiz Scaling Test Matrix
+
+This document defines the reproducible dataset and traffic profiles used by all scaling tests.
+
+## 1) Fixed test environment settings
+
+Use the same settings across all benchmark runs unless a test explicitly targets environment variance.
+
+| Area | Standard setting |
+| --- | --- |
+| Runtime | Node.js 20 LTS |
+| Deployment model | Serverless functions, minimum 1 warm instance before test |
+| Region | Single region per run (same region for app and database) |
+| Database | Postgres with connection pooling enabled |
+| Isolation | No unrelated load on database during benchmark window |
+| Time sync | All hosts NTP-synced |
+| Logging | Structured logs enabled with request ID and endpoint tags |
+
+## 2) Dataset profiles
+
+Each profile is a snapshot and should be regenerated from seed scripts before major test cycles.
+
+| Profile ID | Questions | Categories | Distribution | Notes |
+| --- | ---: | ---: | --- | --- |
+| DS-1K | 1,000 | 20 | Even | Baseline sanity profile |
+| DS-5K | 5,000 | 40 | Even + mild skew | Mid-scale profile |
+| DS-10K | 10,000 | 60 | Mixed skew | SLO target profile |
+| DS-50K | 50,000 | 120 | High skew | Stress profile |
+
+### Category distribution variants
+
+Run each dataset profile with these variants:
+
+1. **EVEN**: categories as close to equal size as possible.
+2. **SKEW-80/20**: 20% categories hold ~80% of questions.
+3. **LONG-TAIL**: top categories large, many categories very small.
+
+### User answer history variants
+
+Run these history states to test growth in `user_answers`:
+
+| History ID | Avg answers per active user | Purpose |
+| --- | ---: | --- |
+| UA-COLD | 0-10 | New/returning mixed traffic |
+| UA-WARM | 100-300 | Realistic ongoing usage |
+| UA-HOT | 1,000+ | Large historical footprint |
+
+## 3) Traffic profiles
+
+Use a fixed endpoint mix unless a test explicitly targets one endpoint.
+
+| Traffic ID | Concurrency | Request pattern | Endpoint mix (`start/quest/answer`) |
+| --- | ---: | --- | --- |
+| TR-SMOKE | 20 | Steady 10 min | 20% / 50% / 30% |
+| TR-TARGET | 200 | Steady 30 min | 20% / 50% / 30% |
+| TR-BURST | 50 -> 300 -> 50 | 2 min burst, 10 min settle | 20% / 50% / 30% |
+| TR-STRESS | 400+ | Ramp + hold 20 min | 20% / 50% / 30% |
+
+## 4) Required capture per run
+
+For every dataset + traffic combination, record:
+
+- p50/p95/p99 for `quiz/start`, `quiz/quest`, `quiz/answer`
+- endpoint error rate and timeout rate
+- database active connections / wait count / timeout count
+- top 5 query patterns by total execution time
+- application instance count over time (if available)
+
+## 5) Run naming convention
+
+Use a deterministic run ID:
+
+`<date>-<dataset>-<distribution>-<history>-<traffic>-<git_sha>`
+
+Example:
+
+`2026-03-14-DS-10K-SKEW-80_20-UA-WARM-TR-TARGET-a1b2c3d`
+
+## 6) Exit criteria for valid benchmark runs
+
+A run is valid only when all are true:
+
+- test completed full planned duration
+- no external incidents impacted app/database region
+- deployment version fixed during run
+- dataset snapshot hash recorded
+- observability pipeline collected complete metrics
+
+If a run is invalid, mark as `DISCARDED` and rerun.


### PR DESCRIPTION
### Motivation

- Improve production observability by recording endpoint latencies and database query metrics for critical quiz endpoints.
- Replace fragile in-memory rate limiting with a shared, DB-backed store and an in-memory fallback for serverless correctness across instances.
- Persist guest quiz progress in the database to make guest state durable across serverless instances and restarts.

### Description

- Add `api/_lib/observability.js` providing `nowInMs`, `createEndpointMetric`, and `createQueryMetric`, and wire DB query and endpoint latency metrics into the stack by importing into `api/_lib/db.js` and relevant endpoints.
- Update `api/_lib/db.js` to create and flush per-query metrics via `createQueryMetric` around `runQuery` calls and keep error serialization helper intact.
- Implement a persistent rate-limit store in `api/_lib/rate-limit.js` with an idempotent schema (`quiz_rate_limits`) and function `isRateLimitedInSharedStore`, using atomic `INSERT ... ON CONFLICT ... DO UPDATE` to increment buckets; keep an in-memory fallback (`localFallbackBuckets`) and make `isRateLimited` attempt the shared store and fall back on error.
- Add a guest progress store in `api/_lib/guest-progress-store.js` with idempotent schema creation (`quiz_guest_progress`), functions `getGuestProgress`, `saveGuestProgress`, `pruneExpiredGuestProgress`, and `normalizeSolvedQuestionIds` for sanitizing inputs.
- Update quiz handlers to use the new shared features and instrumentation: await `isRateLimited` in all auth and quiz handlers, add endpoint metrics via `createEndpointMetric` in `quiz/start`, `quiz/quest`, and `quiz/answer`, and flush metrics on early returns and in `finally` blocks.
- Replace in-memory guest progress handling in `quiz/quest.js` with the DB-backed guest progress store, change candidate selection to use ID bounds and a pivot-based query (`getNextQuestionBounds` and `getNextQuestionCandidateFromPivot`) to avoid large offsets, and adjust selection attempts to sample within the ID span.
- Update docs by adding `docs/quiz-scaling-test-matrix.md` and marking one backlog task done in `docs/quiz-1000-questions-tasks.md`.

### Testing

- Ran the existing automated test suite via `npm test`, and all tests passed.
- Ran the linter via `npm run lint`, and no lint errors were reported.
- Executed basic automated smoke checks against `quiz/start`, `quiz/quest`, and `quiz/answer` (status 200/429 flows), and metrics/log outputs were emitted as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b526224e048333acea4131fcc64300)