### PR TITLE
Legg til Ko-fi flytende chat-widget på alle sider

### DIFF
--- a/Isak/index.html
+++ b/Isak/index.html
@@ -143,5 +143,24 @@
 
     updateUI();
 </script>
+
+
+  <script src='https://storage.ko-fi.com/cdn/scripts/overlay-widget.js'></script>
+  <script>
+    kofiWidgetOverlay.draw('sarcasticsir', {
+      'type': 'floating-chat',
+      'floating-chat.donateButton.text': 'Support me',
+      'floating-chat.donateButton.background-color': '#00000',
+      'floating-chat.donateButton.text-color': '#323842'
+    });
+  </script>
+  <style>
+    #kofi-widget-overlay {
+      left: 20px !important;
+      right: auto !important;
+      bottom: 20px !important;
+    }
+  </style>
+
 </body>
 </html>

--- a/Karusell/index.html
+++ b/Karusell/index.html
@@ -161,5 +161,24 @@
     updateGallery();
 </script>
 
+
+
+  <script src='https://storage.ko-fi.com/cdn/scripts/overlay-widget.js'></script>
+  <script>
+    kofiWidgetOverlay.draw('sarcasticsir', {
+      'type': 'floating-chat',
+      'floating-chat.donateButton.text': 'Support me',
+      'floating-chat.donateButton.background-color': '#00000',
+      'floating-chat.donateButton.text-color': '#323842'
+    });
+  </script>
+  <style>
+    #kofi-widget-overlay {
+      left: 20px !important;
+      right: auto !important;
+      bottom: 20px !important;
+    }
+  </style>
+
 </body>
 </html>

--- a/Lilly/index.html
+++ b/Lilly/index.html
@@ -142,5 +142,24 @@
     updateUI();
 </script>
 
+
+
+  <script src='https://storage.ko-fi.com/cdn/scripts/overlay-widget.js'></script>
+  <script>
+    kofiWidgetOverlay.draw('sarcasticsir', {
+      'type': 'floating-chat',
+      'floating-chat.donateButton.text': 'Support me',
+      'floating-chat.donateButton.background-color': '#00000',
+      'floating-chat.donateButton.text-color': '#323842'
+    });
+  </script>
+  <style>
+    #kofi-widget-overlay {
+      left: 20px !important;
+      right: auto !important;
+      bottom: 20px !important;
+    }
+  </style>
+
 </body>
 </html>

--- a/Mamma/index.html
+++ b/Mamma/index.html
@@ -137,5 +137,24 @@
     updateUI();
 </script>
 
+
+
+  <script src='https://storage.ko-fi.com/cdn/scripts/overlay-widget.js'></script>
+  <script>
+    kofiWidgetOverlay.draw('sarcasticsir', {
+      'type': 'floating-chat',
+      'floating-chat.donateButton.text': 'Support me',
+      'floating-chat.donateButton.background-color': '#00000',
+      'floating-chat.donateButton.text-color': '#323842'
+    });
+  </script>
+  <style>
+    #kofi-widget-overlay {
+      left: 20px !important;
+      right: auto !important;
+      bottom: 20px !important;
+    }
+  </style>
+
 </body>
 </html>

--- a/Pappa/index.html
+++ b/Pappa/index.html
@@ -137,5 +137,24 @@
     updateUI();
 </script>
 
+
+
+  <script src='https://storage.ko-fi.com/cdn/scripts/overlay-widget.js'></script>
+  <script>
+    kofiWidgetOverlay.draw('sarcasticsir', {
+      'type': 'floating-chat',
+      'floating-chat.donateButton.text': 'Support me',
+      'floating-chat.donateButton.background-color': '#00000',
+      'floating-chat.donateButton.text-color': '#323842'
+    });
+  </script>
+  <style>
+    #kofi-widget-overlay {
+      left: 20px !important;
+      right: auto !important;
+      bottom: 20px !important;
+    }
+  </style>
+
 </body>
 </html>

--- a/achievements/index.html
+++ b/achievements/index.html
@@ -57,5 +57,24 @@
     </div>
 
     <script src="script.js"></script>
+
+
+  <script src='https://storage.ko-fi.com/cdn/scripts/overlay-widget.js'></script>
+  <script>
+    kofiWidgetOverlay.draw('sarcasticsir', {
+      'type': 'floating-chat',
+      'floating-chat.donateButton.text': 'Support me',
+      'floating-chat.donateButton.background-color': '#00000',
+      'floating-chat.donateButton.text-color': '#323842'
+    });
+  </script>
+  <style>
+    #kofi-widget-overlay {
+      left: 20px !important;
+      right: auto !important;
+      bottom: 20px !important;
+    }
+  </style>
+
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -667,5 +667,24 @@
     init();
   </script>
 
+
+
+  <script src='https://storage.ko-fi.com/cdn/scripts/overlay-widget.js'></script>
+  <script>
+    kofiWidgetOverlay.draw('sarcasticsir', {
+      'type': 'floating-chat',
+      'floating-chat.donateButton.text': 'Support me',
+      'floating-chat.donateButton.background-color': '#00000',
+      'floating-chat.donateButton.text-color': '#323842'
+    });
+  </script>
+  <style>
+    #kofi-widget-overlay {
+      left: 20px !important;
+      right: auto !important;
+      bottom: 20px !important;
+    }
+  </style>
+
 </body>
 </html>

--- a/memory/index.html
+++ b/memory/index.html
@@ -545,5 +545,24 @@
       backToStartButton.addEventListener('click', backToSettings);
     })();
   </script>
+
+
+  <script src='https://storage.ko-fi.com/cdn/scripts/overlay-widget.js'></script>
+  <script>
+    kofiWidgetOverlay.draw('sarcasticsir', {
+      'type': 'floating-chat',
+      'floating-chat.donateButton.text': 'Support me',
+      'floating-chat.donateButton.background-color': '#00000',
+      'floating-chat.donateButton.text-color': '#323842'
+    });
+  </script>
+  <style>
+    #kofi-widget-overlay {
+      left: 20px !important;
+      right: auto !important;
+      bottom: 20px !important;
+    }
+  </style>
+
 </body>
 </html>

--- a/monstercatch/index.html
+++ b/monstercatch/index.html
@@ -119,5 +119,24 @@
   <a id="homeLink" class="home-link" href="https://sarcasm.games/">
     <button class="home-button">Back to Main Menu</button>
   </a>
+
+
+  <script src='https://storage.ko-fi.com/cdn/scripts/overlay-widget.js'></script>
+  <script>
+    kofiWidgetOverlay.draw('sarcasticsir', {
+      'type': 'floating-chat',
+      'floating-chat.donateButton.text': 'Support me',
+      'floating-chat.donateButton.background-color': '#00000',
+      'floating-chat.donateButton.text-color': '#323842'
+    });
+  </script>
+  <style>
+    #kofi-widget-overlay {
+      left: 20px !important;
+      right: auto !important;
+      bottom: 20px !important;
+    }
+  </style>
+
 </body>
 </html>

--- a/orb.html
+++ b/orb.html
@@ -1,1 +1,19 @@
 
+
+
+  <script src='https://storage.ko-fi.com/cdn/scripts/overlay-widget.js'></script>
+  <script>
+    kofiWidgetOverlay.draw('sarcasticsir', {
+      'type': 'floating-chat',
+      'floating-chat.donateButton.text': 'Support me',
+      'floating-chat.donateButton.background-color': '#00000',
+      'floating-chat.donateButton.text-color': '#323842'
+    });
+  </script>
+  <style>
+    #kofi-widget-overlay {
+      left: 20px !important;
+      right: auto !important;
+      bottom: 20px !important;
+    }
+  </style>

--- a/orb/index.html
+++ b/orb/index.html
@@ -764,5 +764,24 @@ window.onload = () => {
     }
 };
 </script>
+
+
+  <script src='https://storage.ko-fi.com/cdn/scripts/overlay-widget.js'></script>
+  <script>
+    kofiWidgetOverlay.draw('sarcasticsir', {
+      'type': 'floating-chat',
+      'floating-chat.donateButton.text': 'Support me',
+      'floating-chat.donateButton.background-color': '#00000',
+      'floating-chat.donateButton.text-color': '#323842'
+    });
+  </script>
+  <style>
+    #kofi-widget-overlay {
+      left: 20px !important;
+      right: auto !important;
+      bottom: 20px !important;
+    }
+  </style>
+
 </body>
 </html>

--- a/pokemon-quiz/index.html
+++ b/pokemon-quiz/index.html
@@ -19,5 +19,24 @@
     <p>This is a placeholder page. We will build this quiz mode step by step.</p>
     <a href="/">Back to sarcasm.games</a>
   </main>
+
+
+  <script src='https://storage.ko-fi.com/cdn/scripts/overlay-widget.js'></script>
+  <script>
+    kofiWidgetOverlay.draw('sarcasticsir', {
+      'type': 'floating-chat',
+      'floating-chat.donateButton.text': 'Support me',
+      'floating-chat.donateButton.background-color': '#00000',
+      'floating-chat.donateButton.text-color': '#323842'
+    });
+  </script>
+  <style>
+    #kofi-widget-overlay {
+      left: 20px !important;
+      right: auto !important;
+      bottom: 20px !important;
+    }
+  </style>
+
 </body>
 </html>

--- a/quiz-categories/index.html
+++ b/quiz-categories/index.html
@@ -948,5 +948,24 @@
     showView('setup');
     window.quizCategoriesState = runtimeState;
   </script>
+
+
+  <script src='https://storage.ko-fi.com/cdn/scripts/overlay-widget.js'></script>
+  <script>
+    kofiWidgetOverlay.draw('sarcasticsir', {
+      'type': 'floating-chat',
+      'floating-chat.donateButton.text': 'Support me',
+      'floating-chat.donateButton.background-color': '#00000',
+      'floating-chat.donateButton.text-color': '#323842'
+    });
+  </script>
+  <style>
+    #kofi-widget-overlay {
+      left: 20px !important;
+      right: auto !important;
+      bottom: 20px !important;
+    }
+  </style>
+
 </body>
 </html>

--- a/quiz-quest/index.html
+++ b/quiz-quest/index.html
@@ -844,5 +844,24 @@
 
     init();
   </script>
+
+
+  <script src='https://storage.ko-fi.com/cdn/scripts/overlay-widget.js'></script>
+  <script>
+    kofiWidgetOverlay.draw('sarcasticsir', {
+      'type': 'floating-chat',
+      'floating-chat.donateButton.text': 'Support me',
+      'floating-chat.donateButton.background-color': '#00000',
+      'floating-chat.donateButton.text-color': '#323842'
+    });
+  </script>
+  <style>
+    #kofi-widget-overlay {
+      left: 20px !important;
+      right: auto !important;
+      bottom: 20px !important;
+    }
+  </style>
+
 </body>
 </html>

--- a/quiz-random10/index.html
+++ b/quiz-random10/index.html
@@ -8,5 +8,24 @@
 </head>
 <body>
   <p>Redirecting to <a href="/random10/">/random10/</a>...</p>
+
+
+  <script src='https://storage.ko-fi.com/cdn/scripts/overlay-widget.js'></script>
+  <script>
+    kofiWidgetOverlay.draw('sarcasticsir', {
+      'type': 'floating-chat',
+      'floating-chat.donateButton.text': 'Support me',
+      'floating-chat.donateButton.background-color': '#00000',
+      'floating-chat.donateButton.text-color': '#323842'
+    });
+  </script>
+  <style>
+    #kofi-widget-overlay {
+      left: 20px !important;
+      right: auto !important;
+      bottom: 20px !important;
+    }
+  </style>
+
 </body>
 </html>

--- a/random10/index.html
+++ b/random10/index.html
@@ -575,5 +575,24 @@
     syncLanguageFromStorage();
     applyCopy();
   </script>
+
+
+  <script src='https://storage.ko-fi.com/cdn/scripts/overlay-widget.js'></script>
+  <script>
+    kofiWidgetOverlay.draw('sarcasticsir', {
+      'type': 'floating-chat',
+      'floating-chat.donateButton.text': 'Support me',
+      'floating-chat.donateButton.background-color': '#00000',
+      'floating-chat.donateButton.text-color': '#323842'
+    });
+  </script>
+  <style>
+    #kofi-widget-overlay {
+      left: 20px !important;
+      right: auto !important;
+      bottom: 20px !important;
+    }
+  </style>
+
 </body>
 </html>

--- a/tiermaker/index.html
+++ b/tiermaker/index.html
@@ -1790,5 +1790,24 @@
       loadLayout();
     });
   </script>
+
+
+  <script src='https://storage.ko-fi.com/cdn/scripts/overlay-widget.js'></script>
+  <script>
+    kofiWidgetOverlay.draw('sarcasticsir', {
+      'type': 'floating-chat',
+      'floating-chat.donateButton.text': 'Support me',
+      'floating-chat.donateButton.background-color': '#00000',
+      'floating-chat.donateButton.text-color': '#323842'
+    });
+  </script>
+  <style>
+    #kofi-widget-overlay {
+      left: 20px !important;
+      right: auto !important;
+      bottom: 20px !important;
+    }
+  </style>
+
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Gjør Ko-fi overlay-widgeten tilgjengelig site‑wide slik at besøkende kan sende støtte enkelt fra hvilken som helst side. 
- Plasserer widgeten nederst til venstre for å følge ønsket posisjonering. 
- Sørger for konsistent konfigurasjon (`sarcasticsir`) og knapp-tekster på alle HTML-sider.

### Description
- La til Ko-fi overlay-scriptet (`https://storage.ko-fi.com/cdn/scripts/overlay-widget.js`) og init med `kofiWidgetOverlay.draw('sarcasticsir', ...)` i 17 HTML-filer, plassert før `</body>` på hver side. 
- La til CSS-override for å forankre widgeten nederst til venstre med `#kofi-widget-overlay { left: 20px !important; right: auto !important; bottom: 20px !important; }`. 
- Endringene er rene frontend-HTML-oppdateringer og berører ikke backend‑APIer eller serverlogikk. 

### Testing
- Verifisert at widgetinitialisering finnes i alle HTML-filer med `rg -n "kofiWidgetOverlay.draw('sarcasticsir'" -g '*.html'` og treff returnert for alle målte filer (suksess). 
- Verifisert posisjonsstil med `rg -n "#kofi-widget-overlay" -g '*.html' | wc -l` som rapporterte `17` forekomster (suksess). 
- Startet lokal statisk server med `python -m http.server 4173 --bind 0.0.0.0` og hentet en Playwright‑screenshot av `http://127.0.0.1:4173/index.html`; skjermdump ble generert som visuell bekreftelse (suksess).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5b22469b8833397fa29a66111f947)