### PR TITLE
Add game-rules package, deterministic deck, shared-types, Sprint1 bootstrap and unit tests

### DIFF
--- a/dog_game/SPRINT1_BOOTSTRAP.md
+++ b/dog_game/SPRINT1_BOOTSTRAP.md
@@ -1,0 +1,173 @@
+# Sprint 1 bootstrap checklist
+
+This document turns `AGENTS.md` and `PROJECT_PLAN.md` into an immediate, execution-ready Sprint 1 plan.
+
+## Sprint objective
+
+Establish a deterministic, testable foundation for room contracts and core rules so future realtime/web work can safely build on top.
+
+## Deliverables (must complete)
+
+1. Monorepo package skeleton and TS project references
+2. Initial shared contracts for room/config/member/commands/events
+3. Backend command contracts for `create_room`, `join_room`, `set_ready`, `start_match`
+4. Rules-engine base models for board/piece/card/legal-move API
+5. Initial rule tests for Ace dual behavior, King start exit, 4 backward, immune blocker constraints
+6. Persistence contract checks aligned with existing Supabase entities:
+   - `rooms`
+   - `room_members`
+   - `matches`
+   - `match_players`
+   - `game_events`
+
+## Recommended repository layout
+
+```text
+/apps
+  /web
+/packages
+  /shared-types
+  /game-rules
+/services
+  /realtime-server
+  /db
+```
+
+## Work breakdown by stream
+
+### Stream A — Workspace and tooling
+
+- [ ] Add/confirm workspace config and package manager setup
+- [ ] Add root `tsconfig.base.json`
+- [ ] Add project references for all workspace packages
+- [ ] Add scripts: `lint`, `typecheck`, `test`
+- [ ] Add CI baseline to run lint + typecheck + tests
+
+**Acceptance checks**
+
+- [ ] All workspaces install and build
+- [ ] `pnpm -r typecheck` (or equivalent) passes
+- [ ] `packages/game-rules` has no framework/network/database imports
+
+### Stream B — `packages/shared-types`
+
+Define canonical contracts first so UI/backend/rules all share the same language.
+
+- [ ] Room configuration types:
+  - [ ] `gameMode`: `solo | teams`
+  - [ ] `teamCount`
+  - [ ] `playersPerTeam`
+  - [ ] derived `maxPlayers`
+- [ ] Room member types:
+  - [ ] identity union (`userId` or `guestName`)
+  - [ ] `seatNo`, `teamNo`, `slotInTeam`
+  - [ ] `isReady`, `connected`
+- [ ] Command types:
+  - [ ] `create_room`
+  - [ ] `join_room`
+  - [ ] `set_ready`
+  - [ ] `start_match`
+- [ ] Event types:
+  - [ ] minimum room lifecycle + ready + match-start events
+- [ ] Versioning/idempotency envelope fields for commands
+
+**Acceptance checks**
+
+- [ ] Shared types compile in isolation
+- [ ] No framework-specific dependencies
+- [ ] Types enforce max 8 players and mode-aware configuration constraints
+
+### Stream C — `packages/game-rules`
+
+Implement deterministic models before advanced move resolution.
+
+- [ ] Base constants and indexing model:
+  - [ ] seat-aware corner ownership
+  - [ ] 16 spaces between adjacent player entry points
+- [ ] Piece state model with explicit flags:
+  - [ ] `isInStart`
+  - [ ] `isOnBoard`
+  - [ ] `isInHome`
+  - [ ] `isImmune`
+  - [ ] `hasCompletedLap`
+- [ ] Card model:
+  - [ ] ranks including Joker wildcard intent mapping
+- [ ] Legal move API contract:
+  - [ ] deterministic input state + action context
+  - [ ] deterministic list of legal options
+- [ ] Minimal resolver support for:
+  - [ ] Ace 1/11 + start exit
+  - [ ] King 13 + start exit
+  - [ ] 4 forward/backward
+  - [ ] immune blocker restriction checks
+
+**Acceptance checks**
+
+- [ ] Same state + same command gives same output
+- [ ] No UI/network/storage dependencies in package
+
+### Stream D — `services/realtime-server`
+
+Define backend-facing contracts even if transport implementation is partial.
+
+- [ ] Command handlers (skeleton) for:
+  - [ ] `create_room`
+  - [ ] `join_room`
+  - [ ] `set_ready`
+  - [ ] `start_match`
+- [ ] Validation rules:
+  - [ ] room capacity
+  - [ ] team/slot bounds
+  - [ ] seat formula: `seatNo = (slotInTeam - 1) * teamCount + teamNo`
+- [ ] Reject stale or duplicate commands via version/idempotency checks
+
+**Acceptance checks**
+
+- [ ] Invalid/stale requests return deterministic rejections
+- [ ] Seating and team assignment are backend-authoritative
+
+### Stream E — `services/db`
+
+Use existing schema as baseline; do not redesign unless blocked.
+
+- [ ] Add typed adapters/mappers for:
+  - [ ] `rooms`
+  - [ ] `room_members`
+  - [ ] `matches`
+  - [ ] `match_players`
+  - [ ] `game_events`
+- [ ] Add guard checks for schema assumption mismatches
+
+**Acceptance checks**
+
+- [ ] Contract tests (or assertions) confirm required fields are present
+- [ ] Writes that represent authoritative game actions route through backend logic
+
+## Required test suite for Sprint 1
+
+- [ ] Ace dual behavior (1 vs 11)
+- [ ] King start exit when normal move is blocked
+- [ ] 4 backward behavior around board boundaries
+- [ ] Immune blocker cannot be passed/landed/swapped/moved
+
+## Suggested command checklist (local)
+
+```bash
+pnpm install
+pnpm -r lint
+pnpm -r typecheck
+pnpm -r test
+```
+
+## Exit criteria
+
+Sprint 1 is complete only when all are true:
+
+- [ ] End-to-end unit tests run locally
+- [ ] Deterministic state transition contract is established
+- [ ] Rules package has no UI coupling
+- [ ] Backend contracts align with current Supabase persistence model
+
+## Open decisions (only if blocked)
+
+If decisions are needed, ask only blocking questions and prefer binary choices.

--- a/dog_game/package.json
+++ b/dog_game/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "dog-game",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "test": "node --test tests/*.test.js"
+  }
+}

--- a/dog_game/packages/game-rules/deck.js
+++ b/dog_game/packages/game-rules/deck.js
@@ -1,0 +1,157 @@
+const SUITS = ['SPADES', 'HEARTS', 'DIAMONDS', 'CLUBS'];
+const BASE_RANKS = ['ACE', 'TWO', 'THREE', 'FOUR', 'FIVE', 'SIX', 'SEVEN', 'EIGHT', 'NINE', 'TEN', 'JACK', 'QUEEN', 'KING'];
+
+/**
+ * @typedef {Object} DeckCard
+ * @property {string} id
+ * @property {import('../shared-types/index.js').CardRank} rank
+ * @property {string|null} suit
+ */
+
+/**
+ * @typedef {Object} DeckState
+ * @property {DeckCard[]} drawPile
+ * @property {DeckCard[]} discardPile
+ */
+
+/**
+ * @param {number} seed
+ */
+function createSeededRng(seed) {
+  let state = seed >>> 0;
+
+  return function nextRandom() {
+    state = (state * 1664525 + 1013904223) >>> 0;
+    return state / 0x100000000;
+  };
+}
+
+/**
+ * @param {number} playerCount
+ */
+export function getDeckCountForPlayers(playerCount) {
+  if (playerCount < 4) {
+    throw new Error('Dog game requires at least 4 players');
+  }
+
+  return playerCount === 4 ? 2 : 3;
+}
+
+/**
+ * @param {number} deckCount
+ */
+export function buildDeckCards(deckCount) {
+  const cards = [];
+
+  for (let deckNo = 1; deckNo <= deckCount; deckNo += 1) {
+    for (const suit of SUITS) {
+      for (const rank of BASE_RANKS) {
+        cards.push({
+          id: `D${deckNo}-${suit}-${rank}`,
+          rank,
+          suit
+        });
+      }
+    }
+
+    cards.push({ id: `D${deckNo}-JOKER-1`, rank: 'JOKER', suit: null });
+    cards.push({ id: `D${deckNo}-JOKER-2`, rank: 'JOKER', suit: null });
+  }
+
+  return cards;
+}
+
+/**
+ * @template T
+ * @param {T[]} cards
+ * @param {number} seed
+ * @returns {T[]}
+ */
+export function shuffleDeterministic(cards, seed) {
+  const output = [...cards];
+  const random = createSeededRng(seed);
+
+  for (let i = output.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(random() * (i + 1));
+    const tmp = output[i];
+    output[i] = output[j];
+    output[j] = tmp;
+  }
+
+  return output;
+}
+
+/**
+ * @param {number} playerCount
+ * @param {number} seed
+ * @returns {DeckState}
+ */
+export function createDeckState(playerCount, seed = 1) {
+  const deckCount = getDeckCountForPlayers(playerCount);
+  const cards = buildDeckCards(deckCount);
+
+  return {
+    drawPile: shuffleDeterministic(cards, seed),
+    discardPile: []
+  };
+}
+
+/**
+ * @param {number} roundNumber
+ */
+export function getHandSizeForRound(roundNumber) {
+  if (roundNumber < 1) {
+    throw new Error('roundNumber must be >= 1');
+  }
+
+  const cycle = [6, 5, 4, 3, 2];
+  return cycle[(roundNumber - 1) % cycle.length];
+}
+
+/**
+ * @param {DeckState} deckState
+ * @param {number} count
+ * @param {number} reshuffleSeed
+ */
+export function drawCards(deckState, count, reshuffleSeed = 1) {
+  if (count < 0) {
+    throw new Error('count must be >= 0');
+  }
+
+  const nextState = {
+    drawPile: [...deckState.drawPile],
+    discardPile: [...deckState.discardPile]
+  };
+
+  const drawn = [];
+
+  while (drawn.length < count) {
+    if (nextState.drawPile.length === 0) {
+      if (nextState.discardPile.length === 0) {
+        throw new Error('Cannot draw cards: both draw pile and discard pile are empty');
+      }
+
+      nextState.drawPile = shuffleDeterministic(nextState.discardPile, reshuffleSeed);
+      nextState.discardPile = [];
+    }
+
+    const card = nextState.drawPile.shift();
+    drawn.push(card);
+  }
+
+  return {
+    drawn,
+    deckState: nextState
+  };
+}
+
+/**
+ * @param {DeckState} deckState
+ * @param {DeckCard[]} cards
+ */
+export function discardCards(deckState, cards) {
+  return {
+    drawPile: [...deckState.drawPile],
+    discardPile: [...deckState.discardPile, ...cards]
+  };
+}

--- a/dog_game/packages/game-rules/index.js
+++ b/dog_game/packages/game-rules/index.js
@@ -1,0 +1,271 @@
+import { CARD_RANKS } from '../shared-types/index.js';
+
+export const TRACK_SPACES_BETWEEN_PLAYERS = 16;
+
+/**
+ * @param {number} value
+ * @param {number} trackLength
+ */
+function wrap(value, trackLength) {
+  return ((value % trackLength) + trackLength) % trackLength;
+}
+
+/**
+ * @param {import('../shared-types/index.js').CardRank} card
+ */
+export function getStepValues(card) {
+  switch (card) {
+    case 'ACE':
+      return [1, 11];
+    case 'FOUR':
+      return [4, -4];
+    case 'KING':
+      return [13];
+    case 'TWO':
+      return [2];
+    case 'THREE':
+      return [3];
+    case 'FIVE':
+      return [5];
+    case 'SIX':
+      return [6];
+    case 'EIGHT':
+      return [8];
+    case 'NINE':
+      return [9];
+    case 'TEN':
+      return [10];
+    case 'QUEEN':
+      return [12];
+    default:
+      return [];
+  }
+}
+
+/**
+ * @param {import('../shared-types/index.js').CardRank} card
+ */
+export function canExitStart(card) {
+  return card === 'ACE' || card === 'KING';
+}
+
+/**
+ * @param {import('../shared-types/index.js').GameState} state
+ * @param {string} pieceId
+ * @returns {import('../shared-types/index.js').PieceState | undefined}
+ */
+function findPiece(state, pieceId) {
+  return state.pieces.find((piece) => piece.id === pieceId);
+}
+
+/**
+ * @param {import('../shared-types/index.js').GameState} state
+ * @param {number} square
+ * @param {string=} skipPieceId
+ */
+function pieceAtSquare(state, square, skipPieceId) {
+  return state.pieces.find((piece) => piece.id !== skipPieceId && piece.isOnBoard && piece.position === square);
+}
+
+/**
+ * @param {import('../shared-types/index.js').GameState} state
+ * @param {number} from
+ * @param {number} steps
+ * @param {string} movingPieceId
+ */
+function isPathBlockedByImmune(state, from, steps, movingPieceId) {
+  const distance = Math.abs(steps);
+  const direction = Math.sign(steps);
+
+  for (let offset = 1; offset <= distance; offset += 1) {
+    const square = wrap(from + direction * offset, state.trackLength);
+    const occupant = pieceAtSquare(state, square, movingPieceId);
+
+    if (occupant?.isImmune) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * @param {import('../shared-types/index.js').GameState} state
+ * @param {string} playerId
+ * @param {import('../shared-types/index.js').CardRank} card
+ * @returns {import('../shared-types/index.js').MoveOption[]}
+ */
+export function generateLegalMoves(state, playerId, card) {
+  if (!CARD_RANKS.includes(card)) {
+    throw new Error(`Unknown card: ${card}`);
+  }
+
+  const options = [];
+  const ownPieces = state.pieces.filter((piece) => piece.ownerId === playerId);
+
+  for (const piece of ownPieces) {
+    if (piece.isInHome) {
+      continue;
+    }
+
+    if (piece.isInStart) {
+      if (canExitStart(card)) {
+        const startSquare = state.startIndexes[playerId];
+        const occupant = pieceAtSquare(state, startSquare, piece.id);
+
+        if (!occupant?.isImmune) {
+          options.push({
+            pieceId: piece.id,
+            card,
+            action: 'EXIT_START',
+            from: null,
+            to: startSquare
+          });
+        }
+      }
+      continue;
+    }
+
+    if (!piece.isOnBoard || piece.position === null) {
+      continue;
+    }
+
+    for (const steps of getStepValues(card)) {
+      if (steps === 0) {
+        continue;
+      }
+
+      if (isPathBlockedByImmune(state, piece.position, steps, piece.id)) {
+        continue;
+      }
+
+      const destination = wrap(piece.position + steps, state.trackLength);
+      const occupant = pieceAtSquare(state, destination, piece.id);
+
+      if (occupant?.isImmune) {
+        continue;
+      }
+
+      options.push({
+        pieceId: piece.id,
+        card,
+        action: 'MOVE',
+        from: piece.position,
+        to: destination,
+        steps
+      });
+    }
+  }
+
+  if (card === 'JACK') {
+    return generateJackSwapOptions(state, playerId);
+  }
+
+  return options.sort((a, b) => {
+    if (a.pieceId !== b.pieceId) {
+      return a.pieceId.localeCompare(b.pieceId);
+    }
+
+    return (a.steps ?? 0) - (b.steps ?? 0);
+  });
+}
+
+/**
+ * @param {import('../shared-types/index.js').GameState} state
+ * @param {string} playerId
+ * @returns {import('../shared-types/index.js').MoveOption[]}
+ */
+export function generateJackSwapOptions(state, playerId) {
+  const ownOnBoard = state.pieces.filter(
+    (piece) => piece.ownerId === playerId && piece.isOnBoard && piece.position !== null && !piece.isImmune
+  );
+
+  const targets = state.pieces.filter(
+    (piece) => piece.ownerId !== playerId && piece.isOnBoard && piece.position !== null && !piece.isImmune
+  );
+
+  const options = [];
+
+  for (const mine of ownOnBoard) {
+    for (const target of targets) {
+      options.push({
+        pieceId: mine.id,
+        card: 'JACK',
+        action: 'SWAP',
+        from: mine.position,
+        to: target.position,
+        swapTargetPieceId: target.id
+      });
+    }
+  }
+
+  return options.sort((a, b) => {
+    if (a.pieceId !== b.pieceId) {
+      return a.pieceId.localeCompare(b.pieceId);
+    }
+
+    return a.swapTargetPieceId.localeCompare(b.swapTargetPieceId);
+  });
+}
+
+/**
+ * @param {number} playerCount
+ */
+export function buildStartIndexes(playerCount) {
+  const startIndexes = {};
+
+  for (let seat = 0; seat < playerCount; seat += 1) {
+    startIndexes[`P${seat + 1}`] = seat * TRACK_SPACES_BETWEEN_PLAYERS;
+  }
+
+  return startIndexes;
+}
+
+/**
+ * @param {import('../shared-types/index.js').GameState} state
+ * @param {import('../shared-types/index.js').MoveOption} move
+ */
+export function applyMovePreview(state, move) {
+  const nextState = {
+    ...state,
+    pieces: state.pieces.map((piece) => ({ ...piece }))
+  };
+
+  const movingPiece = findPiece(nextState, move.pieceId);
+  if (!movingPiece) {
+    throw new Error(`Unknown piece: ${move.pieceId}`);
+  }
+
+  if (move.action === 'EXIT_START') {
+    movingPiece.isInStart = false;
+    movingPiece.isOnBoard = true;
+    movingPiece.position = move.to;
+    movingPiece.isImmune = true;
+    return nextState;
+  }
+
+  if (move.action === 'MOVE') {
+    movingPiece.position = move.to;
+    movingPiece.isImmune = false;
+    return nextState;
+  }
+
+  if (move.action === 'SWAP') {
+    if (!move.swapTargetPieceId) {
+      throw new Error('swapTargetPieceId is required for SWAP move');
+    }
+
+    const targetPiece = findPiece(nextState, move.swapTargetPieceId);
+    if (!targetPiece) {
+      throw new Error(`Unknown target piece: ${move.swapTargetPieceId}`);
+    }
+
+    const from = movingPiece.position;
+    movingPiece.position = targetPiece.position;
+    targetPiece.position = from;
+
+    return nextState;
+  }
+
+  throw new Error(`Unsupported action: ${move.action}`);
+}

--- a/dog_game/packages/shared-types/index.js
+++ b/dog_game/packages/shared-types/index.js
@@ -1,0 +1,68 @@
+/**
+ * @typedef {'ACE'|'TWO'|'THREE'|'FOUR'|'FIVE'|'SIX'|'SEVEN'|'EIGHT'|'NINE'|'TEN'|'JACK'|'QUEEN'|'KING'|'JOKER'} CardRank
+ */
+
+/**
+ * @typedef {Object} PieceState
+ * @property {string} id
+ * @property {string} ownerId
+ * @property {number|null} position
+ * @property {boolean} isInStart
+ * @property {boolean} isOnBoard
+ * @property {boolean} isInHome
+ * @property {boolean} isImmune
+ * @property {boolean} hasCompletedLap
+ */
+
+/**
+ * @typedef {Object} GameState
+ * @property {number} trackLength
+ * @property {Record<string, number>} startIndexes
+ * @property {PieceState[]} pieces
+ */
+
+/**
+ * @typedef {Object} MoveOption
+ * @property {string} pieceId
+ * @property {CardRank} card
+ * @property {'MOVE'|'EXIT_START'|'SWAP'} action
+ * @property {number|null} from
+ * @property {number|null} to
+ * @property {number=} steps
+ * @property {string=} swapTargetPieceId
+ */
+
+export const CARD_RANKS = Object.freeze([
+  'ACE',
+  'TWO',
+  'THREE',
+  'FOUR',
+  'FIVE',
+  'SIX',
+  'SEVEN',
+  'EIGHT',
+  'NINE',
+  'TEN',
+  'JACK',
+  'QUEEN',
+  'KING',
+  'JOKER'
+]);
+
+/**
+ * @param {string} id
+ * @param {string} ownerId
+ * @returns {PieceState}
+ */
+export function createPieceInStart(id, ownerId) {
+  return {
+    id,
+    ownerId,
+    position: null,
+    isInStart: true,
+    isOnBoard: false,
+    isInHome: false,
+    isImmune: false,
+    hasCompletedLap: false
+  };
+}

--- a/dog_game/tests/deck.test.js
+++ b/dog_game/tests/deck.test.js
@@ -1,0 +1,65 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildDeckCards,
+  createDeckState,
+  discardCards,
+  drawCards,
+  getDeckCountForPlayers,
+  getHandSizeForRound,
+  shuffleDeterministic
+} from '../packages/game-rules/deck.js';
+
+test('Deck count follows player-count rules (4 => 2 decks, >4 => 3 decks)', () => {
+  assert.equal(getDeckCountForPlayers(4), 2);
+  assert.equal(getDeckCountForPlayers(5), 3);
+  assert.equal(getDeckCountForPlayers(8), 3);
+});
+
+test('Deck card totals include jokers: 2 decks = 108, 3 decks = 162', () => {
+  assert.equal(buildDeckCards(2).length, 108);
+  assert.equal(buildDeckCards(3).length, 162);
+});
+
+test('Hand-size cycle repeats 6,5,4,3,2', () => {
+  const rounds = Array.from({ length: 10 }, (_, index) => index + 1);
+  const handSizes = rounds.map((round) => getHandSizeForRound(round));
+
+  assert.deepEqual(handSizes, [6, 5, 4, 3, 2, 6, 5, 4, 3, 2]);
+});
+
+test('Deterministic shuffle returns same order for same seed', () => {
+  const cards = buildDeckCards(2);
+  const shuffledA = shuffleDeterministic(cards, 123);
+  const shuffledB = shuffleDeterministic(cards, 123);
+  const shuffledC = shuffleDeterministic(cards, 456);
+
+  assert.deepEqual(
+    shuffledA.map((card) => card.id),
+    shuffledB.map((card) => card.id)
+  );
+
+  assert.notDeepEqual(
+    shuffledA.map((card) => card.id),
+    shuffledC.map((card) => card.id)
+  );
+});
+
+test('Draw reshuffles discard pile when draw pile is empty', () => {
+  const deckState = createDeckState(4, 999);
+
+  const { drawn: firstDraw, deckState: afterFirstDraw } = drawCards(deckState, 6, 77);
+  const afterDiscard = discardCards(afterFirstDraw, firstDraw);
+
+  const forcedEmptyDraw = {
+    drawPile: [],
+    discardPile: [...afterDiscard.discardPile]
+  };
+
+  const { drawn, deckState: afterReshuffleDraw } = drawCards(forcedEmptyDraw, 3, 77);
+
+  assert.equal(drawn.length, 3);
+  assert.equal(afterReshuffleDraw.discardPile.length, 0);
+  assert.equal(afterReshuffleDraw.drawPile.length, forcedEmptyDraw.discardPile.length - 3);
+});

--- a/dog_game/tests/game-rules.test.js
+++ b/dog_game/tests/game-rules.test.js
@@ -1,0 +1,140 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createPieceInStart } from '../packages/shared-types/index.js';
+import {
+  applyMovePreview,
+  buildStartIndexes,
+  generateJackSwapOptions,
+  generateLegalMoves,
+  TRACK_SPACES_BETWEEN_PLAYERS
+} from '../packages/game-rules/index.js';
+
+function buildState({ trackLength = 64, startIndexes, pieces }) {
+  return {
+    trackLength,
+    startIndexes,
+    pieces
+  };
+}
+
+test('Ace offers both 1 and 11 forward moves', () => {
+  const startIndexes = buildStartIndexes(4);
+  const piece = {
+    ...createPieceInStart('P1-A', 'P1'),
+    isInStart: false,
+    isOnBoard: true,
+    position: 0
+  };
+
+  const state = buildState({
+    trackLength: TRACK_SPACES_BETWEEN_PLAYERS * 4,
+    startIndexes,
+    pieces: [piece]
+  });
+
+  const moves = generateLegalMoves(state, 'P1', 'ACE');
+  assert.equal(moves.length, 2);
+  assert.deepEqual(
+    moves.map((move) => move.steps),
+    [1, 11]
+  );
+  assert.deepEqual(
+    moves.map((move) => move.to),
+    [1, 11]
+  );
+});
+
+test('King can exit start when piece is in start', () => {
+  const startIndexes = buildStartIndexes(4);
+  const state = buildState({
+    trackLength: TRACK_SPACES_BETWEEN_PLAYERS * 4,
+    startIndexes,
+    pieces: [createPieceInStart('P1-A', 'P1')]
+  });
+
+  const moves = generateLegalMoves(state, 'P1', 'KING');
+  assert.equal(moves.length, 1);
+  assert.equal(moves[0].action, 'EXIT_START');
+  assert.equal(moves[0].to, startIndexes.P1);
+
+  const previewState = applyMovePreview(state, moves[0]);
+  const movedPiece = previewState.pieces[0];
+  assert.equal(movedPiece.isOnBoard, true);
+  assert.equal(movedPiece.isInStart, false);
+  assert.equal(movedPiece.isImmune, true);
+});
+
+test('4 backward wraps around board boundaries', () => {
+  const startIndexes = buildStartIndexes(4);
+  const piece = {
+    ...createPieceInStart('P1-A', 'P1'),
+    isInStart: false,
+    isOnBoard: true,
+    position: 1
+  };
+
+  const state = buildState({
+    trackLength: TRACK_SPACES_BETWEEN_PLAYERS * 4,
+    startIndexes,
+    pieces: [piece]
+  });
+
+  const moves = generateLegalMoves(state, 'P1', 'FOUR');
+  const backwardMove = moves.find((move) => move.steps === -4);
+
+  assert.ok(backwardMove);
+  assert.equal(backwardMove.to, 61);
+});
+
+test('Immune blocker cannot be passed, landed on, or swapped by Jack', () => {
+  const startIndexes = buildStartIndexes(4);
+
+  const myMover = {
+    ...createPieceInStart('P1-A', 'P1'),
+    isInStart: false,
+    isOnBoard: true,
+    position: 1
+  };
+
+  const enemyImmune = {
+    ...createPieceInStart('P2-A', 'P2'),
+    isInStart: false,
+    isOnBoard: true,
+    position: 3,
+    isImmune: true
+  };
+
+  const enemyNormal = {
+    ...createPieceInStart('P2-B', 'P2'),
+    isInStart: false,
+    isOnBoard: true,
+    position: 8,
+    isImmune: false
+  };
+
+  const state = buildState({
+    trackLength: TRACK_SPACES_BETWEEN_PLAYERS * 4,
+    startIndexes,
+    pieces: [myMover, enemyImmune, enemyNormal]
+  });
+
+  const fourMoves = generateLegalMoves(state, 'P1', 'FOUR');
+  assert.equal(
+    fourMoves.some((move) => move.steps === 4),
+    false,
+    'Forward 4 should be blocked because path crosses immune piece'
+  );
+
+  const jackSwaps = generateJackSwapOptions(state, 'P1');
+  assert.equal(
+    jackSwaps.some((move) => move.swapTargetPieceId === 'P2-A'),
+    false,
+    'Immune piece must not be a Jack target'
+  );
+  assert.equal(
+    jackSwaps.some((move) => move.swapTargetPieceId === 'P2-B'),
+    true,
+    'Non-immune in-play piece should remain a valid Jack target'
+  );
+});


### PR DESCRIPTION
### Motivation

- Establish a deterministic, testable foundation for core card/deck logic and board move rules to support future realtime/web work.
- Provide canonical shared types and a minimal rules engine implementing key behaviors required for Sprint 1 (Ace dual, King exit, 4 backward, immune blockers, Jack swap). 

### Description

- Add `dog_game/SPRINT1_BOOTSTRAP.md` with the Sprint 1 checklist and recommended repo layout. 
- Add top-level `dog_game/package.json` with a `test` script using `node --test tests/*.test.js`.
- Add `packages/shared-types/index.js` with `CardRank`, `PieceState`, `GameState`, `MoveOption`, `CARD_RANKS`, and `createPieceInStart` helpers. 
- Implement `packages/game-rules/deck.js` with deterministic RNG, `getDeckCountForPlayers`, `buildDeckCards`, `shuffleDeterministic`, `createDeckState`, `getHandSizeForRound`, `drawCards`, and `discardCards`. 
- Implement `packages/game-rules/index.js` with core rule utilities including `TRACK_SPACES_BETWEEN_PLAYERS`, `getStepValues`, `canExitStart`, `buildStartIndexes`, `generateLegalMoves`, `generateJackSwapOptions`, `applyMovePreview`, and path/immune checks. 
- Add unit tests under `tests/` for deck behavior (`deck.test.js`) and rules behavior (`game-rules.test.js`) that validate deck sizes, deterministic shuffling, reshuffle-on-empty logic, Ace/Kings/4/immune/Jack behaviors.

### Testing

- Ran the test suite via `node --test tests/*.test.js` which executed `tests/deck.test.js` and `tests/game-rules.test.js` and all assertions passed. 
- The deck tests validated `getDeckCountForPlayers`, `buildDeckCards` lengths, `shuffleDeterministic` determinism, `getHandSizeForRound` cycle, and reshuffle behavior. 
- The rules tests validated `buildStartIndexes`, `generateLegalMoves` for `ACE`, `KING`, `FOUR`, immune blocker handling, `generateJackSwapOptions`, and `applyMovePreview` behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b81c81a1e48333b90fc72234a349b5)