### PR TITLE
Support JOKER move generation and add hand playability evaluation

### DIFF
--- a/dog_game/packages/game-rules/index.js
+++ b/dog_game/packages/game-rules/index.js
@@ -100,6 +100,10 @@ export function generateLegalMoves(state, playerId, card) {
     throw new Error(`Unknown card: ${card}`);
   }
 
+  if (card === 'JOKER') {
+    return generateJokerOptions(state, playerId);
+  }
+
   const options = [];
   const ownPieces = state.pieces.filter((piece) => piece.ownerId === playerId);
 
@@ -175,6 +179,46 @@ export function generateLegalMoves(state, playerId, card) {
  * @param {string} playerId
  * @returns {import('../shared-types/index.js').MoveOption[]}
  */
+export function generateJokerOptions(state, playerId) {
+  const mirroredCards = CARD_RANKS.filter((rank) => rank !== 'JOKER');
+  const uniqueMoves = new Map();
+
+  for (const mirroredCard of mirroredCards) {
+    const moves = generateLegalMoves(state, playerId, mirroredCard);
+
+    for (const move of moves) {
+      const jokerMove = {
+        ...move,
+        card: 'JOKER'
+      };
+
+      const key = [jokerMove.action, jokerMove.pieceId, jokerMove.from, jokerMove.to, jokerMove.steps, jokerMove.swapTargetPieceId].join('|');
+      uniqueMoves.set(key, jokerMove);
+    }
+  }
+
+  return [...uniqueMoves.values()].sort((a, b) => {
+    if (a.action !== b.action) {
+      return a.action.localeCompare(b.action);
+    }
+
+    if (a.pieceId !== b.pieceId) {
+      return a.pieceId.localeCompare(b.pieceId);
+    }
+
+    if ((a.steps ?? 0) !== (b.steps ?? 0)) {
+      return (a.steps ?? 0) - (b.steps ?? 0);
+    }
+
+    return (a.swapTargetPieceId ?? '').localeCompare(b.swapTargetPieceId ?? '');
+  });
+}
+
+/**
+ * @param {import('../shared-types/index.js').GameState} state
+ * @param {string} playerId
+ * @returns {import('../shared-types/index.js').MoveOption[]}
+ */
 export function generateJackSwapOptions(state, playerId) {
   const ownOnBoard = state.pieces.filter(
     (piece) => piece.ownerId === playerId && piece.isOnBoard && piece.position !== null && !piece.isImmune
@@ -219,6 +263,31 @@ export function buildStartIndexes(playerCount) {
   }
 
   return startIndexes;
+}
+
+
+/**
+ * @param {import('../shared-types/index.js').GameState} state
+ * @param {string} playerId
+ * @param {import('../shared-types/index.js').CardRank[]} hand
+ */
+export function evaluateHandPlayability(state, playerId, hand) {
+  const perCardMoves = {};
+  let hasAnyLegalMove = false;
+
+  for (const card of hand) {
+    const moves = generateLegalMoves(state, playerId, card);
+    perCardMoves[card] = moves;
+
+    if (moves.length > 0) {
+      hasAnyLegalMove = true;
+    }
+  }
+
+  return {
+    hasAnyLegalMove,
+    perCardMoves
+  };
 }
 
 /**

--- a/dog_game/tests/game-rules.test.js
+++ b/dog_game/tests/game-rules.test.js
@@ -7,6 +7,7 @@ import {
   buildStartIndexes,
   generateJackSwapOptions,
   generateLegalMoves,
+  evaluateHandPlayability,
   TRACK_SPACES_BETWEEN_PLAYERS
 } from '../packages/game-rules/index.js';
 
@@ -137,4 +138,158 @@ test('Immune blocker cannot be passed, landed on, or swapped by Jack', () => {
     true,
     'Non-immune in-play piece should remain a valid Jack target'
   );
+});
+
+test('Joker mirrors legal moves from other card types', () => {
+  const startIndexes = buildStartIndexes(4);
+
+  const myOnBoard = {
+    ...createPieceInStart('P1-A', 'P1'),
+    isInStart: false,
+    isOnBoard: true,
+    position: 5,
+    isImmune: false
+  };
+
+  const myInStart = createPieceInStart('P1-B', 'P1');
+
+  const enemyOnBoard = {
+    ...createPieceInStart('P2-A', 'P2'),
+    isInStart: false,
+    isOnBoard: true,
+    position: 9,
+    isImmune: false
+  };
+
+  const state = buildState({
+    trackLength: TRACK_SPACES_BETWEEN_PLAYERS * 4,
+    startIndexes,
+    pieces: [myOnBoard, myInStart, enemyOnBoard]
+  });
+
+  const jokerMoves = generateLegalMoves(state, 'P1', 'JOKER');
+
+  assert.equal(
+    jokerMoves.some((move) => move.action === 'EXIT_START' && move.pieceId === 'P1-B' && move.to === startIndexes.P1),
+    true,
+    'Joker should include start-exit moves from Ace/King behavior'
+  );
+
+  assert.equal(
+    jokerMoves.some((move) => move.action === 'MOVE' && move.pieceId === 'P1-A' && move.steps === 13),
+    true,
+    'Joker should include king-like 13-step movement'
+  );
+
+  assert.equal(
+    jokerMoves.some((move) => move.action === 'SWAP' && move.pieceId === 'P1-A' && move.swapTargetPieceId === 'P2-A'),
+    true,
+    'Joker should include Jack-like swap options'
+  );
+});
+
+
+test('Joker equals deduplicated union of all non-Joker legal moves', () => {
+  const startIndexes = buildStartIndexes(4);
+
+  const state = buildState({
+    trackLength: TRACK_SPACES_BETWEEN_PLAYERS * 4,
+    startIndexes,
+    pieces: [
+      {
+        ...createPieceInStart('P1-A', 'P1'),
+        isInStart: false,
+        isOnBoard: true,
+        position: 5,
+        isImmune: false
+      },
+      createPieceInStart('P1-B', 'P1'),
+      {
+        ...createPieceInStart('P2-A', 'P2'),
+        isInStart: false,
+        isOnBoard: true,
+        position: 7,
+        isImmune: true
+      },
+      {
+        ...createPieceInStart('P2-B', 'P2'),
+        isInStart: false,
+        isOnBoard: true,
+        position: 9,
+        isImmune: false
+      }
+    ]
+  });
+
+  const nonJokerCards = ['ACE', 'TWO', 'THREE', 'FOUR', 'FIVE', 'SIX', 'SEVEN', 'EIGHT', 'NINE', 'TEN', 'JACK', 'QUEEN', 'KING'];
+
+  const expected = new Map();
+  for (const card of nonJokerCards) {
+    for (const move of generateLegalMoves(state, 'P1', card)) {
+      const jokerMove = { ...move, card: 'JOKER' };
+      const key = [
+        jokerMove.action,
+        jokerMove.pieceId,
+        jokerMove.from,
+        jokerMove.to,
+        jokerMove.steps,
+        jokerMove.swapTargetPieceId
+      ].join('|');
+      expected.set(key, jokerMove);
+    }
+  }
+
+  const actual = generateLegalMoves(state, 'P1', 'JOKER');
+  const actualKeys = new Set(
+    actual.map((move) => [move.action, move.pieceId, move.from, move.to, move.steps, move.swapTargetPieceId].join('|'))
+  );
+
+  assert.equal(actual.length, actualKeys.size, 'Joker result should not contain duplicate move entries');
+  assert.deepEqual([...actualKeys].sort(), [...expected.keys()].sort());
+});
+
+
+test('Must-play is true when at least one card in hand has legal moves', () => {
+  const startIndexes = buildStartIndexes(4);
+  const state = buildState({
+    trackLength: TRACK_SPACES_BETWEEN_PLAYERS * 4,
+    startIndexes,
+    pieces: [createPieceInStart('P1-A', 'P1')]
+  });
+
+  const hand = ['SEVEN', 'JACK', 'KING'];
+  const result = evaluateHandPlayability(state, 'P1', hand);
+
+  assert.equal(result.hasAnyLegalMove, true);
+  assert.equal(result.perCardMoves.SEVEN.length, 0);
+  assert.equal(result.perCardMoves.JACK.length, 0);
+  assert.equal(result.perCardMoves.KING.length, 1);
+  assert.equal(result.perCardMoves.KING[0].action, 'EXIT_START');
+});
+
+test('No-legal-move is true when all cards in hand are blocked', () => {
+  const startIndexes = buildStartIndexes(4);
+
+  const myStartPiece = createPieceInStart('P1-A', 'P1');
+  const enemyImmuneAtStart = {
+    ...createPieceInStart('P2-A', 'P2'),
+    isInStart: false,
+    isOnBoard: true,
+    position: startIndexes.P1,
+    isImmune: true
+  };
+
+  const state = buildState({
+    trackLength: TRACK_SPACES_BETWEEN_PLAYERS * 4,
+    startIndexes,
+    pieces: [myStartPiece, enemyImmuneAtStart]
+  });
+
+  const hand = ['ACE', 'KING', 'JACK'];
+  const result = evaluateHandPlayability(state, 'P1', hand);
+
+  assert.equal(result.hasAnyLegalMove, false);
+  assert.equal(result.perCardMoves.ACE.length, 0);
+  assert.equal(result.perCardMoves.KING.length, 0);
+  assert.equal(result.perCardMoves.JACK.length, 0);
 });


### PR DESCRIPTION
### Motivation
- Implement full support for the `JOKER` card by making it mirror all other card behaviors so players can play any legal move a non-Joker card would allow.  
- Avoid duplicate move entries when aggregating mirrored moves from multiple card types.  
- Provide a utility to evaluate whether a player's hand contains any playable card and to expose per-card legal moves for UI/AI use.

### Description
- Added a `JOKER` branch to `generateLegalMoves` to delegate Joker handling to a new `generateJokerOptions` function.  
- Implemented `generateJokerOptions` to call `generateLegalMoves` for each non-Joker rank, tag those moves with `card: 'JOKER'`, deduplicate by a deterministic key, and return a stable sorted list.  
- Added `evaluateHandPlayability(state, playerId, hand)` which returns `hasAnyLegalMove` and `perCardMoves` by calling `generateLegalMoves` per card.  
- Updated unit tests in `dog_game/tests/game-rules.test.js` to cover Joker behavior and the new `evaluateHandPlayability` functionality.

### Testing
- Ran the game-rules unit tests in `dog_game/tests/game-rules.test.js` which include new cases for Joker move mirroring, Joker deduplication, positive must-play detection, and blocked-hand detection.  
- Tests were executed with the project test runner (e.g. `node --test dog_game/tests/game-rules.test.js` or `npm test`).  
- All added and existing assertions in `game-rules.test.js` passed.  
- No regressions observed in the tested game-rules behaviors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b8220f2e488333b8811dc72f03367b)