### PR TITLE
Add Phase 1 status doc and unit tests for immune/blocker edge cases

### DIFF
--- a/dog_game/PHASE1_STATUS.md
+++ b/dog_game/PHASE1_STATUS.md
@@ -1,0 +1,43 @@
+# Phase 1 status: rules engine completion
+
+This checklist tracks the Phase 1 objective: deterministic, server-safe game logic with practical edge-case coverage.
+
+## Core logic status
+
+- [x] Board indexing model with seat-aware start indexes
+- [x] Explicit piece flags (`isInStart`, `isOnBoard`, `isInHome`, `isImmune`, `hasCompletedLap`)
+- [x] Legal move generation is the primary source of truth
+- [x] Card effects implemented (Ace, 2-10, 4 backward, 7 split, Jack swap, Queen, King, Joker)
+- [x] Collision + knockback handling
+- [x] Immunity constraints enforced in move generation and preview application
+- [x] Exact home-lane entry and overshoot behavior
+- [x] Must-play / no-legal-move hand evaluation
+
+## Critical edge-case test status
+
+- [x] Ace as 1 vs 11
+- [x] Ace/King start exit when no piece can otherwise move
+- [x] 4 backward crossing board boundaries
+- [x] 7 split across multiple pieces
+- [x] 7 split knocking allied pieces
+- [x] 7 split with immune blocker present
+- [x] Jack swap with enemy piece
+- [x] Jack forbidden against immune piece
+- [x] Joker mirrors all card types (deduplicated)
+- [x] Exact `bo` entry
+- [x] Overshoot `bo` and continue on track
+- [x] Must-play when only one obscure legal move exists
+
+## Deferred to later phases
+
+- [ ] Preview-session lifecycle behavior (`start_move_preview` / `cancel_move_preview` / `confirm_move`) requires realtime room orchestration (Phase 3)
+- [ ] Round-end flow when remaining players are blocked requires turn/round state machine at room level (Phase 3)
+- [ ] Reconnect-in-the-middle scenarios require room snapshots and transport/session handling (Phase 3)
+
+## Phase 1 completion definition
+
+Phase 1 is considered complete for the current codebase when:
+
+1. All rules-engine and deck/team unit tests pass.
+2. Deterministic move generation and move preview behavior are validated by tests.
+3. Remaining unchecked items are integration concerns owned by Phase 3 room service.

--- a/dog_game/tests/game-rules.test.js
+++ b/dog_game/tests/game-rules.test.js
@@ -68,6 +68,46 @@ test('King can exit start when piece is in start', () => {
   assert.equal(movedPiece.isImmune, true);
 });
 
+test('Ace can still exit start when normal on-board Ace moves are blocked by immune piece', () => {
+  const startIndexes = buildStartIndexes(4);
+
+  const blockedMover = {
+    ...createPieceInStart('P1-A', 'P1'),
+    isInStart: false,
+    isOnBoard: true,
+    position: 2
+  };
+
+  const startPiece = createPieceInStart('P1-B', 'P1');
+
+  const immuneBlocker = {
+    ...createPieceInStart('P2-A', 'P2'),
+    isInStart: false,
+    isOnBoard: true,
+    position: 3,
+    isImmune: true
+  };
+
+  const state = buildState({
+    trackLength: TRACK_SPACES_BETWEEN_PLAYERS * 4,
+    startIndexes,
+    pieces: [blockedMover, startPiece, immuneBlocker]
+  });
+
+  const moves = generateLegalMoves(state, 'P1', 'ACE');
+
+  assert.equal(
+    moves.some((move) => move.action === 'MOVE' && move.pieceId === 'P1-A'),
+    false,
+    'On-board ACE moves should be blocked by immune piece'
+  );
+  assert.equal(
+    moves.some((move) => move.action === 'EXIT_START' && move.pieceId === 'P1-B' && move.to === startIndexes.P1),
+    true,
+    'ACE exit-from-start option should remain legal'
+  );
+});
+
 test('4 backward wraps around board boundaries', () => {
   const startIndexes = buildStartIndexes(4);
   const piece = {
@@ -601,4 +641,89 @@ test('Seven split knocks passed pieces (including allied pieces) back to start',
   assert.equal(alliedAfter.isInStart, true);
   assert.equal(alliedAfter.isOnBoard, false);
   assert.equal(alliedAfter.position, null);
+});
+
+test('Seven split has no legal routes when immune blocker is on every first step', () => {
+  const startIndexes = buildStartIndexes(4);
+
+  const p1a = {
+    ...createPieceInStart('P1-A', 'P1'),
+    isInStart: false,
+    isOnBoard: true,
+    position: 0
+  };
+
+  const p1b = {
+    ...createPieceInStart('P1-B', 'P1'),
+    isInStart: false,
+    isOnBoard: true,
+    position: 10
+  };
+
+  const immuneAheadA = {
+    ...createPieceInStart('P2-A', 'P2'),
+    isInStart: false,
+    isOnBoard: true,
+    position: 1,
+    isImmune: true
+  };
+
+  const immuneAheadB = {
+    ...createPieceInStart('P2-B', 'P2'),
+    isInStart: false,
+    isOnBoard: true,
+    position: 11,
+    isImmune: true
+  };
+
+  const state = buildState({
+    trackLength: TRACK_SPACES_BETWEEN_PLAYERS * 4,
+    startIndexes,
+    pieces: [p1a, p1b, immuneAheadA, immuneAheadB]
+  });
+
+  const sevenMoves = generateLegalMoves(state, 'P1', 'SEVEN');
+  assert.equal(sevenMoves.length, 0);
+});
+
+test('Must-play remains true when hand has exactly one obscure legal move', () => {
+  const startIndexes = buildStartIndexes(4);
+
+  const myOnBoard = {
+    ...createPieceInStart('P1-A', 'P1'),
+    isInStart: false,
+    isOnBoard: true,
+    position: 1
+  };
+
+  const enemyImmuneForwardOne = {
+    ...createPieceInStart('P2-A', 'P2'),
+    isInStart: false,
+    isOnBoard: true,
+    position: 2,
+    isImmune: true
+  };
+
+  const enemyImmuneForwardEleven = {
+    ...createPieceInStart('P2-B', 'P2'),
+    isInStart: false,
+    isOnBoard: true,
+    position: 12,
+    isImmune: true
+  };
+
+  const state = buildState({
+    trackLength: TRACK_SPACES_BETWEEN_PLAYERS * 4,
+    startIndexes,
+    pieces: [myOnBoard, enemyImmuneForwardOne, enemyImmuneForwardEleven]
+  });
+
+  const hand = ['ACE', 'KING', 'FOUR'];
+  const result = evaluateHandPlayability(state, 'P1', hand);
+
+  assert.equal(result.hasAnyLegalMove, true);
+  assert.equal(result.perCardMoves.ACE.length, 0);
+  assert.equal(result.perCardMoves.KING.length, 0);
+  assert.equal(result.perCardMoves.FOUR.some((move) => move.steps === -4), true);
+  assert.equal(result.perCardMoves.FOUR.some((move) => move.steps === 4), false);
 });


### PR DESCRIPTION
### Motivation
- Document Phase 1 completion criteria and track remaining integration work. 
- Improve rules-engine coverage around immune blockers, start-exit behavior, seven-split routing, and must-play detection for obscure moves.

### Description
- Add `dog_game/PHASE1_STATUS.md` containing the Phase 1 checklist, core logic status, critical edge-case coverage, and deferred items for later phases. 
- Add unit tests to `dog_game/tests/game-rules.test.js` that verify an `ACE` can exit start when on-board ACE moves are blocked by an immune piece. 
- Add a test that verifies `SEVEN` split has no legal routes when an immune blocker occupies every first step of potential routes. 
- Add a test that ensures the `must-play` evaluation remains true when the hand has exactly one obscure legal move and other moves are blocked by immunity.

### Testing
- Ran unit tests with `npm test` and confirmed the full test suite completed successfully. 
- The added `game-rules.test.js` cases were executed as part of the suite and passed. 
- No automated tests failed during this run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b83f8bd5548333b39c52dac962c297)