### PR TITLE
Add authoritative room engine, Phase 1 status, and extended rules tests

### DIFF
--- a/dog_game/PHASE1_STATUS.md
+++ b/dog_game/PHASE1_STATUS.md
@@ -1,0 +1,43 @@
+# Phase 1 status: rules engine completion
+
+This checklist tracks the Phase 1 objective: deterministic, server-safe game logic with practical edge-case coverage.
+
+## Core logic status
+
+- [x] Board indexing model with seat-aware start indexes
+- [x] Explicit piece flags (`isInStart`, `isOnBoard`, `isInHome`, `isImmune`, `hasCompletedLap`)
+- [x] Legal move generation is the primary source of truth
+- [x] Card effects implemented (Ace, 2-10, 4 backward, 7 split, Jack swap, Queen, King, Joker)
+- [x] Collision + knockback handling
+- [x] Immunity constraints enforced in move generation and preview application
+- [x] Exact home-lane entry and overshoot behavior
+- [x] Must-play / no-legal-move hand evaluation
+
+## Critical edge-case test status
+
+- [x] Ace as 1 vs 11
+- [x] Ace/King start exit when no piece can otherwise move
+- [x] 4 backward crossing board boundaries
+- [x] 7 split across multiple pieces
+- [x] 7 split knocking allied pieces
+- [x] 7 split with immune blocker present
+- [x] Jack swap with enemy piece
+- [x] Jack forbidden against immune piece
+- [x] Joker mirrors all card types (deduplicated)
+- [x] Exact `bo` entry
+- [x] Overshoot `bo` and continue on track
+- [x] Must-play when only one obscure legal move exists
+
+## Deferred to later phases
+
+- [ ] Preview-session lifecycle behavior (`start_move_preview` / `cancel_move_preview` / `confirm_move`) requires realtime room orchestration (Phase 3)
+- [ ] Round-end flow when remaining players are blocked requires turn/round state machine at room level (Phase 3)
+- [ ] Reconnect-in-the-middle scenarios require room snapshots and transport/session handling (Phase 3)
+
+## Phase 1 completion definition
+
+Phase 1 is considered complete for the current codebase when:
+
+1. All rules-engine and deck/team unit tests pass.
+2. Deterministic move generation and move preview behavior are validated by tests.
+3. Remaining unchecked items are integration concerns owned by Phase 3 room service.

--- a/dog_game/services/realtime-server/room-engine.js
+++ b/dog_game/services/realtime-server/room-engine.js
@@ -1,0 +1,447 @@
+import { createPieceInStart } from '../../packages/shared-types/index.js';
+import { applyMovePreview, buildStartIndexes, evaluateHandPlayability, generateLegalMoves, TRACK_SPACES_BETWEEN_PLAYERS } from '../../packages/game-rules/index.js';
+import { createDeckState, dealRoundHands, discardCards } from '../../packages/game-rules/deck.js';
+
+function clone(value) {
+  return structuredClone(value);
+}
+
+function deriveMaxPlayers(config) {
+  return config.teamCount * config.playersPerTeam;
+}
+
+function assertVersion(state, expectedVersion) {
+  if (expectedVersion === undefined) {
+    return;
+  }
+
+  if (state.version !== expectedVersion) {
+    throw new Error(`Version mismatch: expected ${expectedVersion}, actual ${state.version}`);
+  }
+}
+
+function withVersionBump(state) {
+  return {
+    ...state,
+    version: state.version + 1
+  };
+}
+
+function ensureUniqueSeat(players, seatNo) {
+  if (players.some((player) => player.seatNo === seatNo)) {
+    throw new Error(`Seat ${seatNo} is already occupied`);
+  }
+}
+
+function seatFromTeamSlot(teamNo, slotInTeam, teamCount) {
+  return (slotInTeam - 1) * teamCount + teamNo;
+}
+
+function assertActiveTurn(state, playerId) {
+  if (state.status !== 'active') {
+    throw new Error('Match is not active');
+  }
+
+  const activePlayerId = state.match.turnOrder[state.match.turnIndex];
+  if (activePlayerId !== playerId) {
+    throw new Error(`Not your turn: active player is ${activePlayerId}`);
+  }
+}
+
+function findCardIndexByRank(hand, rank) {
+  return hand.findIndex((card) => card.rank === rank);
+}
+
+function buildInitialPieces(playerIds) {
+  const pieces = [];
+
+  for (const playerId of playerIds) {
+    for (let i = 1; i <= 4; i += 1) {
+      pieces.push(createPieceInStart(`${playerId}-${i}`, playerId));
+    }
+  }
+
+  return pieces;
+}
+
+function buildGameStateFromPlayers(players) {
+  const ordered = [...players].sort((a, b) => a.seatNo - b.seatNo);
+  const playerIds = ordered.map((player) => player.playerId);
+
+  return {
+    trackLength: TRACK_SPACES_BETWEEN_PLAYERS * playerIds.length,
+    startIndexes: buildStartIndexes(playerIds.length),
+    pieces: buildInitialPieces(playerIds)
+  };
+}
+
+function createMatch(room) {
+  const ordered = [...room.players].sort((a, b) => a.seatNo - b.seatNo);
+  const playerIds = ordered.map((player) => player.playerId);
+
+  const deckState = createDeckState(playerIds.length, 1);
+  const dealt = dealRoundHands(deckState, playerIds, 1, 101);
+
+  return {
+    turnOrder: playerIds,
+    turnIndex: 0,
+    roundNumber: 1,
+    handsByPlayerId: dealt.hands,
+    deckState: dealt.deckState,
+    discardPile: [],
+    gameState: buildGameStateFromPlayers(ordered),
+    pendingPreview: null
+  };
+}
+
+function withIdempotency(state, idempotencyKey, executor) {
+  if (!idempotencyKey) {
+    return executor();
+  }
+
+  if (state.idempotency[idempotencyKey]) {
+    return {
+      state,
+      response: clone(state.idempotency[idempotencyKey])
+    };
+  }
+
+  const result = executor();
+  const nextState = {
+    ...result.state,
+    idempotency: {
+      ...result.state.idempotency,
+      [idempotencyKey]: clone(result.response)
+    }
+  };
+
+  return {
+    state: nextState,
+    response: result.response
+  };
+}
+
+export function createRoom(command) {
+  const {
+    roomId,
+    hostPlayerId,
+    gameMode = 'solo',
+    teamCount = 4,
+    playersPerTeam = 1,
+    idempotencyKey
+  } = command;
+
+  const config = { gameMode, teamCount, playersPerTeam };
+  const maxPlayers = deriveMaxPlayers(config);
+
+  if (maxPlayers < 4 || maxPlayers > 8) {
+    throw new Error('Room size must be between 4 and 8 players');
+  }
+
+  const host = {
+    playerId: hostPlayerId,
+    teamNo: 1,
+    slotInTeam: 1,
+    seatNo: seatFromTeamSlot(1, 1, teamCount),
+    ready: false,
+    connected: true
+  };
+
+  const state = {
+    roomId,
+    config,
+    maxPlayers,
+    status: 'lobby',
+    version: 1,
+    players: [host],
+    match: null,
+    idempotency: {},
+    hostPlayerId
+  };
+
+  if (idempotencyKey) {
+    state.idempotency[idempotencyKey] = { ok: true, roomId, version: state.version };
+  }
+
+  return state;
+}
+
+function handleJoinRoom(state, command) {
+  const { playerId, teamNo, slotInTeam } = command;
+
+  if (state.status !== 'lobby') {
+    throw new Error('Cannot join after match start');
+  }
+
+  if (state.players.some((player) => player.playerId === playerId)) {
+    return {
+      state,
+      response: { ok: true, joined: false, reason: 'already_joined', version: state.version }
+    };
+  }
+
+  if (state.players.length >= state.maxPlayers) {
+    throw new Error('Room is full');
+  }
+
+  if (teamNo < 1 || teamNo > state.config.teamCount) {
+    throw new Error('teamNo out of bounds');
+  }
+
+  if (slotInTeam < 1 || slotInTeam > state.config.playersPerTeam) {
+    throw new Error('slotInTeam out of bounds');
+  }
+
+  if (state.players.some((player) => player.teamNo === teamNo && player.slotInTeam === slotInTeam)) {
+    throw new Error('Team slot already occupied');
+  }
+
+  const seatNo = seatFromTeamSlot(teamNo, slotInTeam, state.config.teamCount);
+  ensureUniqueSeat(state.players, seatNo);
+
+  const nextState = withVersionBump({
+    ...state,
+    players: [
+      ...state.players,
+      {
+        playerId,
+        teamNo,
+        slotInTeam,
+        seatNo,
+        ready: false,
+        connected: true
+      }
+    ]
+  });
+
+  return {
+    state: nextState,
+    response: { ok: true, joined: true, seatNo, version: nextState.version }
+  };
+}
+
+function handleSetReady(state, command) {
+  const { playerId, isReady } = command;
+
+  if (state.status !== 'lobby') {
+    throw new Error('Cannot set ready after match start');
+  }
+
+  const playerIndex = state.players.findIndex((player) => player.playerId === playerId);
+  if (playerIndex < 0) {
+    throw new Error('Player not in room');
+  }
+
+  const players = [...state.players];
+  players[playerIndex] = {
+    ...players[playerIndex],
+    ready: Boolean(isReady)
+  };
+
+  const nextState = withVersionBump({ ...state, players });
+  return {
+    state: nextState,
+    response: { ok: true, version: nextState.version }
+  };
+}
+
+function handleStartMatch(state, command) {
+  const { playerId } = command;
+
+  if (state.status !== 'lobby') {
+    throw new Error('Match already started');
+  }
+
+  if (state.hostPlayerId !== playerId) {
+    throw new Error('Only host can start match');
+  }
+
+  if (state.players.length !== state.maxPlayers) {
+    throw new Error('Room is not full');
+  }
+
+  if (state.players.some((player) => player.ready !== true)) {
+    throw new Error('All players must be ready');
+  }
+
+  const match = createMatch(state);
+  const nextState = withVersionBump({
+    ...state,
+    status: 'active',
+    match
+  });
+
+  return {
+    state: nextState,
+    response: {
+      ok: true,
+      started: true,
+      activePlayerId: match.turnOrder[0],
+      version: nextState.version
+    }
+  };
+}
+
+function handleRequestLegalMoves(state, command) {
+  const { playerId, card } = command;
+  assertActiveTurn(state, playerId);
+
+  const hand = state.match.handsByPlayerId[playerId] ?? [];
+  if (findCardIndexByRank(hand, card) < 0) {
+    throw new Error(`Card ${card} not in hand`);
+  }
+
+  const moves = generateLegalMoves(state.match.gameState, playerId, card);
+  return {
+    state,
+    response: { ok: true, moves, card, version: state.version }
+  };
+}
+
+function normalizeMove(move) {
+  return JSON.stringify(move);
+}
+
+function handleStartMovePreview(state, command) {
+  const { playerId, card, move } = command;
+  assertActiveTurn(state, playerId);
+
+  const hand = state.match.handsByPlayerId[playerId] ?? [];
+  if (findCardIndexByRank(hand, card) < 0) {
+    throw new Error(`Card ${card} not in hand`);
+  }
+
+  const legalMoves = generateLegalMoves(state.match.gameState, playerId, card);
+  const desired = normalizeMove(move);
+  const legal = legalMoves.find((candidate) => normalizeMove(candidate) === desired);
+  if (!legal) {
+    throw new Error('Illegal move preview request');
+  }
+
+  const previewState = applyMovePreview(state.match.gameState, legal);
+  const nextState = withVersionBump({
+    ...state,
+    match: {
+      ...state.match,
+      pendingPreview: {
+        playerId,
+        card,
+        move: legal,
+        previewState
+      }
+    }
+  });
+
+  return {
+    state: nextState,
+    response: {
+      ok: true,
+      preview: nextState.match.pendingPreview,
+      version: nextState.version
+    }
+  };
+}
+
+function handleCancelMovePreview(state, command) {
+  const { playerId } = command;
+  assertActiveTurn(state, playerId);
+
+  if (!state.match.pendingPreview || state.match.pendingPreview.playerId !== playerId) {
+    throw new Error('No pending preview for player');
+  }
+
+  const nextState = withVersionBump({
+    ...state,
+    match: {
+      ...state.match,
+      pendingPreview: null
+    }
+  });
+
+  return {
+    state: nextState,
+    response: { ok: true, cancelled: true, version: nextState.version }
+  };
+}
+
+function handleConfirmMove(state, command) {
+  const { playerId } = command;
+  assertActiveTurn(state, playerId);
+
+  const pending = state.match.pendingPreview;
+  if (!pending || pending.playerId !== playerId) {
+    throw new Error('No pending preview to confirm');
+  }
+
+  const hand = [...(state.match.handsByPlayerId[playerId] ?? [])];
+  const cardIndex = findCardIndexByRank(hand, pending.card);
+  if (cardIndex < 0) {
+    throw new Error(`Card ${pending.card} missing at confirm time`);
+  }
+
+  const [usedCard] = hand.splice(cardIndex, 1);
+  const handsByPlayerId = {
+    ...state.match.handsByPlayerId,
+    [playerId]: hand
+  };
+
+  const discarded = discardCards(state.match.deckState, [usedCard]);
+  const turnIndex = (state.match.turnIndex + 1) % state.match.turnOrder.length;
+
+  const nextState = withVersionBump({
+    ...state,
+    match: {
+      ...state.match,
+      gameState: pending.previewState,
+      pendingPreview: null,
+      handsByPlayerId,
+      deckState: discarded,
+      turnIndex
+    }
+  });
+
+  return {
+    state: nextState,
+    response: {
+      ok: true,
+      confirmed: true,
+      nextPlayerId: nextState.match.turnOrder[nextState.match.turnIndex],
+      version: nextState.version
+    }
+  };
+}
+
+export function handleRoomCommand(state, command) {
+  assertVersion(state, command.expectedVersion);
+
+  return withIdempotency(state, command.idempotencyKey, () => {
+    switch (command.type) {
+      case 'join_room':
+        return handleJoinRoom(state, command);
+      case 'set_ready':
+        return handleSetReady(state, command);
+      case 'start_match':
+        return handleStartMatch(state, command);
+      case 'request_legal_moves':
+        return handleRequestLegalMoves(state, command);
+      case 'start_move_preview':
+        return handleStartMovePreview(state, command);
+      case 'cancel_move_preview':
+        return handleCancelMovePreview(state, command);
+      case 'confirm_move':
+        return handleConfirmMove(state, command);
+      default:
+        throw new Error(`Unknown command: ${command.type}`);
+    }
+  });
+}
+
+export function evaluateCurrentTurnPlayability(state) {
+  if (state.status !== 'active') {
+    throw new Error('Match is not active');
+  }
+
+  const playerId = state.match.turnOrder[state.match.turnIndex];
+  const hand = state.match.handsByPlayerId[playerId].map((card) => card.rank);
+  return evaluateHandPlayability(state.match.gameState, playerId, hand);
+}

--- a/dog_game/tests/game-rules.test.js
+++ b/dog_game/tests/game-rules.test.js
@@ -68,6 +68,46 @@ test('King can exit start when piece is in start', () => {
   assert.equal(movedPiece.isImmune, true);
 });
 
+test('Ace can still exit start when normal on-board Ace moves are blocked by immune piece', () => {
+  const startIndexes = buildStartIndexes(4);
+
+  const blockedMover = {
+    ...createPieceInStart('P1-A', 'P1'),
+    isInStart: false,
+    isOnBoard: true,
+    position: 2
+  };
+
+  const startPiece = createPieceInStart('P1-B', 'P1');
+
+  const immuneBlocker = {
+    ...createPieceInStart('P2-A', 'P2'),
+    isInStart: false,
+    isOnBoard: true,
+    position: 3,
+    isImmune: true
+  };
+
+  const state = buildState({
+    trackLength: TRACK_SPACES_BETWEEN_PLAYERS * 4,
+    startIndexes,
+    pieces: [blockedMover, startPiece, immuneBlocker]
+  });
+
+  const moves = generateLegalMoves(state, 'P1', 'ACE');
+
+  assert.equal(
+    moves.some((move) => move.action === 'MOVE' && move.pieceId === 'P1-A'),
+    false,
+    'On-board ACE moves should be blocked by immune piece'
+  );
+  assert.equal(
+    moves.some((move) => move.action === 'EXIT_START' && move.pieceId === 'P1-B' && move.to === startIndexes.P1),
+    true,
+    'ACE exit-from-start option should remain legal'
+  );
+});
+
 test('4 backward wraps around board boundaries', () => {
   const startIndexes = buildStartIndexes(4);
   const piece = {
@@ -601,4 +641,89 @@ test('Seven split knocks passed pieces (including allied pieces) back to start',
   assert.equal(alliedAfter.isInStart, true);
   assert.equal(alliedAfter.isOnBoard, false);
   assert.equal(alliedAfter.position, null);
+});
+
+test('Seven split has no legal routes when immune blocker is on every first step', () => {
+  const startIndexes = buildStartIndexes(4);
+
+  const p1a = {
+    ...createPieceInStart('P1-A', 'P1'),
+    isInStart: false,
+    isOnBoard: true,
+    position: 0
+  };
+
+  const p1b = {
+    ...createPieceInStart('P1-B', 'P1'),
+    isInStart: false,
+    isOnBoard: true,
+    position: 10
+  };
+
+  const immuneAheadA = {
+    ...createPieceInStart('P2-A', 'P2'),
+    isInStart: false,
+    isOnBoard: true,
+    position: 1,
+    isImmune: true
+  };
+
+  const immuneAheadB = {
+    ...createPieceInStart('P2-B', 'P2'),
+    isInStart: false,
+    isOnBoard: true,
+    position: 11,
+    isImmune: true
+  };
+
+  const state = buildState({
+    trackLength: TRACK_SPACES_BETWEEN_PLAYERS * 4,
+    startIndexes,
+    pieces: [p1a, p1b, immuneAheadA, immuneAheadB]
+  });
+
+  const sevenMoves = generateLegalMoves(state, 'P1', 'SEVEN');
+  assert.equal(sevenMoves.length, 0);
+});
+
+test('Must-play remains true when hand has exactly one obscure legal move', () => {
+  const startIndexes = buildStartIndexes(4);
+
+  const myOnBoard = {
+    ...createPieceInStart('P1-A', 'P1'),
+    isInStart: false,
+    isOnBoard: true,
+    position: 1
+  };
+
+  const enemyImmuneForwardOne = {
+    ...createPieceInStart('P2-A', 'P2'),
+    isInStart: false,
+    isOnBoard: true,
+    position: 2,
+    isImmune: true
+  };
+
+  const enemyImmuneForwardEleven = {
+    ...createPieceInStart('P2-B', 'P2'),
+    isInStart: false,
+    isOnBoard: true,
+    position: 12,
+    isImmune: true
+  };
+
+  const state = buildState({
+    trackLength: TRACK_SPACES_BETWEEN_PLAYERS * 4,
+    startIndexes,
+    pieces: [myOnBoard, enemyImmuneForwardOne, enemyImmuneForwardEleven]
+  });
+
+  const hand = ['ACE', 'KING', 'FOUR'];
+  const result = evaluateHandPlayability(state, 'P1', hand);
+
+  assert.equal(result.hasAnyLegalMove, true);
+  assert.equal(result.perCardMoves.ACE.length, 0);
+  assert.equal(result.perCardMoves.KING.length, 0);
+  assert.equal(result.perCardMoves.FOUR.some((move) => move.steps === -4), true);
+  assert.equal(result.perCardMoves.FOUR.some((move) => move.steps === 4), false);
 });

--- a/dog_game/tests/room-engine.test.js
+++ b/dog_game/tests/room-engine.test.js
@@ -1,0 +1,221 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createRoom, evaluateCurrentTurnPlayability, handleRoomCommand } from '../services/realtime-server/room-engine.js';
+
+function bootstrapFourPlayerLobby() {
+  let state = createRoom({
+    roomId: 'ROOM1',
+    hostPlayerId: 'P1',
+    gameMode: 'solo',
+    teamCount: 4,
+    playersPerTeam: 1
+  });
+
+  state = handleRoomCommand(state, {
+    type: 'join_room',
+    playerId: 'P2',
+    teamNo: 2,
+    slotInTeam: 1,
+    expectedVersion: state.version
+  }).state;
+
+  state = handleRoomCommand(state, {
+    type: 'join_room',
+    playerId: 'P3',
+    teamNo: 3,
+    slotInTeam: 1,
+    expectedVersion: state.version
+  }).state;
+
+  state = handleRoomCommand(state, {
+    type: 'join_room',
+    playerId: 'P4',
+    teamNo: 4,
+    slotInTeam: 1,
+    expectedVersion: state.version
+  }).state;
+
+  for (const playerId of ['P1', 'P2', 'P3', 'P4']) {
+    state = handleRoomCommand(state, {
+      type: 'set_ready',
+      playerId,
+      isReady: true,
+      expectedVersion: state.version
+    }).state;
+  }
+
+  return state;
+}
+
+test('join_room enforces deterministic seat formula and version checks', () => {
+  let state = createRoom({
+    roomId: 'ROOM2',
+    hostPlayerId: 'P1',
+    gameMode: 'teams',
+    teamCount: 2,
+    playersPerTeam: 2
+  });
+
+  const join = handleRoomCommand(state, {
+    type: 'join_room',
+    playerId: 'P2',
+    teamNo: 2,
+    slotInTeam: 1,
+    expectedVersion: state.version
+  });
+
+  state = join.state;
+  assert.equal(join.response.seatNo, 2);
+
+  assert.throws(
+    () =>
+      handleRoomCommand(state, {
+        type: 'join_room',
+        playerId: 'P3',
+        teamNo: 1,
+        slotInTeam: 2,
+        expectedVersion: state.version - 1
+      }),
+    /Version mismatch/
+  );
+});
+
+test('start_match requires full ready lobby and produces deterministic first turn', () => {
+  let state = bootstrapFourPlayerLobby();
+
+  const start = handleRoomCommand(state, {
+    type: 'start_match',
+    playerId: 'P1',
+    expectedVersion: state.version
+  });
+
+  state = start.state;
+
+  assert.equal(start.response.started, true);
+  assert.equal(state.status, 'active');
+  assert.deepEqual(state.match.turnOrder, ['P1', 'P2', 'P3', 'P4']);
+  assert.equal(state.match.handsByPlayerId.P1.length, 6);
+});
+
+test('request_legal_moves + preview/cancel/confirm follows authoritative turn flow', () => {
+  let state = bootstrapFourPlayerLobby();
+  state = handleRoomCommand(state, {
+    type: 'start_match',
+    playerId: 'P1',
+    expectedVersion: state.version
+  }).state;
+
+  const activePlayerId = state.match.turnOrder[state.match.turnIndex];
+  const handRanks = state.match.handsByPlayerId[activePlayerId].map((card) => card.rank);
+
+  let card = null;
+  let legal = null;
+  for (const candidateCard of handRanks) {
+    const attempt = handleRoomCommand(state, {
+      type: 'request_legal_moves',
+      playerId: activePlayerId,
+      card: candidateCard,
+      expectedVersion: state.version
+    });
+
+    if (attempt.response.moves.length > 0) {
+      card = candidateCard;
+      legal = attempt;
+      break;
+    }
+  }
+
+  assert.ok(legal, 'Expected at least one legal move in active player hand');
+
+  const move = legal.response.moves[0];
+  assert.ok(move, 'Expected at least one legal move to preview');
+
+  const preview = handleRoomCommand(state, {
+    type: 'start_move_preview',
+    playerId: activePlayerId,
+    card,
+    move,
+    expectedVersion: state.version
+  });
+
+  state = preview.state;
+  assert.equal(state.match.pendingPreview.playerId, activePlayerId);
+
+  const cancel = handleRoomCommand(state, {
+    type: 'cancel_move_preview',
+    playerId: activePlayerId,
+    expectedVersion: state.version
+  });
+
+  state = cancel.state;
+  assert.equal(state.match.pendingPreview, null);
+
+  state = handleRoomCommand(state, {
+    type: 'start_move_preview',
+    playerId: activePlayerId,
+    card,
+    move,
+    expectedVersion: state.version
+  }).state;
+
+  const beforeConfirmCards = state.match.handsByPlayerId[activePlayerId].length;
+
+  const confirm = handleRoomCommand(state, {
+    type: 'confirm_move',
+    playerId: activePlayerId,
+    expectedVersion: state.version
+  });
+
+  state = confirm.state;
+
+  assert.equal(state.match.handsByPlayerId[activePlayerId].length, beforeConfirmCards - 1);
+  assert.equal(state.match.turnOrder[state.match.turnIndex], 'P2');
+});
+
+test('idempotency key returns stable response for duplicate command submissions', () => {
+  let state = createRoom({
+    roomId: 'ROOM3',
+    hostPlayerId: 'P1',
+    gameMode: 'solo',
+    teamCount: 4,
+    playersPerTeam: 1
+  });
+
+  const first = handleRoomCommand(state, {
+    type: 'join_room',
+    playerId: 'P2',
+    teamNo: 2,
+    slotInTeam: 1,
+    idempotencyKey: 'join-P2',
+    expectedVersion: state.version
+  });
+
+  state = first.state;
+
+  const second = handleRoomCommand(state, {
+    type: 'join_room',
+    playerId: 'P2',
+    teamNo: 2,
+    slotInTeam: 1,
+    idempotencyKey: 'join-P2',
+    expectedVersion: state.version
+  });
+
+  assert.deepEqual(second.response, first.response);
+  assert.equal(second.state.version, state.version);
+  assert.equal(second.state.players.length, state.players.length);
+});
+
+test('evaluateCurrentTurnPlayability reflects must-play / no-legal-move output shape', () => {
+  let state = bootstrapFourPlayerLobby();
+  state = handleRoomCommand(state, {
+    type: 'start_match',
+    playerId: 'P1',
+    expectedVersion: state.version
+  }).state;
+
+  const summary = evaluateCurrentTurnPlayability(state);
+  assert.equal(typeof summary.hasAnyLegalMove, 'boolean');
+  assert.equal(typeof summary.perCardMoves, 'object');
+});


### PR DESCRIPTION
### Motivation

- Provide a deterministic, server-side room/match engine that coordinates lobby and turn flow and integrates with the rules engine and deck logic. 
- Capture Phase 1 completion criteria and outstanding integration work in a checklist for tracking progress. 
- Expand rule-suite coverage for subtle interactions (immune blockers, seven-split, must-play semantics) to ensure move-generation correctness. 

### Description

- Add `services/realtime-server/room-engine.js` implementing `createRoom`, `handleRoomCommand`, idempotency support, optimistic version checks, match lifecycle (`start_match`), turn flow, legal-move requests, move preview lifecycle (`start_move_preview`, `cancel_move_preview`, `confirm_move`) and `evaluateCurrentTurnPlayability`. 
- Integrate the engine with the rules package calls `generateLegalMoves`, `applyMovePreview`, `evaluateHandPlayability`, and deck helpers `createDeckState`, `dealRoundHands`, `discardCards`. 
- Add `PHASE1_STATUS.md` to document Phase 1 goals, completed rule items, edge-case coverage, and deferred Phase 3 concerns. 
- Extend tests in `tests/game-rules.test.js` with edge cases for ACE exit-from-start when on-board moves are blocked, seven-split blocked by immune pieces, and must-play behavior for obscure moves, and add new `tests/room-engine.test.js` to validate lobby, deterministic seating, start-match, request/preview/cancel/confirm flows, idempotency behavior, and `evaluateCurrentTurnPlayability` output shape. 

### Testing

- Ran the rules unit tests with `node --test dog_game/tests/game-rules.test.js` and they passed. 
- Ran the realtime engine tests with `node --test dog_game/tests/room-engine.test.js` and they passed. 
- Ran the combined test suite (project test runner) with `npm test` and all tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b83f8bd5548333b39c52dac962c297)