### PR TITLE
Invite URL handling, winner detection on confirm, CORS-aware edge handler, and tests

### DIFF
--- a/dog_game/NEXT_ROUND_LIVE_MILESTONE.md
+++ b/dog_game/NEXT_ROUND_LIVE_MILESTONE.md
@@ -1,0 +1,102 @@
+# Next round milestone: playable 4-player live game
+
+This milestone defines the minimum deliverables needed so a host can:
+
+1. create a room for four players,
+2. share an invite URL to three friends,
+3. start a match,
+4. play the match to completion.
+
+## Definition of done
+
+A milestone pass requires all items below in one deployed environment (staging is fine):
+
+- Host can create a 4-player room and receives a room code.
+- Host sees a copy/shareable invite URL in the client.
+- Three remote players can open the invite URL, authenticate, and join successfully.
+- All four players can mark ready.
+- Host can start match when room is full + all ready.
+- Turn flow runs with authoritative command handling until a winner is detected.
+- At least one reconnect is tested during an active turn without desync.
+- Opponent card privacy is validated in network payloads.
+
+## Scope for the next coding round
+
+### A) Invite URL and room entry UX
+
+- Add a minimal playable `/dog` UI route with:
+  - `Create 4-player room` action,
+  - visible room code,
+  - `Copy invite URL` action,
+  - room lobby roster/ready state.
+- Invite URL format should include room identity (`roomId` or `roomCode`) and open directly into join flow.
+- Join flow should validate room existence and return a user-safe error message when invalid/expired.
+
+### B) Command plumbing to authoritative backend
+
+- Wire client intents to Edge handler command endpoint:
+  - `create_room`
+  - `join_room`
+  - `set_ready`
+  - `start_match`
+  - `request_legal_moves`
+  - `start_move_preview`
+  - `cancel_move_preview`
+  - `confirm_move`
+- Ensure each write intent includes idempotency key + expected room/match version where applicable.
+
+### C) Realtime subscriptions and rendering
+
+- Subscribe clients to room events over Supabase Realtime.
+- Apply incoming snapshots/events to UI state.
+- Render these minimum panels:
+  - room/lobby status,
+  - current turn + active player,
+  - local hand,
+  - legal move options + confirm/cancel controls,
+  - winner/end-state banner.
+
+### D) Match completion flow
+
+- Detect and render winner from authoritative events.
+- Disable move actions after terminal state.
+- Keep final board state visible for all players.
+
+### E) Hardening needed for first live pilot
+
+- Validate environment variables for Supabase URL/keys and handler config.
+- Add request validation + basic rate-limiting at command ingress.
+- Confirm public/private payload projection in realtime events (no opponent hand leaks).
+
+## Test checklist required in same PR/round
+
+- Unit/integration tests continue passing (`npm test` in `dog_game`).
+- New integration test for invite URL parse + join flow happy path.
+- New integration test for full 4-player lobby lifecycle:
+  - create, join x3, ready x4, start.
+- New integration test for playing to terminal winner in room engine path.
+- Manual staging smoke run with 4 real browsers/users.
+
+## Suggested implementation order
+
+1. `/dog` minimal lobby UI (create/join/ready/start only).
+2. Realtime subscription + lobby synchronization.
+3. Turn UI for request_legal_moves + preview/confirm cycle.
+4. Winner/end-state rendering.
+5. Reconnect and privacy validation.
+
+## Out of scope for this milestone
+
+- Spectators
+- Advanced animations
+- Social/friends features
+- Match history UI polish
+
+## Exit criteria for "ready to test a full round"
+
+Declare ready only when all are true:
+
+- 4-player create/join/start works from invite URL in staging.
+- Full round can be completed with legal move flow (preview/confirm) and winner broadcast.
+- Reconnect once during active turn is successful.
+- No hidden-information leakage observed in payload inspection.

--- a/dog_game/services/realtime-server/invite-url.js
+++ b/dog_game/services/realtime-server/invite-url.js
@@ -1,0 +1,45 @@
+const ROOM_QUERY_KEY = 'room';
+
+/**
+ * @param {{ baseUrl: string, roomId: string }} params
+ */
+export function buildInviteUrl(params) {
+  const { baseUrl, roomId } = params;
+
+  if (!baseUrl || typeof baseUrl !== 'string') {
+    throw new Error('baseUrl is required');
+  }
+
+  if (!roomId || typeof roomId !== 'string') {
+    throw new Error('roomId is required');
+  }
+
+  const url = new URL('/dog', ensureTrailingSlash(baseUrl));
+  url.searchParams.set(ROOM_QUERY_KEY, roomId);
+  return url.toString();
+}
+
+/**
+ * @param {string} inviteUrl
+ */
+export function parseInviteUrl(inviteUrl) {
+  if (!inviteUrl || typeof inviteUrl !== 'string') {
+    throw new Error('inviteUrl is required');
+  }
+
+  const url = new URL(inviteUrl);
+  const roomId = url.searchParams.get(ROOM_QUERY_KEY);
+
+  if (!roomId) {
+    throw new Error('Invite URL is missing room');
+  }
+
+  return {
+    roomId,
+    path: url.pathname
+  };
+}
+
+function ensureTrailingSlash(value) {
+  return value.endsWith('/') ? value : `${value}/`;
+}

--- a/dog_game/services/realtime-server/room-engine.js
+++ b/dog_game/services/realtime-server/room-engine.js
@@ -6,6 +6,7 @@ import {
   generateLegalMoves,
   TRACK_SPACES_BETWEEN_PLAYERS
 } from '../../packages/game-rules/index.js';
+import { detectWinner } from '../../packages/game-rules/phase2.js';
 import {
   applyTeamCardExchange,
   createDeckState,
@@ -139,7 +140,8 @@ function createMatch(room) {
 
   return {
     ...roundState,
-    gameState: buildGameStateFromPlayers(ordered)
+    gameState: buildGameStateFromPlayers(ordered),
+    winner: null
   };
 }
 
@@ -584,11 +586,47 @@ function handleConfirmMove(state, command) {
   };
 
   const deckState = discardCards(state.match.deckState, [usedCard]);
+  const movedGameState = pending.previewState;
+  const teamByPlayerId = getTeamByPlayerId(state.players);
+  const winner = detectWinner({
+    gameMode: state.config.gameMode,
+    pieces: movedGameState.pieces,
+    playerIds: state.match.turnOrder,
+    teamByPlayerId
+  });
+
+  if (winner) {
+    const nextState = withVersionBump({
+      ...state,
+      status: 'finished',
+      match: {
+        ...state.match,
+        gameState: movedGameState,
+        pendingPreview: null,
+        handsByPlayerId,
+        deckState,
+        phase: 'finished',
+        winner
+      }
+    });
+
+    return {
+      state: nextState,
+      response: {
+        ok: true,
+        confirmed: true,
+        gameFinished: true,
+        winner,
+        version: nextState.version
+      }
+    };
+  }
+
   let nextState = withVersionBump({
     ...state,
     match: {
       ...state.match,
-      gameState: pending.previewState,
+      gameState: movedGameState,
       pendingPreview: null,
       handsByPlayerId,
       deckState,
@@ -703,7 +741,8 @@ export function getPublicRoomView(state) {
           blockedPlayerIds: [...state.match.blockedPlayerIds],
           handCountsByPlayerId: Object.fromEntries(
             Object.entries(state.match.handsByPlayerId).map(([playerId, hand]) => [playerId, hand.length])
-          )
+          ),
+          winner: state.match.winner ?? null
         }
       : null
   };

--- a/dog_game/services/realtime-server/supabase-edge-handler.js
+++ b/dog_game/services/realtime-server/supabase-edge-handler.js
@@ -1,4 +1,19 @@
 /**
+ * @param {Request} request
+ */
+function buildCorsHeaders(request) {
+  const origin = request.headers.get('origin') ?? '*';
+
+  return {
+    'access-control-allow-origin': origin,
+    'access-control-allow-methods': 'POST, OPTIONS',
+    'access-control-allow-headers': 'authorization, x-client-info, apikey, content-type',
+    'access-control-max-age': '86400',
+    vary: 'origin'
+  };
+}
+
+/**
  * @param {unknown} payload
  */
 function validateCommandPayload(payload) {
@@ -14,6 +29,31 @@ function validateCommandPayload(payload) {
 }
 
 /**
+ * @param {Request} request
+ * @param {any} body
+ * @param {number} status
+ */
+function jsonResponse(request, body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'content-type': 'application/json',
+      ...buildCorsHeaders(request)
+    }
+  });
+}
+
+/**
+ * @param {Request} request
+ */
+function preflightResponse(request) {
+  return new Response(null, {
+    status: 204,
+    headers: buildCorsHeaders(request)
+  });
+}
+
+/**
  * @param {{
  *  request: Request,
  *  roomService: { processRoomCommand: (command:any)=>Promise<any>, attach: (roomId:string, playerId?:string)=>Promise<any> }
@@ -22,32 +62,28 @@ function validateCommandPayload(payload) {
 export async function handleEdgeRoomRequest(params) {
   const { request, roomService } = params;
 
+  if (request.method === 'OPTIONS') {
+    return preflightResponse(request);
+  }
+
   try {
     const payload = validateCommandPayload(await request.json());
 
     if (payload.type === 'attach') {
       const result = await roomService.attach(payload.roomId, payload.playerId);
-      return new Response(JSON.stringify({ ok: true, result }), {
-        status: 200,
-        headers: { 'content-type': 'application/json' }
-      });
+      return jsonResponse(request, { ok: true, result }, 200);
     }
 
     const result = await roomService.processRoomCommand(payload);
-    return new Response(JSON.stringify({ ok: true, result }), {
-      status: 200,
-      headers: { 'content-type': 'application/json' }
-    });
+    return jsonResponse(request, { ok: true, result }, 200);
   } catch (error) {
-    return new Response(
-      JSON.stringify({
+    return jsonResponse(
+      request,
+      {
         ok: false,
         error: error instanceof Error ? error.message : String(error)
-      }),
-      {
-        status: 400,
-        headers: { 'content-type': 'application/json' }
-      }
+      },
+      400
     );
   }
 }

--- a/dog_game/services/realtime-server/supabase-room-service.js
+++ b/dog_game/services/realtime-server/supabase-room-service.js
@@ -4,6 +4,7 @@ import {
   getPublicRoomView,
   handleRoomCommand
 } from './room-engine.js';
+import { buildInviteUrl } from './invite-url.js';
 
 function toEvent(type, roomId, payload) {
   return {
@@ -73,9 +74,13 @@ export function createSupabaseRoomService(deps) {
       roomId: command.roomId
     });
 
+    const inviteUrl = command.clientBaseUrl
+      ? buildInviteUrl({ baseUrl: command.clientBaseUrl, roomId: command.roomId })
+      : null;
+
     return {
       roomId: command.roomId,
-      response: { ok: true, roomId: command.roomId },
+      response: { ok: true, roomId: command.roomId, inviteUrl },
       public: getPublicRoomView(state),
       private: command.playerId ? getPlayerPrivateView(state, command.playerId).private : null
     };
@@ -90,7 +95,8 @@ export function createSupabaseRoomService(deps) {
         gameMode: command.gameMode,
         teamCount: command.teamCount,
         playersPerTeam: command.playersPerTeam,
-        idempotencyKey: command.idempotencyKey
+        idempotencyKey: command.idempotencyKey,
+        clientBaseUrl: command.clientBaseUrl
       });
     }
 

--- a/dog_game/tests/invite-url.test.js
+++ b/dog_game/tests/invite-url.test.js
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildInviteUrl, parseInviteUrl } from '../services/realtime-server/invite-url.js';
+
+test('buildInviteUrl returns /dog URL with room query param', () => {
+  const inviteUrl = buildInviteUrl({
+    baseUrl: 'https://sarcasm.games',
+    roomId: 'DOG-ROOM-42'
+  });
+
+  assert.equal(inviteUrl, 'https://sarcasm.games/dog?room=DOG-ROOM-42');
+});
+
+test('parseInviteUrl extracts roomId from invite URL', () => {
+  const parsed = parseInviteUrl('https://sarcasm.games/dog?room=DOG-ROOM-42');
+
+  assert.equal(parsed.roomId, 'DOG-ROOM-42');
+  assert.equal(parsed.path, '/dog');
+});
+

--- a/dog_game/tests/room-engine.test.js
+++ b/dog_game/tests/room-engine.test.js
@@ -356,3 +356,92 @@ test('evaluateCurrentTurnPlayability reflects must-play / no-legal-move output s
   assert.equal(typeof summary.hasAnyLegalMove, 'boolean');
   assert.equal(typeof summary.perCardMoves, 'object');
 });
+
+
+test('confirm_move finishes match when winning move sends final piece home', () => {
+  let state = bootstrapFourPlayerLobby();
+  state = handleRoomCommand(state, {
+    type: 'start_match',
+    playerId: 'P1',
+    expectedVersion: state.version
+  }).state;
+
+  // Force deterministic near-win state for P1.
+  const homeEntry = (state.match.gameState.startIndexes.P1 - 1 + state.match.gameState.trackLength) % state.match.gameState.trackLength;
+  state.match.gameState.homeLanes = {
+    P1: [0, 1, 2, 3],
+    P2: [0, 1, 2, 3],
+    P3: [0, 1, 2, 3],
+    P4: [0, 1, 2, 3]
+  };
+  state.match.gameState.homeEntryIndexes = {
+    P1: homeEntry,
+    P2: (state.match.gameState.startIndexes.P2 - 1 + state.match.gameState.trackLength) % state.match.gameState.trackLength,
+    P3: (state.match.gameState.startIndexes.P3 - 1 + state.match.gameState.trackLength) % state.match.gameState.trackLength,
+    P4: (state.match.gameState.startIndexes.P4 - 1 + state.match.gameState.trackLength) % state.match.gameState.trackLength
+  };
+
+  let occupiedHomeIndex = 1;
+  for (const piece of state.match.gameState.pieces) {
+    if (piece.ownerId !== 'P1') {
+      continue;
+    }
+
+    if (piece.id === 'P1-4') {
+      piece.isInStart = false;
+      piece.isOnBoard = true;
+      piece.isInHome = false;
+      piece.homeIndex = null;
+      piece.position = homeEntry;
+      piece.hasCompletedLap = true;
+      piece.isImmune = false;
+      continue;
+    }
+
+    piece.isInStart = false;
+    piece.isOnBoard = false;
+    piece.isInHome = true;
+    piece.homeIndex = occupiedHomeIndex;
+    piece.position = null;
+    piece.hasCompletedLap = true;
+    piece.isImmune = false;
+    occupiedHomeIndex += 1;
+  }
+
+  state.match.handsByPlayerId.P1 = [{ id: 'P1-ACE', rank: 'ACE', suit: 'SPADES' }];
+  state.match.turnIndex = 0;
+
+  const legal = handleRoomCommand(state, {
+    type: 'request_legal_moves',
+    playerId: 'P1',
+    card: 'ACE',
+    expectedVersion: state.version
+  });
+
+  const winningMove = legal.response.moves.find((move) => move.pieceId === 'P1-4' && move.toHomeIndex === 0);
+  assert.ok(winningMove);
+
+  state = handleRoomCommand(state, {
+    type: 'start_move_preview',
+    playerId: 'P1',
+    card: 'ACE',
+    move: winningMove,
+    expectedVersion: state.version
+  }).state;
+
+  const confirmed = handleRoomCommand(state, {
+    type: 'confirm_move',
+    playerId: 'P1',
+    expectedVersion: state.version
+  });
+
+  state = confirmed.state;
+
+  assert.equal(confirmed.response.gameFinished, true);
+  assert.deepEqual(confirmed.response.winner, { winnerType: 'PLAYER', playerId: 'P1' });
+  assert.equal(state.status, 'finished');
+  assert.equal(state.match.phase, 'finished');
+
+  const publicView = getPublicRoomView(state);
+  assert.deepEqual(publicView.match.winner, { winnerType: 'PLAYER', playerId: 'P1' });
+});

--- a/dog_game/tests/supabase-room-service.test.js
+++ b/dog_game/tests/supabase-room-service.test.js
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 
 import { handleEdgeRoomRequest } from '../services/realtime-server/supabase-edge-handler.js';
 import { createSupabaseRoomService } from '../services/realtime-server/supabase-room-service.js';
+import { parseInviteUrl } from '../services/realtime-server/invite-url.js';
 
 function createInMemoryStore() {
   const states = new Map();
@@ -99,6 +100,44 @@ test('supabase room service can create room and process join/ready/start command
   assert.equal(publisher.playerSnapshots.some((item) => item.playerId === 'P1'), true);
 });
 
+
+
+test('create_room returns invite URL that can be parsed and used for join flow', async () => {
+  const store = createInMemoryStore();
+  const service = createSupabaseRoomService({
+    store,
+    publisher: createPublisherSpy()
+  });
+
+  const created = await service.processRoomCommand({
+    type: 'create_room',
+    roomId: 'DOG-INV-1',
+    playerId: 'P1',
+    gameMode: 'solo',
+    teamCount: 4,
+    playersPerTeam: 1,
+    clientBaseUrl: 'https://sarcasm.games'
+  });
+
+  const inviteUrl = created.response.inviteUrl;
+  assert.ok(inviteUrl);
+
+  const parsed = parseInviteUrl(inviteUrl);
+  assert.equal(parsed.roomId, 'DOG-INV-1');
+
+  const joined = await service.processRoomCommand({
+    type: 'join_room',
+    roomId: parsed.roomId,
+    playerId: 'P2',
+    teamNo: 2,
+    slotInTeam: 1
+  });
+
+  assert.equal(joined.response.ok, true);
+  assert.equal(joined.response.joined, true);
+  assert.equal(joined.public.players.length, 2);
+});
+
 test('attach returns public and private snapshot for reconnecting player', async () => {
   const service = createSupabaseRoomService({
     store: createInMemoryStore(),
@@ -153,4 +192,56 @@ test('edge handler routes command payloads and returns json responses', async ()
   assert.equal(attachRes.status, 200);
   assert.equal(attachBody.ok, true);
   assert.equal(attachBody.result.private.playerId, 'P1');
+});
+
+
+test('edge handler responds to CORS preflight OPTIONS requests', async () => {
+  const service = createSupabaseRoomService({
+    store: createInMemoryStore(),
+    publisher: createPublisherSpy()
+  });
+
+  const preflightReq = new Request('http://localhost/room-command', {
+    method: 'OPTIONS',
+    headers: {
+      origin: 'https://www.sarcasm.games',
+      'access-control-request-method': 'POST',
+      'access-control-request-headers': 'content-type, apikey'
+    }
+  });
+
+  const preflightRes = await handleEdgeRoomRequest({ request: preflightReq, roomService: service });
+
+  assert.equal(preflightRes.status, 204);
+  assert.equal(preflightRes.headers.get('access-control-allow-origin'), 'https://www.sarcasm.games');
+  assert.equal(preflightRes.headers.get('access-control-allow-methods'), 'POST, OPTIONS');
+});
+
+test('edge handler includes CORS headers on POST responses', async () => {
+  const service = createSupabaseRoomService({
+    store: createInMemoryStore(),
+    publisher: createPublisherSpy()
+  });
+
+  const createReq = new Request('http://localhost/room-command', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      origin: 'https://www.sarcasm.games'
+    },
+    body: JSON.stringify({
+      type: 'create_room',
+      roomId: 'DOG-CORS-1',
+      playerId: 'P1',
+      gameMode: 'solo',
+      teamCount: 4,
+      playersPerTeam: 1
+    })
+  });
+
+  const createRes = await handleEdgeRoomRequest({ request: createReq, roomService: service });
+
+  assert.equal(createRes.status, 200);
+  assert.equal(createRes.headers.get('access-control-allow-origin'), 'https://www.sarcasm.games');
+  assert.equal(createRes.headers.get('access-control-allow-methods'), 'POST, OPTIONS');
 });


### PR DESCRIPTION
### Motivation

- Provide invite URL support so clients can create/share room links and join directly via `/dog` query params.
- Ensure the authoritative room engine can detect and end a match when a confirmed move produces a winner. 
- Harden the Supabase edge handler to return JSON consistently and support CORS preflight requests. 

### Description

- Add `invite-url.js` with `buildInviteUrl` and `parseInviteUrl` to generate and parse `/dog?room=...` links and wire `clientBaseUrl` through `create_room` responses. 
- Extend `room-engine.js` to call `detectWinner` on `confirm_move`, set `winner` and terminal `status`/`phase` when a winning move is confirmed, and expose `winner` in public projections. 
- Update `supabase-edge-handler.js` to return JSON responses via `jsonResponse` and handle CORS preflight `OPTIONS` via `preflightResponse` with proper headers. 
- Update `supabase-room-service.js` to include `inviteUrl` in the `create_room` response when `clientBaseUrl` is provided. 
- Add milestone doc `NEXT_ROUND_LIVE_MILESTONE.md` describing the next-round playable 4-player live game deliverables. 
- Add/expand tests: `tests/invite-url.test.js`, new match-finish scenario in `tests/room-engine.test.js`, and additional `tests/supabase-room-service.test.js` cases for invite URL parsing and CORS behavior. 

### Testing

- Ran the test suite under `dog_game` using the repository test harness which executed the new and existing `node:test` suites. 
- `tests/invite-url.test.js` validated URL build/parse and passed. 
- `tests/room-engine.test.js` included the new `confirm_move` winner scenario and passed. 
- `tests/supabase-room-service.test.js` exercised `handleEdgeRoomRequest` JSON responses, CORS preflight handling, and invite-based join flow and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b891aeb2488333ac6085e735e2e451)