### PR TITLE
Bytt autentisering til Supabase

### DIFF
--- a/api/_lib/auth.js
+++ b/api/_lib/auth.js
@@ -1,31 +1,9 @@
-const { SignJWT, jwtVerify } = require('jose');
-const { getUserById } = require('./db');
+const { getUserByAuthUserId } = require('./db');
+const { getSupabaseAnonClient } = require('./supabase');
 
-const COOKIE_NAME = 'sg_session';
-const SESSION_TTL_SECONDS = 60 * 60 * 24 * 7;
-
-function getJwtSecret() {
-  const secret = process.env.AUTH_SECRET || process.env.NEXTAUTH_SECRET;
-  if (!secret) {
-    throw new Error('Missing AUTH_SECRET (or NEXTAUTH_SECRET) environment variable.');
-  }
-  return new TextEncoder().encode(secret);
-}
-
-async function signSessionToken(payload) {
-  const secret = getJwtSecret();
-  return new SignJWT(payload)
-    .setProtectedHeader({ alg: 'HS256' })
-    .setIssuedAt()
-    .setExpirationTime(`${SESSION_TTL_SECONDS}s`)
-    .sign(secret);
-}
-
-async function verifySessionToken(token) {
-  const secret = getJwtSecret();
-  const { payload } = await jwtVerify(token, secret);
-  return payload;
-}
+const ACCESS_COOKIE_NAME = 'sg_sb_access_token';
+const REFRESH_COOKIE_NAME = 'sg_sb_refresh_token';
+const COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 7;
 
 function parseCookies(req) {
   const rawCookie = req.headers.cookie || '';
@@ -38,69 +16,91 @@ function parseCookies(req) {
   return cookies;
 }
 
-function setSessionCookie(res, token) {
+function createCookie(name, value, maxAge) {
   const secure = process.env.NODE_ENV === 'production';
-  const cookie = [
-    `${COOKIE_NAME}=${encodeURIComponent(token)}`,
+  return [
+    `${name}=${encodeURIComponent(value)}`,
     'Path=/',
     'HttpOnly',
     'SameSite=Lax',
-    `Max-Age=${SESSION_TTL_SECONDS}`,
+    `Max-Age=${maxAge}`,
     secure ? 'Secure' : null
   ]
     .filter(Boolean)
     .join('; ');
-  res.setHeader('Set-Cookie', cookie);
+}
+
+function setAuthCookies(res, session) {
+  res.setHeader('Set-Cookie', [
+    createCookie(ACCESS_COOKIE_NAME, session.access_token, session.expires_in || COOKIE_MAX_AGE_SECONDS),
+    createCookie(REFRESH_COOKIE_NAME, session.refresh_token, COOKIE_MAX_AGE_SECONDS)
+  ]);
 }
 
 function clearSessionCookie(res) {
-  const secure = process.env.NODE_ENV === 'production';
-  const cookie = [
-    `${COOKIE_NAME}=`,
-    'Path=/',
-    'HttpOnly',
-    'SameSite=Lax',
-    'Max-Age=0',
-    secure ? 'Secure' : null
-  ]
-    .filter(Boolean)
-    .join('; ');
-  res.setHeader('Set-Cookie', cookie);
+  res.setHeader('Set-Cookie', [
+    createCookie(ACCESS_COOKIE_NAME, '', 0),
+    createCookie(REFRESH_COOKIE_NAME, '', 0)
+  ]);
+}
+
+async function getSessionFromCookies(req, res, { allowRefresh = true } = {}) {
+  const cookies = parseCookies(req);
+  const accessToken = cookies[ACCESS_COOKIE_NAME];
+  const refreshToken = cookies[REFRESH_COOKIE_NAME];
+
+  if (!accessToken && !refreshToken) {
+    return null;
+  }
+
+  const supabase = getSupabaseAnonClient();
+  let authUser = null;
+  let activeAccessToken = accessToken || null;
+
+  if (accessToken) {
+    const { data, error } = await supabase.auth.getUser(accessToken);
+    if (!error && data?.user) {
+      authUser = data.user;
+    }
+  }
+
+  if (!authUser && allowRefresh && refreshToken) {
+    const { data, error } = await supabase.auth.refreshSession({ refresh_token: refreshToken });
+    if (!error && data?.session?.access_token && data?.user) {
+      setAuthCookies(res, data.session);
+      authUser = data.user;
+      activeAccessToken = data.session.access_token;
+    }
+  }
+
+  if (!authUser?.id) {
+    return null;
+  }
+
+  const user = await getUserByAuthUserId(authUser.id);
+  if (!user) {
+    return null;
+  }
+
+  return {
+    id: user.id,
+    authUserId: authUser.id,
+    accessToken: activeAccessToken,
+    username: user.username,
+    email: user.email || authUser.email,
+    role: user.role,
+    country: user.country || 'unknown'
+  };
 }
 
 async function requireSession(req, res) {
   try {
-    const cookies = parseCookies(req);
-    const token = cookies[COOKIE_NAME];
-    if (!token) {
-      res.status(401).json({ error: 'Not authenticated' });
-      return null;
-    }
+    const session = await getSessionFromCookies(req, res);
+    if (session) return session;
 
-    const payload = await verifySessionToken(token);
-    const userId = Number(payload.id || payload.sub);
-    if (!Number.isInteger(userId)) {
-      clearSessionCookie(res);
-      res.status(401).json({ error: 'Invalid session' });
-      return null;
-    }
-
-    const user = await getUserById(userId);
-    if (!user) {
-      clearSessionCookie(res);
-      res.status(401).json({ error: 'Invalid session' });
-      return null;
-    }
-
-    return {
-      ...payload,
-      id: user.id,
-      sub: String(user.id),
-      username: user.username,
-      email: user.email,
-      role: user.role,
-      country: user.country || 'unknown'
-    };
+    clearSessionCookie(res);
+    res.status(401).json({ error: 'Not authenticated' });
+    return null;
   } catch (error) {
     clearSessionCookie(res);
     res.status(401).json({ error: 'Invalid session' });
@@ -109,11 +109,11 @@ async function requireSession(req, res) {
 }
 
 module.exports = {
-  COOKIE_NAME,
-  signSessionToken,
-  verifySessionToken,
+  ACCESS_COOKIE_NAME,
+  REFRESH_COOKIE_NAME,
   parseCookies,
-  setSessionCookie,
+  setAuthCookies,
   clearSessionCookie,
+  getSessionFromCookies,
   requireSession
 };

--- a/api/_lib/db.js
+++ b/api/_lib/db.js
@@ -124,74 +124,89 @@ async function runQuery(text, params = []) {
   }
 }
 
+function mapUserRow(row) {
+  if (!row) return null;
+  return {
+    id: row.id,
+    auth_user_id: row.auth_user_id,
+    username: row.username,
+    email: row.email,
+    role: row.role,
+    country: row.country,
+    created_at: row.created_at,
+    updated_at: row.updated_at
+  };
+}
+
 async function getUserByEmail(email) {
   const result = await runQuery(
-    `SELECT id, username, email, password_hash, role, country, created_at, updated_at
+    `SELECT id, auth_user_id, username, email, role, country, created_at, updated_at
      FROM users
      WHERE LOWER(email) = LOWER($1)
      LIMIT 1`,
     [email]
   );
-  return result.rows[0] || null;
+  return mapUserRow(result.rows[0]);
 }
 
 async function getUserByUsername(username) {
   const result = await runQuery(
-    `SELECT id, username, email, password_hash, role, country, created_at, updated_at
+    `SELECT id, auth_user_id, username, email, role, country, created_at, updated_at
      FROM users
      WHERE LOWER(username) = LOWER($1)
      LIMIT 1`,
     [username]
   );
-  return result.rows[0] || null;
+  return mapUserRow(result.rows[0]);
 }
 
 async function getUserById(id) {
   const result = await runQuery(
-    `SELECT id, username, email, password_hash, role, country, created_at, updated_at
+    `SELECT id, auth_user_id, username, email, role, country, created_at, updated_at
      FROM users
      WHERE id = $1
      LIMIT 1`,
     [id]
   );
-  return result.rows[0] || null;
+  return mapUserRow(result.rows[0]);
 }
 
-async function insertUser({ username, email, passwordHash, role = 'user', country }) {
+async function getUserByAuthUserId(authUserId) {
   const result = await runQuery(
-    `INSERT INTO users (username, email, password_hash, role, country)
-     VALUES ($1, $2, $3, $4, $5)
-     RETURNING id, username, email, role, country, created_at, updated_at`,
-    [username, email, passwordHash, role, country]
+    `SELECT id, auth_user_id, username, email, role, country, created_at, updated_at
+     FROM users
+     WHERE auth_user_id = $1
+     LIMIT 1`,
+    [authUserId]
   );
-  return result.rows[0];
+  return mapUserRow(result.rows[0]);
 }
 
-async function updatePasswordByUserId(userId, passwordHash) {
-  await runQuery(
-    `UPDATE users
-     SET password_hash = $1
-     WHERE id = $2`,
-    [passwordHash, userId]
+async function insertUser({ authUserId, username, email, role = 'user', country }) {
+  const result = await runQuery(
+    `INSERT INTO users (auth_user_id, username, email, role, country)
+     VALUES ($1, $2, $3, $4, $5)
+     RETURNING id, auth_user_id, username, email, role, country, created_at, updated_at`,
+    [authUserId, username, email, role, country]
   );
+  return mapUserRow(result.rows[0]);
 }
 
 async function getUsersForAdminList() {
   const result = await runQuery(
-    `SELECT id, username, email, role, country, created_at, updated_at
+    `SELECT id, auth_user_id, username, email, role, country, created_at, updated_at
      FROM users
      ORDER BY created_at DESC`
   );
-  return result.rows;
+  return result.rows.map((row) => mapUserRow(row));
 }
-
 
 module.exports = {
   runQuery,
   getUserByEmail,
   getUserByUsername,
   getUserById,
+  getUserByAuthUserId,
   insertUser,
-  updatePasswordByUserId,
   getUsersForAdminList
 };

--- a/api/_lib/supabase.js
+++ b/api/_lib/supabase.js
@@ -1,0 +1,49 @@
+const { createClient } = require('@supabase/supabase-js');
+
+function getSupabaseUrl() {
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  if (!url) {
+    throw new Error('Missing SUPABASE_URL (or NEXT_PUBLIC_SUPABASE_URL) environment variable.');
+  }
+  return url;
+}
+
+function getSupabaseAnonKey() {
+  const key = process.env.SUPABASE_ANON_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  if (!key) {
+    throw new Error('Missing SUPABASE_ANON_KEY (or NEXT_PUBLIC_SUPABASE_ANON_KEY) environment variable.');
+  }
+  return key;
+}
+
+function getSupabaseServiceRoleKey() {
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!key) {
+    throw new Error('Missing SUPABASE_SERVICE_ROLE_KEY environment variable.');
+  }
+  return key;
+}
+
+function createSupabaseClient(key, options = {}) {
+  return createClient(getSupabaseUrl(), key, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+      detectSessionInUrl: false
+    },
+    ...options
+  });
+}
+
+function getSupabaseAnonClient() {
+  return createSupabaseClient(getSupabaseAnonKey());
+}
+
+function getSupabaseAdminClient() {
+  return createSupabaseClient(getSupabaseServiceRoleKey());
+}
+
+module.exports = {
+  getSupabaseAnonClient,
+  getSupabaseAdminClient
+};

--- a/api/auth/login.js
+++ b/api/auth/login.js
@@ -32,12 +32,6 @@ module.exports = async function handler(req, res) {
       return;
     }
 
-    if (!process.env.AUTH_SECRET && !process.env.NEXTAUTH_SECRET) {
-      console.error('[auth/login] Missing AUTH_SECRET or NEXTAUTH_SECRET environment variable.');
-      res.status(500).json({ error: 'Server auth secret is not configured.' });
-      return;
-    }
-
     if (!username || !password) {
       res.status(400).json({ error: 'username and password are required' });
       return;
@@ -56,41 +50,37 @@ module.exports = async function handler(req, res) {
       return;
     }
 
-    const bcrypt = require('bcryptjs');
     const { getUserByUsername } = require('../_lib/db');
-    const { setSessionCookie, signSessionToken } = require('../_lib/auth');
+    const { setAuthCookies } = require('../_lib/auth');
+    const { getSupabaseAnonClient } = require('../_lib/supabase');
 
     const normalizedUsername = trimmedUsername.toLowerCase();
-    const user = await getUserByUsername(normalizedUsername);
-    if (!user || !user.password_hash) {
+    const profile = await getUserByUsername(normalizedUsername);
+    if (!profile?.email) {
       res.status(401).json({ error: 'Invalid username or password' });
       return;
     }
 
-    const passwordOk = await bcrypt.compare(rawPassword, user.password_hash);
-    if (!passwordOk) {
-      res.status(401).json({ error: 'Invalid username or password' });
-      return;
-    }
-
-    const token = await signSessionToken({
-      sub: String(user.id),
-      id: user.id,
-      username: user.username,
-      email: user.email,
-      role: user.role,
-      country: user.country || 'unknown'
+    const supabase = getSupabaseAnonClient();
+    const { data, error } = await supabase.auth.signInWithPassword({
+      email: profile.email,
+      password: rawPassword
     });
 
-    setSessionCookie(res, token);
+    if (error || !data?.session || !data?.user) {
+      res.status(401).json({ error: 'Invalid username or password' });
+      return;
+    }
+
+    setAuthCookies(res, data.session);
 
     res.status(200).json({
       user: {
-        id: user.id,
-        username: user.username,
-        email: user.email,
-        role: user.role,
-        country: user.country || 'unknown'
+        id: profile.id,
+        username: profile.username,
+        email: profile.email,
+        role: profile.role,
+        country: profile.country || 'unknown'
       }
     });
   } catch (error) {

--- a/api/auth/register.js
+++ b/api/auth/register.js
@@ -56,8 +56,9 @@ module.exports = async function handler(req, res) {
       return;
     }
 
-    const bcrypt = require('bcryptjs');
     const { getUserByEmail, getUserByUsername, insertUser } = require('../_lib/db');
+    const { setAuthCookies } = require('../_lib/auth');
+    const { getSupabaseAnonClient, getSupabaseAdminClient } = require('../_lib/supabase');
 
     const normalizedUsername = trimmedUsername.toLowerCase();
     const normalizedEmail = trimmedEmail.toLowerCase();
@@ -74,25 +75,68 @@ module.exports = async function handler(req, res) {
       return;
     }
 
-    const passwordHash = await bcrypt.hash(rawPassword, 12);
     const countryHeader = req.headers['x-vercel-ip-country'];
     const country = typeof countryHeader === 'string' && countryHeader.trim() ? countryHeader.trim() : 'unknown';
 
-    const user = await insertUser({
-      username: normalizedUsername,
+    const adminClient = getSupabaseAdminClient();
+    const { data: createdUserData, error: createUserError } = await adminClient.auth.admin.createUser({
       email: normalizedEmail,
-      passwordHash,
-      role: 'user',
-      country
+      password: rawPassword,
+      email_confirm: true,
+      user_metadata: {
+        username: normalizedUsername
+      }
     });
+
+    if (createUserError || !createdUserData?.user?.id) {
+      const status = createUserError?.status === 422 ? 409 : 500;
+      res.status(status).json({ error: createUserError?.message || 'Failed to create account' });
+      return;
+    }
+
+    let profile = null;
+
+    try {
+      profile = await insertUser({
+        authUserId: createdUserData.user.id,
+        username: normalizedUsername,
+        email: normalizedEmail,
+        role: 'user',
+        country
+      });
+    } catch (error) {
+      await adminClient.auth.admin.deleteUser(createdUserData.user.id);
+      throw error;
+    }
+
+    const supabase = getSupabaseAnonClient();
+    const { data: signInData, error: signInError } = await supabase.auth.signInWithPassword({
+      email: normalizedEmail,
+      password: rawPassword
+    });
+
+    if (signInError || !signInData?.session) {
+      res.status(201).json({
+        user: {
+          id: profile.id,
+          username: profile.username,
+          email: profile.email,
+          role: profile.role,
+          country: profile.country
+        }
+      });
+      return;
+    }
+
+    setAuthCookies(res, signInData.session);
 
     res.status(201).json({
       user: {
-        id: user.id,
-        username: user.username,
-        email: user.email,
-        role: user.role,
-        country: user.country
+        id: profile.id,
+        username: profile.username,
+        email: profile.email,
+        role: profile.role,
+        country: profile.country
       }
     });
   } catch (error) {

--- a/api/auth/self-reset.js
+++ b/api/auth/self-reset.js
@@ -83,8 +83,8 @@ module.exports = async function handler(req, res) {
       return;
     }
 
-    const bcrypt = require('bcryptjs');
-    const { getUserByUsername, updatePasswordByUserId } = require('../_lib/db');
+    const { getUserByUsername } = require('../_lib/db');
+    const { getSupabaseAdminClient } = require('../_lib/supabase');
 
     const normalizedUsername = trimmedUsername.toLowerCase();
     const normalizedEmail = trimmedEmail.toLowerCase();
@@ -100,8 +100,21 @@ module.exports = async function handler(req, res) {
       return;
     }
 
-    const passwordHash = await bcrypt.hash(rawPassword, 12);
-    await updatePasswordByUserId(user.id, passwordHash);
+    if (!user.auth_user_id) {
+      res.status(500).json({ error: 'User is missing linked Supabase auth account' });
+      return;
+    }
+
+    const adminClient = getSupabaseAdminClient();
+    const { error } = await adminClient.auth.admin.updateUserById(user.auth_user_id, {
+      password: rawPassword
+    });
+
+    if (error) {
+      console.error('[auth/self-reset] Supabase reset failed:', error.message);
+      res.status(500).json({ error: 'Self reset failed' });
+      return;
+    }
 
     res.status(200).json({ ok: true });
   } catch (error) {

--- a/api/quiz/answer.js
+++ b/api/quiz/answer.js
@@ -1,5 +1,5 @@
 const { runQuery } = require('../_lib/db');
-const { parseCookies, verifySessionToken, COOKIE_NAME } = require('../_lib/auth');
+const { getSessionFromCookies } = require('../_lib/auth');
 const { evaluateAnswer } = require('../../lib/server/quiz-answer-evaluator');
 const { isRateLimited } = require('../_lib/rate-limit');
 const { sendQuizRateLimited } = require('../_lib/quiz-rate-limit-response');
@@ -96,15 +96,7 @@ module.exports = async function handler(req, res) {
       retryAvailable: body.retryAvailable !== false
     });
 
-    let session = null;
-    try {
-      const cookies = parseCookies(req);
-      if (cookies[COOKIE_NAME]) {
-        session = await verifySessionToken(cookies[COOKIE_NAME]);
-      }
-    } catch (error) {
-      session = null;
-    }
+    const session = await getSessionFromCookies(req, res, { allowRefresh: true });
 
     if (session && session.id && (evaluation.status === 'correct' || evaluation.status === 'wrong')) {
       await persistProgress(session.id, questionId, evaluation.status === 'correct');

--- a/api/quiz/quest.js
+++ b/api/quiz/quest.js
@@ -1,6 +1,6 @@
 const crypto = require('crypto');
 const { runQuery } = require('../_lib/db');
-const { parseCookies, verifySessionToken, COOKIE_NAME } = require('../_lib/auth');
+const { getSessionFromCookies } = require('../_lib/auth');
 const { isRateLimited } = require('../_lib/rate-limit');
 const { sendQuizRateLimited } = require('../_lib/quiz-rate-limit-response');
 const { createEndpointMetric } = require('../_lib/observability');
@@ -29,12 +29,9 @@ function parseCategoryList(value) {
     });
 }
 
-async function tryGetSession(req) {
+async function tryGetSession(req, res) {
   try {
-    const cookies = parseCookies(req);
-    const token = cookies[COOKIE_NAME];
-    if (!token) return null;
-    return await verifySessionToken(token);
+    return await getSessionFromCookies(req, res, { allowRefresh: true });
   } catch (error) {
     return null;
   }
@@ -307,7 +304,7 @@ module.exports = async function handler(req, res) {
     const body = parseJsonBody(req.body);
     const action = String(body.action || '').trim().toLowerCase();
     const lang = body.lang === 'no' ? 'no' : 'en';
-    const session = await tryGetSession(req);
+    const session = await tryGetSession(req, res);
     const userId = session && Number.isInteger(Number(session.id)) ? Number(session.id) : null;
     const guestProgress = userId ? { token: null, solvedQuestionIds: [] } : await loadGuestProgress(body);
 

--- a/docs/supabase-migration.md
+++ b/docs/supabase-migration.md
@@ -1,0 +1,67 @@
+# Supabase migration notes
+
+This repo already talks directly to Postgres with the `pg` driver, so Vercel can continue to host the API routes while Supabase provides both Postgres and Auth.
+
+## What changed in code
+
+- Database access still uses `pg`, now expecting a Supabase Postgres connection string (`SUPABASE_DB_URL` or `DATABASE_URL`).
+- Authentication now uses Supabase Auth instead of local password hashes + custom JWT signing.
+- Server routes store Supabase access/refresh tokens in HTTP-only cookies.
+- App profile data still lives in the `public.users` table and is linked to Supabase Auth via `users.auth_user_id`.
+- Quiz progress continues to use the internal numeric `users.id`, so existing `user_answers.user_id` references do not need to change.
+
+## Required environment variables on Vercel
+
+Set these server-side environment variables:
+
+- `SUPABASE_URL`
+- `SUPABASE_ANON_KEY`
+- `SUPABASE_SERVICE_ROLE_KEY`
+- `SUPABASE_DB_URL` (or `DATABASE_URL`)
+- Optional pool tuning:
+  - `DB_POOL_MAX`
+  - `DB_POOL_IDLE_TIMEOUT_MS`
+  - `DB_POOL_CONNECTION_TIMEOUT_MS`
+
+You can also expose these client-compatible names if you want consistency with Supabase defaults:
+
+- `NEXT_PUBLIC_SUPABASE_URL`
+- `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+
+## Required SQL migration in Supabase
+
+Run this in Supabase SQL editor before deploying:
+
+```sql
+alter table public.users
+  add column if not exists auth_user_id uuid unique;
+
+alter table public.users
+  drop column if exists password_hash;
+
+create unique index if not exists users_auth_user_id_idx
+  on public.users (auth_user_id);
+
+create unique index if not exists users_username_lower_idx
+  on public.users ((lower(username)));
+
+create unique index if not exists users_email_lower_idx
+  on public.users ((lower(email)));
+```
+
+## Migration strategy for existing users
+
+Existing local users from the old password-hash setup are **not automatically migrated** by this patch.
+
+For each existing account, you should either:
+
+1. create a matching Supabase Auth user and copy the returned `auth.users.id` into `public.users.auth_user_id`, or
+2. ask users to re-register if the old accounts are disposable.
+
+If you want a full one-time migration, use the Supabase Admin API or dashboard to create auth users, then backfill `public.users.auth_user_id`.
+
+## Notes
+
+- Registration now creates the Supabase Auth user first, then inserts the linked app profile row.
+- Login still accepts `username + password` in the UI, but server-side it resolves the username to the stored email before calling Supabase Auth.
+- Self-service password reset now updates the linked Supabase Auth user password instead of touching a local password hash.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,24 +8,121 @@
       "name": "sarcasm-games",
       "version": "1.0.0",
       "dependencies": {
-        "bcryptjs": "^2.4.3",
-        "jose": "^5.9.6",
+        "@supabase/supabase-js": "^2.99.3",
         "pg": "^8.13.1"
       }
     },
-    "node_modules/bcryptjs": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
-      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
+    "node_modules/@supabase/auth-js": {
+      "version": "2.99.3",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.99.3.tgz",
+      "integrity": "sha512-vMEVLA1kGGYd/kdsJSwtjiFUZM1nGfrz2DWmgMBZtocV48qL+L2+4QpIkueXyBEumMQZFEyhz57i/5zGHjvdBw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.99.3",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.99.3.tgz",
+      "integrity": "sha512-6tk2zrcBkzKaaBXPOG5nshn30uJNFGOH9LxOnE8i850eQmsX+jVm7vql9kTPyvUzEHwU4zdjSOkXS9M+9ukMVA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.99.3",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.99.3.tgz",
+      "integrity": "sha512-8HxEf+zNycj7Z8+ONhhlu+7J7Ha+L6weyCtdEeK2mN5OWJbh6n4LPU4iuJ5UlCvvNnbSXMoutY7piITEEAgl2g==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.99.3",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.99.3.tgz",
+      "integrity": "sha512-c1azgZ2nZPczbY5k5u5iFrk1InpxN81IvNE+UBAkjrBz3yc5ALLJNkeTQwbJZT4PZBuYXEzqYGLMuh9fdTtTMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "tslib": "2.8.1",
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.99.3",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.99.3.tgz",
+      "integrity": "sha512-lOfIm4hInNcd8x0i1LWphnLKxec42wwbjs+vhaVAvR801Vda0UAMbTooUY6gfqgQb8v29GofqKuQMMTAsl6w/w==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.99.3",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.99.3.tgz",
+      "integrity": "sha512-GuPbzoEaI51AkLw9VGhLNvnzw4PHbS3p8j2/JlvLeZNQMKwZw4aEYQIDBRtFwL5Nv7/275n9m4DHtakY8nCvgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.99.3",
+        "@supabase/functions-js": "2.99.3",
+        "@supabase/postgrest-js": "2.99.3",
+        "@supabase/realtime-js": "2.99.3",
+        "@supabase/storage-js": "2.99.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
+      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.7.tgz",
+      "integrity": "sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q==",
       "license": "MIT"
     },
-    "node_modules/jose": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
-      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/pg": {
@@ -163,6 +260,39 @@
       "license": "ISC",
       "engines": {
         "node": ">= 10.x"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT"
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -3,8 +3,7 @@
   "private": true,
   "version": "1.0.0",
   "dependencies": {
-    "bcryptjs": "^2.4.3",
-    "jose": "^5.9.6",
+    "@supabase/supabase-js": "^2.99.3",
     "pg": "^8.13.1"
   },
   "scripts": {


### PR DESCRIPTION
### Motivation

- Fjerne den hjemmelagde JWT/password-hash-flyten og bruke Supabase Auth for enklere drift og Supabase-integrasjon.
- Koble eksisterende app-profiler i `public.users` til Supabase Auth via `auth_user_id` uten å endre intern numerisk `users.id` som brukes av quiz-fremgang.

### Description

- Legg til `api/_lib/supabase.js` som wrapper rundt `@supabase/supabase-js` og nye helpers `getSupabaseAnonClient` og `getSupabaseAdminClient`.
- Bytt auth-implementasjon i `api/_lib/auth.js` til å lese Supabase access/refresh cookies (`ACCESS_COOKIE_NAME`/`REFRESH_COOKIE_NAME`) og gjøre session-oppslag/refresh via Supabase; behold `requireSession` API for ruter.
- Oppdater database-helpers i `api/_lib/db.js` for å bruke og returnere `auth_user_id`, fjern lokal `password_hash`-avhengighet, og legg til `getUserByAuthUserId` samt `insertUser({ authUserId, ... })`.
- Rewire auth-endepunkter: `api/auth/login.js`, `api/auth/register.js`, `api/auth/self-reset.js`, og `api/auth/logout.js` til å bruke Supabase Auth (inkl. admin-create for registrering) og sette HTTP-only auth-cookies; oppdater også quiz-endepunktene `api/quiz/answer.js` og `api/quiz/quest.js` til å bruke den nye session-funksjonen.
- Oppdater `package.json`/`package-lock.json` for å legge til `@supabase/supabase-js` og fjerne gamle lokale hash/jwt-avhengigheter, og tilføyer dokumentasjon `docs/supabase-migration.md` med nødvendige env-vars og SQL-migrasjonsskript.

### Testing

- Lastet modulene med `node -e "require('./api/_lib/auth'); require('./api/_lib/db'); require('./api/_lib/supabase'); require('./api/auth/login'); require('./api/auth/register'); require('./api/auth/self-reset'); require('./api/auth/logout'); require('./api/auth/session'); require('./api/quiz/answer'); require('./api/quiz/quest'); require('./api/admin/users'); console.log('module load ok')"` og fikk `module load ok`.
- Kjørte statisk sjekk med `git diff --check` som ga ingen problemer.
- Verifiserte installerte pakker med `npm ls @supabase/supabase-js pg` som rapporterte forventede avhengigheter.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc322834ec83339281c18a912b3151)