### PR TITLE
Add admin Insert Quiz UI and API to bulk-insert quiz questions

### DIFF
--- a/api/admin/insert-quiz.js
+++ b/api/admin/insert-quiz.js
@@ -1,0 +1,121 @@
+const { requireSession } = require('../_lib/auth');
+const { runQuery } = require('../_lib/db');
+const { parseJsonBody } = require('../_lib/parse-body');
+
+function readString(value) {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function normalizeDifficulty(value) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > 3) return null;
+  return parsed;
+}
+
+function normalizeEntry(entry) {
+  if (!entry || typeof entry !== 'object') return null;
+
+  const category = readString(entry.category);
+  const questionEn = readString(entry.question_en);
+  const questionNo = readString(entry.question_no);
+  const sharedAnswer = readString(entry.shared_answer);
+  const difficulty = normalizeDifficulty(entry.difficulty);
+
+  if (!category || !questionEn || !questionNo || !sharedAnswer || !difficulty) {
+    return null;
+  }
+
+  return {
+    category,
+    question_en: questionEn,
+    question_no: questionNo,
+    shared_answer: sharedAnswer,
+    difficulty
+  };
+}
+
+async function existsQuizQuestion(category, questionEn) {
+  const result = await runQuery(
+    `SELECT id
+     FROM public.quiz_questions
+     WHERE lower(trim(category)) = lower(trim($1))
+       AND lower(trim(question_en)) = lower(trim($2))
+     LIMIT 1`,
+    [category, questionEn]
+  );
+
+  return Boolean(result.rows[0]);
+}
+
+async function insertQuizQuestion(entry) {
+  const trimmedAnswer = entry.shared_answer.trim();
+
+  await runQuery(
+    `INSERT INTO public.quiz_questions (
+      category,
+      question_en,
+      question_no,
+      answers_en,
+      answers_no,
+      difficulty
+    ) VALUES ($1, $2, $3, $4::text[], $5::text[], $6)`,
+    [
+      entry.category,
+      entry.question_en,
+      entry.question_no,
+      [trimmedAnswer],
+      [trimmedAnswer],
+      entry.difficulty
+    ]
+  );
+}
+
+module.exports = async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const session = await requireSession(req, res);
+  if (!session) return;
+
+  if (session.role !== 'admin') {
+    res.status(403).json({ error: 'Forbidden' });
+    return;
+  }
+
+  const payload = parseJsonBody(req.body);
+  const entries = Array.isArray(payload.entries) ? payload.entries : [];
+
+  if (!entries.length) {
+    res.status(400).json({ error: 'entries must contain at least one item' });
+    return;
+  }
+
+  const normalizedEntries = entries.map(normalizeEntry);
+  if (normalizedEntries.some((entry) => entry === null)) {
+    res.status(400).json({ error: 'Each entry requires category, question_en, question_no, shared_answer and difficulty (1-3)' });
+    return;
+  }
+
+  const inserted = [];
+  const duplicates = [];
+
+  for (const entry of normalizedEntries) {
+    const duplicate = await existsQuizQuestion(entry.category, entry.question_en);
+    if (duplicate) {
+      duplicates.push({ category: entry.category, question_en: entry.question_en });
+      continue;
+    }
+
+    await insertQuizQuestion(entry);
+    inserted.push({ category: entry.category, question_en: entry.question_en });
+  }
+
+  res.status(200).json({
+    insertedCount: inserted.length,
+    duplicateCount: duplicates.length,
+    inserted,
+    duplicates
+  });
+};

--- a/index.html
+++ b/index.html
@@ -290,7 +290,15 @@
       }
     };
 
-    const FEATURE_MODULES = [];
+    const FEATURE_MODULES = [
+      {
+        title: 'Quiz admin',
+        adminOnly: true,
+        links: [
+          { href: '/insertquiz/', label: 'Insert quiz questions' }
+        ]
+      }
+    ];
 
     let currentCaptcha = null;
     let failedResetAttempts = 0;

--- a/insertquiz/index.html
+++ b/insertquiz/index.html
@@ -1,0 +1,267 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Insert quiz question</title>
+  <style>
+    :root { --bg:#0b0c10; --card:#1e1f25; --txt:#eaeaea; --bd:#2f313a; --accent:#4ecca3; --danger:#ff6b6b; --muted:#9aa0ad; }
+    body { margin:0; font:16px/1.4 system-ui, Segoe UI, Roboto, Arial; background:var(--bg); color:var(--txt); min-height:100dvh; }
+    main { max-width: 920px; margin: 0 auto; padding: 28px 18px 40px; }
+    .card { background:var(--card); border:1px solid var(--bd); border-radius:12px; padding:16px; margin-bottom:14px; }
+    h1 { margin: 0 0 8px; }
+    p { color: var(--muted); }
+    .grid { display:grid; grid-template-columns:1fr 1fr; gap:10px; }
+    .full { grid-column:1 / -1; }
+    label { display:block; margin-bottom:4px; color:var(--muted); font-size:.9rem; }
+    input, select { width:100%; box-sizing:border-box; background:var(--bg); color:var(--txt); border:1px solid var(--bd); border-radius:8px; padding:10px 12px; }
+    .actions { display:flex; gap:8px; flex-wrap:wrap; margin-top:14px; }
+    button { border:0; border-radius:8px; padding:10px 14px; font-weight:700; cursor:pointer; }
+    .btn-primary { background:var(--accent); color:#111; }
+    .btn-neutral { background:var(--bd); color:var(--txt); }
+    .btn-danger { background:var(--danger); color:#fff; }
+    .status { min-height:20px; margin-top:12px; white-space:pre-wrap; }
+    .status.error { color: var(--danger); }
+    .status.success { color: var(--accent); }
+    .queue-item { border:1px dashed var(--bd); border-radius:8px; padding:10px; margin-top:8px; }
+    .queue-item strong { display:block; }
+    .muted { color: var(--muted); }
+    .hidden { display:none !important; }
+    .top-links { display:flex; gap:10px; margin-bottom:10px; }
+    .top-links a { color: var(--accent); }
+    @media (max-width: 760px) {
+      .grid { grid-template-columns: 1fr; }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <div class="top-links">
+      <a href="/">← Home</a>
+    </div>
+
+    <div class="card">
+      <h1>Insert quiz question</h1>
+      <p class="muted">Admin-only tool for inserting questions into <code>public.quiz_questions</code>.</p>
+      <div id="accessStatus" class="status">Checking access…</div>
+    </div>
+
+    <div class="card hidden" id="formCard">
+      <div class="grid">
+        <div>
+          <label for="category">Category</label>
+          <input id="category" type="text" />
+        </div>
+        <div>
+          <label for="difficulty">Difficulty</label>
+          <select id="difficulty">
+            <option value="">Choose difficulty</option>
+            <option value="1">1</option>
+            <option value="2">2</option>
+            <option value="3">3</option>
+          </select>
+        </div>
+        <div class="full">
+          <label for="questionEn">Question English</label>
+          <input id="questionEn" type="text" />
+        </div>
+        <div class="full">
+          <label for="questionNo">Question Norwegian</label>
+          <input id="questionNo" type="text" />
+        </div>
+        <div class="full">
+          <label for="sharedAnswer">Answer for both languages</label>
+          <input id="sharedAnswer" type="text" />
+        </div>
+      </div>
+
+      <div class="actions">
+        <button id="addBtn" class="btn-neutral" type="button">+ Add question</button>
+        <button id="submitBtn" class="btn-primary" type="button">Submit queued questions</button>
+        <button id="clearBtn" class="btn-danger" type="button">Clear queue</button>
+      </div>
+      <div id="formStatus" class="status"></div>
+    </div>
+
+    <div class="card hidden" id="queueCard">
+      <h3>Queued questions</h3>
+      <div id="queueList" class="muted">No questions queued yet.</div>
+    </div>
+  </main>
+
+  <script>
+    const queue = [];
+
+    const accessStatus = document.getElementById('accessStatus');
+    const formCard = document.getElementById('formCard');
+    const queueCard = document.getElementById('queueCard');
+    const formStatus = document.getElementById('formStatus');
+    const queueList = document.getElementById('queueList');
+
+    const categoryInput = document.getElementById('category');
+    const difficultyInput = document.getElementById('difficulty');
+    const questionEnInput = document.getElementById('questionEn');
+    const questionNoInput = document.getElementById('questionNo');
+    const sharedAnswerInput = document.getElementById('sharedAnswer');
+
+    function readString(value) {
+      return typeof value === 'string' && value.trim() ? value.trim() : null;
+    }
+
+    function setFormStatus(message, type = 'neutral') {
+      formStatus.classList.remove('error', 'success');
+      if (type === 'error') formStatus.classList.add('error');
+      if (type === 'success') formStatus.classList.add('success');
+      formStatus.textContent = message || '';
+    }
+
+    function renderQueue() {
+      if (!queue.length) {
+        queueList.textContent = 'No questions queued yet.';
+        return;
+      }
+
+      queueList.innerHTML = '';
+      queue.forEach((item, index) => {
+        const container = document.createElement('div');
+        container.className = 'queue-item';
+
+        const title = document.createElement('strong');
+        title.textContent = `${index + 1}. [${item.category}] ${item.question_en}`;
+
+        const meta = document.createElement('div');
+        meta.className = 'muted';
+        meta.textContent = `NO: ${item.question_no} | Answer: ${item.shared_answer} | Difficulty: ${item.difficulty}`;
+
+        container.appendChild(title);
+        container.appendChild(meta);
+        queueList.appendChild(container);
+      });
+    }
+
+    function resetFormInputs() {
+      categoryInput.value = '';
+      difficultyInput.value = '';
+      questionEnInput.value = '';
+      questionNoInput.value = '';
+      sharedAnswerInput.value = '';
+      categoryInput.focus();
+    }
+
+    function readFormEntry() {
+      const category = readString(categoryInput.value);
+      const question_en = readString(questionEnInput.value);
+      const question_no = readString(questionNoInput.value);
+      const shared_answer = readString(sharedAnswerInput.value);
+      const difficulty = Number(difficultyInput.value);
+
+      if (!category || !question_en || !question_no || !shared_answer) {
+        return { error: 'Please fill out all fields before adding to queue.' };
+      }
+
+      if (!Number.isInteger(difficulty) || difficulty < 1 || difficulty > 3) {
+        return { error: 'Difficulty must be 1, 2 or 3.' };
+      }
+
+      return {
+        value: {
+          category,
+          question_en,
+          question_no,
+          shared_answer,
+          difficulty
+        }
+      };
+    }
+
+    async function ensureAdminAccess() {
+      try {
+        const response = await fetch('/api/auth/session', { credentials: 'include' });
+        if (!response.ok) {
+          accessStatus.textContent = 'Access denied. Please log in as admin.';
+          accessStatus.classList.add('error');
+          return;
+        }
+
+        const data = await response.json();
+        if (data?.user?.role !== 'admin') {
+          accessStatus.textContent = 'Access denied. This page is admin-only.';
+          accessStatus.classList.add('error');
+          return;
+        }
+
+        accessStatus.textContent = `Admin access confirmed for ${data.user.username}.`;
+        accessStatus.classList.add('success');
+        formCard.classList.remove('hidden');
+        queueCard.classList.remove('hidden');
+        renderQueue();
+      } catch (error) {
+        accessStatus.textContent = 'Could not verify access due to a network error.';
+        accessStatus.classList.add('error');
+      }
+    }
+
+    document.getElementById('addBtn').addEventListener('click', () => {
+      const result = readFormEntry();
+      if (result.error) {
+        setFormStatus(result.error, 'error');
+        return;
+      }
+
+      queue.push(result.value);
+      renderQueue();
+      setFormStatus(`Queued question ${queue.length}.`, 'success');
+      resetFormInputs();
+    });
+
+    document.getElementById('clearBtn').addEventListener('click', () => {
+      queue.splice(0, queue.length);
+      renderQueue();
+      setFormStatus('Queue cleared.');
+      resetFormInputs();
+    });
+
+    document.getElementById('submitBtn').addEventListener('click', async () => {
+      if (!queue.length) {
+        setFormStatus('Add at least one question before submitting.', 'error');
+        return;
+      }
+
+      setFormStatus('Submitting…');
+
+      try {
+        const response = await fetch('/api/admin/insert-quiz', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({ entries: queue })
+        });
+
+        const data = await response.json().catch(() => ({}));
+
+        if (!response.ok) {
+          setFormStatus(data.error || 'Insert failed.', 'error');
+          return;
+        }
+
+        const duplicateMessage = (data.duplicates || []).length
+          ? `Skipped duplicates: ${(data.duplicates || []).map((item) => `"${item.question_en}" in "${item.category}"`).join(', ')}.`
+          : 'No duplicates found.';
+
+        setFormStatus(
+          `Inserted ${data.insertedCount || 0} question(s). ${duplicateMessage}`,
+          'success'
+        );
+
+        queue.splice(0, queue.length);
+        renderQueue();
+        resetFormInputs();
+      } catch (error) {
+        setFormStatus('Insert failed due to network error.', 'error');
+      }
+    });
+
+    ensureAdminAccess();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation

- Provide an admin-only tool to bulk insert quiz questions into the `public.quiz_questions` table from a simple web UI. 
- Enforce minimal validation and prevent duplicate questions based on normalized `category` and `question_en` to keep data consistent. 
- Expose the feature from the main UI so admins can discover and use the tool.

### Description

- Add a new API endpoint `api/admin/insert-quiz.js` that requires an admin session, validates and normalizes posted entries, skips duplicates (by lower(trim(category)) + lower(trim(question_en))), and inserts new rows into `public.quiz_questions` with `answers_en` and `answers_no` populated from the shared answer.
- Add an admin UI page at `insertquiz/index.html` that allows queuing multiple question entries, validates inputs in the browser, and posts the queued entries to `POST /api/admin/insert-quiz` using `fetch` with credentials included.
- Update `index.html` to expose the new feature under `FEATURE_MODULES` with a link to `/insertquiz/` and ensure the page is discoverable only to admins via the session check in the client script.

### Testing

- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c28caa05cc83339de37c9651d24018)