### PR TITLE
Add select/deselect-all to category grids and improve category card layout

### DIFF
--- a/quiz-categories/index.html
+++ b/quiz-categories/index.html
@@ -65,6 +65,7 @@
     .grid {
       display: grid;
       grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+      align-items: stretch;
       gap: 10px;
       margin: 0 0 16px;
     }
@@ -74,6 +75,7 @@
       border-radius:10px;
       padding:10px;
       background:#181920;
+      height: 100%;
       transition: border-color 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
     }
 
@@ -86,10 +88,11 @@
     .cat label {
       display:flex;
       gap:8px;
-      align-items:center;
+      align-items:flex-start;
       cursor:pointer;
       position: relative;
       min-height: 24px;
+      height: 100%;
     }
 
     .cat input[type="checkbox"] {
@@ -115,8 +118,20 @@
       box-shadow: 0 0 0 3px rgba(67, 200, 159, 0.2);
     }
 
-    .cat-name { font-weight:700; }
-    .cat-count { color:var(--muted); font-size: 14px; }
+    .cat-name {
+      display: block;
+      font-weight:700;
+      overflow-wrap: anywhere;
+      word-break: break-word;
+    }
+
+    .cat-count {
+      display: block;
+      color:var(--muted);
+      font-size: 14px;
+      overflow-wrap: anywhere;
+      word-break: break-word;
+    }
 
     .controls {
       display:flex;
@@ -275,6 +290,10 @@
 
       <p id="status" class="status" role="status" aria-live="polite">Loading categories…</p>
       <section id="categoryGrid" class="grid" aria-label="Quiz categories"></section>
+      <div class="actions">
+        <button id="selectAllBtn" type="button">Select all</button>
+        <button id="deselectAllBtn" type="button">Deselect all</button>
+      </div>
 
       <div class="controls">
         <label>
@@ -348,6 +367,8 @@
         setupLead: 'Choose one or more categories. Max question count updates based on your selection.',
         loadingCategories: 'Loading categories…',
         questionCount: 'Question count',
+        selectAll: 'Select all',
+        deselectAll: 'Deselect all',
         startQuiz: 'Start quiz',
         backHome: 'Back to sarcasm.games',
         abortQuiz: 'Abort quiz',
@@ -404,6 +425,8 @@
         setupLead: 'Velg én eller flere kategorier. Maks antall spørsmål oppdateres basert på valget ditt.',
         loadingCategories: 'Laster kategorier…',
         questionCount: 'Antall spørsmål',
+        selectAll: 'Velg alle',
+        deselectAll: 'Fjern alle',
         startQuiz: 'Start quiz',
         backHome: 'Tilbake til sarcasm.games',
         abortQuiz: 'Avbryt quiz',
@@ -459,6 +482,8 @@
 
     const activeLang = readQuizLanguage();
     const categoryGrid = document.getElementById('categoryGrid');
+    const selectAllBtn = document.getElementById('selectAllBtn');
+    const deselectAllBtn = document.getElementById('deselectAllBtn');
     const setupView = document.getElementById('setupView');
     const questionView = document.getElementById('questionView');
     const resultView = document.getElementById('resultView');
@@ -576,6 +601,15 @@
 
     function renderCategories() {
       categoryGrid.innerHTML = '';
+      if (!runtimeState.categories.length) {
+        selectAllBtn.disabled = true;
+        deselectAllBtn.disabled = true;
+        renderCountState();
+        return;
+      }
+
+      selectAllBtn.disabled = false;
+      deselectAllBtn.disabled = false;
 
       runtimeState.categories.forEach((category, index) => {
         const wrapper = document.createElement('article');
@@ -617,6 +651,14 @@
       });
 
       renderCountState();
+    }
+
+    function setAllCategoriesSelected(selected) {
+      if (!runtimeState.categories.length) return;
+      runtimeState.categories.forEach((category) => {
+        category.selected = selected;
+      });
+      renderCategories();
     }
 
     function getFilteredAnsweredQuestions() {
@@ -773,17 +815,16 @@
 
         if (!categories.length || !payload.totalQuestions) {
           runtimeState.categories = [];
-          categoryGrid.innerHTML = '';
           statusEl.classList.remove('error');
           statusEl.textContent = uiCopy().noCategories;
-          renderCountState();
+          renderCategories();
           return;
         }
 
         runtimeState.categories = categories.map((category) => ({
           name: category.name,
           questionCount: Number(category.questionCount) || 0,
-          selected: true
+          selected: false
         }));
 
         statusEl.classList.remove('error');
@@ -793,14 +834,15 @@
         renderCategories();
       } catch (error) {
         runtimeState.categories = [];
-        categoryGrid.innerHTML = '';
         statusEl.classList.add('error');
         statusEl.textContent = uiCopy().loadCategoriesError.replace('{message}', error.message);
-        renderCountState();
+        renderCategories();
       }
     }
 
     countInput.addEventListener('change', renderCountState);
+    selectAllBtn.addEventListener('click', () => setAllCategoriesSelected(true));
+    deselectAllBtn.addEventListener('click', () => setAllCategoriesSelected(false));
 
     startButton.addEventListener('click', async () => {
       const selectedCategories = getSelectedCategories().map((category) => category.name);
@@ -995,6 +1037,8 @@
       setupLead.textContent = c.setupLead;
       statusEl.textContent = c.loadingCategories;
       questionCountLabel.firstChild.textContent = `${c.questionCount} `;
+      selectAllBtn.textContent = c.selectAll;
+      deselectAllBtn.textContent = c.deselectAll;
       startButton.textContent = c.startQuiz;
       for (const backLink of backLinks) {
         backLink.textContent = c.backHome;

--- a/quiz-quest/index.html
+++ b/quiz-quest/index.html
@@ -58,6 +58,7 @@
     .grid {
       display: grid;
       grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+      align-items: stretch;
       gap: 10px;
       margin: 0 0 16px;
     }
@@ -67,6 +68,7 @@
       border-radius:10px;
       padding:10px;
       background:#181920;
+      height: 100%;
       transition: border-color 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
     }
 
@@ -79,10 +81,11 @@
     .cat label {
       display:flex;
       gap:8px;
-      align-items:center;
+      align-items:flex-start;
       cursor:pointer;
       position: relative;
       min-height: 24px;
+      height: 100%;
     }
 
     .cat input[type="checkbox"] {
@@ -108,8 +111,20 @@
       box-shadow: 0 0 0 3px rgba(67, 200, 159, 0.2);
     }
 
-    .cat-name { font-weight:700; }
-    .cat-count { color:var(--muted); font-size: 14px; }
+    .cat-name {
+      display: block;
+      font-weight:700;
+      overflow-wrap: anywhere;
+      word-break: break-word;
+    }
+
+    .cat-count {
+      display: block;
+      color:var(--muted);
+      font-size: 14px;
+      overflow-wrap: anywhere;
+      word-break: break-word;
+    }
 
     .controls,
     .actions,
@@ -192,6 +207,10 @@
       <p id="setupStatus" class="status" role="status" aria-live="polite"></p>
 
       <section id="categoryGrid" class="grid" aria-label="Quiz quest categories"></section>
+      <div class="actions">
+        <button id="selectAllBtn" type="button">Select all</button>
+        <button id="deselectAllBtn" type="button">Deselect all</button>
+      </div>
 
       <div class="controls">
         <label for="questionCount" id="questionCountLabel">Question count
@@ -243,6 +262,8 @@
         selectedPool: 'Selected pool: {remaining} remaining of {total} total.',
         selectHint: 'Select at least one category to continue.',
         questionCount: 'Question count',
+        selectAll: 'Select all',
+        deselectAll: 'Deselect all',
         selectedPoolCount: 'Selected pool supports between 1 and {count} questions.',
         startQuest: 'Start quest',
         next: 'Next question',
@@ -276,6 +297,8 @@
         selectedPool: 'Valgt pool: {remaining} gjenstår av {total} totalt.',
         selectHint: 'Velg minst én kategori for å fortsette.',
         questionCount: 'Antall spørsmål',
+        selectAll: 'Velg alle',
+        deselectAll: 'Fjern alle',
         selectedPoolCount: 'Valgt pool støtter mellom 1 og {count} spørsmål.',
         startQuest: 'Start quest',
         next: 'Neste spørsmål',
@@ -324,6 +347,8 @@
     const poolStatus = document.getElementById('poolStatus');
     const setupStatus = document.getElementById('setupStatus');
     const categoryGrid = document.getElementById('categoryGrid');
+    const selectAllBtn = document.getElementById('selectAllBtn');
+    const deselectAllBtn = document.getElementById('deselectAllBtn');
     const questionCountLabel = document.getElementById('questionCountLabel');
     const questionCountInput = document.getElementById('questionCount');
     const countMeta = document.getElementById('countMeta');
@@ -512,6 +537,15 @@
       submitBtn.disabled = false;
     }
 
+    function setAllCategorySelection(selected) {
+      if (!state.categories.length) return;
+      for (const category of state.categories) {
+        category.selected = selected;
+      }
+      clearQuestionState();
+      renderCategories();
+    }
+
     function setQuestActive(active) {
       state.isQuestActive = active;
       setupView.classList.toggle('hidden', active);
@@ -549,12 +583,17 @@
         empty.className = 'muted';
         empty.textContent = ui().noCategories;
         categoryGrid.appendChild(empty);
+        selectAllBtn.disabled = true;
+        deselectAllBtn.disabled = true;
         startQuestBtn.disabled = true;
         renderPoolStatus();
         renderQuestionCountState();
         renderResetCategories();
         return;
       }
+
+      selectAllBtn.disabled = false;
+      deselectAllBtn.disabled = false;
 
       state.categories.forEach((category, index) => {
         const wrapper = document.createElement('article');
@@ -620,10 +659,6 @@
           ...entry,
           selected: selectedBefore.size ? selectedBefore.has(entry.name) : false
         }));
-
-        if (!state.categories.some((category) => category.selected) && state.categories.length) {
-          state.categories[0].selected = true;
-        }
 
         renderCategories();
         setupStatus.className = 'status';
@@ -821,6 +856,8 @@
       introText.textContent = ui().intro;
       modeText.textContent = state.session ? ui().modeUser : ui().modeGuest;
       questionCountLabel.childNodes[0].nodeValue = `${ui().questionCount} `;
+      selectAllBtn.textContent = ui().selectAll;
+      deselectAllBtn.textContent = ui().deselectAll;
       startQuestBtn.textContent = ui().startQuest;
       nextBtn.textContent = ui().next;
       submitBtn.textContent = ui().submit;
@@ -831,6 +868,8 @@
     }
 
     questionCountInput.addEventListener('input', renderQuestionCountState);
+    selectAllBtn.addEventListener('click', () => setAllCategorySelection(true));
+    deselectAllBtn.addEventListener('click', () => setAllCategorySelection(false));
     nextBtn.addEventListener('click', proceedAfterAnswer);
     startQuestBtn.addEventListener('click', startQuest);
     answerForm.addEventListener('submit', submitAnswer);


### PR DESCRIPTION
### Motivation
- Provide a quick way to select or deselect all categories in the quiz setup views and make category cards behave consistently when names are long.
- Ensure the select all controls are disabled when no categories are available and keep the UI responsive to overview/load errors.

### Description
- Added `Select all` and `Deselect all` buttons to both `quiz-categories/index.html` and `quiz-quest/index.html` and added corresponding localized strings in the copy objects.
- Implemented selection helpers `setAllCategoriesSelected` and `setAllCategorySelection` and wired button handlers to call them, and disabled the buttons when no categories exist.
- Adjusted category card layout CSS to make grid items stretch (`align-items: stretch`), force `.cat` to `height: 100%`, align label content with `align-items: flex-start`, and make `.cat-name` and `.cat-count` wrap with `overflow-wrap`/`word-break` so long names don't overflow.
- Updated category load behavior in `quiz-categories` to initialize categories as unselected (`selected: false`) and centralized empty/error rendering via `renderCategories()` for consistent button state updates.

### Testing
- No automated tests were added or run for these HTML/JS changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2a922e92483339ba9b6e199ee4858)