### PR TITLE
Add select/deselect-all controls and improve category grid UI for quizzes

### DIFF
--- a/quiz-categories/index.html
+++ b/quiz-categories/index.html
@@ -64,8 +64,10 @@
 
     .grid {
       display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
-      gap: 10px;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      justify-items: stretch;
+      align-items: stretch;
+      gap: 12px;
       margin: 0 0 16px;
     }
 
@@ -74,6 +76,8 @@
       border-radius:10px;
       padding:10px;
       background:#181920;
+      width: 100%;
+      height: 92px;
       transition: border-color 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
     }
 
@@ -85,11 +89,14 @@
 
     .cat label {
       display:flex;
-      gap:8px;
+      flex-direction: column;
+      justify-content: center;
       align-items:center;
+      text-align: center;
+      gap:6px;
       cursor:pointer;
       position: relative;
-      min-height: 24px;
+      height: 100%;
     }
 
     .cat input[type="checkbox"] {
@@ -98,25 +105,28 @@
       pointer-events: none;
     }
 
-    .cat-pill {
-      width: 14px;
-      height: 14px;
-      border-radius: 999px;
-      border: 1px solid #6f7788;
-      background: #2f3340;
-      box-sizing: border-box;
-      flex-shrink: 0;
-      transition: border-color 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
+    .cat-copy {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 4px;
+      width: 100%;
     }
 
-    .cat.is-selected .cat-pill {
-      border-color: #56d5ad;
-      background: #43c89f;
-      box-shadow: 0 0 0 3px rgba(67, 200, 159, 0.2);
+    .cat-name {
+      display: block;
+      font-weight:700;
+      overflow-wrap: anywhere;
+      word-break: break-word;
     }
 
-    .cat-name { font-weight:700; }
-    .cat-count { color:var(--muted); font-size: 14px; }
+    .cat-count {
+      display: block;
+      color:var(--muted);
+      font-size: 14px;
+      overflow-wrap: anywhere;
+      word-break: break-word;
+    }
 
     .controls {
       display:flex;
@@ -275,6 +285,10 @@
 
       <p id="status" class="status" role="status" aria-live="polite">Loading categories…</p>
       <section id="categoryGrid" class="grid" aria-label="Quiz categories"></section>
+      <div class="actions">
+        <button id="selectAllBtn" type="button">Select all</button>
+        <button id="deselectAllBtn" type="button">Deselect all</button>
+      </div>
 
       <div class="controls">
         <label>
@@ -348,6 +362,8 @@
         setupLead: 'Choose one or more categories. Max question count updates based on your selection.',
         loadingCategories: 'Loading categories…',
         questionCount: 'Question count',
+        selectAll: 'Select all',
+        deselectAll: 'Deselect all',
         startQuiz: 'Start quiz',
         backHome: 'Back to sarcasm.games',
         abortQuiz: 'Abort quiz',
@@ -404,6 +420,8 @@
         setupLead: 'Velg én eller flere kategorier. Maks antall spørsmål oppdateres basert på valget ditt.',
         loadingCategories: 'Laster kategorier…',
         questionCount: 'Antall spørsmål',
+        selectAll: 'Velg alle',
+        deselectAll: 'Fjern alle',
         startQuiz: 'Start quiz',
         backHome: 'Tilbake til sarcasm.games',
         abortQuiz: 'Avbryt quiz',
@@ -459,6 +477,8 @@
 
     const activeLang = readQuizLanguage();
     const categoryGrid = document.getElementById('categoryGrid');
+    const selectAllBtn = document.getElementById('selectAllBtn');
+    const deselectAllBtn = document.getElementById('deselectAllBtn');
     const setupView = document.getElementById('setupView');
     const questionView = document.getElementById('questionView');
     const resultView = document.getElementById('resultView');
@@ -576,6 +596,15 @@
 
     function renderCategories() {
       categoryGrid.innerHTML = '';
+      if (!runtimeState.categories.length) {
+        selectAllBtn.disabled = true;
+        deselectAllBtn.disabled = true;
+        renderCountState();
+        return;
+      }
+
+      selectAllBtn.disabled = false;
+      deselectAllBtn.disabled = false;
 
       runtimeState.categories.forEach((category, index) => {
         const wrapper = document.createElement('article');
@@ -590,10 +619,6 @@
         checkbox.checked = category.selected;
         checkbox.setAttribute('aria-label', `Select ${category.name}`);
 
-        const visualPill = document.createElement('span');
-        visualPill.className = 'cat-pill';
-        visualPill.setAttribute('aria-hidden', 'true');
-
         checkbox.addEventListener('change', () => {
           runtimeState.categories[index].selected = checkbox.checked;
           wrapper.classList.toggle('is-selected', checkbox.checked);
@@ -601,6 +626,7 @@
         });
 
         const textWrapper = document.createElement('span');
+        textWrapper.className = 'cat-copy';
 
         const nameEl = document.createElement('span');
         nameEl.className = 'cat-name';
@@ -610,13 +636,21 @@
         countEl.className = 'cat-count';
         countEl.textContent = `${category.questionCount} ${category.questionCount === 1 ? 'question' : 'questions'}`;
 
-        textWrapper.append(nameEl, document.createElement('br'), countEl);
-        label.append(checkbox, visualPill, textWrapper);
+        textWrapper.append(nameEl, countEl);
+        label.append(checkbox, textWrapper);
         wrapper.appendChild(label);
         categoryGrid.appendChild(wrapper);
       });
 
       renderCountState();
+    }
+
+    function setAllCategoriesSelected(selected) {
+      if (!runtimeState.categories.length) return;
+      runtimeState.categories.forEach((category) => {
+        category.selected = selected;
+      });
+      renderCategories();
     }
 
     function getFilteredAnsweredQuestions() {
@@ -773,17 +807,16 @@
 
         if (!categories.length || !payload.totalQuestions) {
           runtimeState.categories = [];
-          categoryGrid.innerHTML = '';
           statusEl.classList.remove('error');
           statusEl.textContent = uiCopy().noCategories;
-          renderCountState();
+          renderCategories();
           return;
         }
 
         runtimeState.categories = categories.map((category) => ({
           name: category.name,
           questionCount: Number(category.questionCount) || 0,
-          selected: true
+          selected: false
         }));
 
         statusEl.classList.remove('error');
@@ -793,14 +826,15 @@
         renderCategories();
       } catch (error) {
         runtimeState.categories = [];
-        categoryGrid.innerHTML = '';
         statusEl.classList.add('error');
         statusEl.textContent = uiCopy().loadCategoriesError.replace('{message}', error.message);
-        renderCountState();
+        renderCategories();
       }
     }
 
     countInput.addEventListener('change', renderCountState);
+    selectAllBtn.addEventListener('click', () => setAllCategoriesSelected(true));
+    deselectAllBtn.addEventListener('click', () => setAllCategoriesSelected(false));
 
     startButton.addEventListener('click', async () => {
       const selectedCategories = getSelectedCategories().map((category) => category.name);
@@ -995,6 +1029,8 @@
       setupLead.textContent = c.setupLead;
       statusEl.textContent = c.loadingCategories;
       questionCountLabel.firstChild.textContent = `${c.questionCount} `;
+      selectAllBtn.textContent = c.selectAll;
+      deselectAllBtn.textContent = c.deselectAll;
       startButton.textContent = c.startQuiz;
       for (const backLink of backLinks) {
         backLink.textContent = c.backHome;

--- a/quiz-quest/index.html
+++ b/quiz-quest/index.html
@@ -57,8 +57,10 @@
 
     .grid {
       display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
-      gap: 10px;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      justify-items: stretch;
+      align-items: stretch;
+      gap: 12px;
       margin: 0 0 16px;
     }
 
@@ -67,6 +69,8 @@
       border-radius:10px;
       padding:10px;
       background:#181920;
+      width: 100%;
+      height: 92px;
       transition: border-color 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
     }
 
@@ -78,11 +82,14 @@
 
     .cat label {
       display:flex;
-      gap:8px;
+      flex-direction: column;
+      justify-content: center;
       align-items:center;
+      text-align: center;
+      gap:6px;
       cursor:pointer;
       position: relative;
-      min-height: 24px;
+      height: 100%;
     }
 
     .cat input[type="checkbox"] {
@@ -91,25 +98,28 @@
       pointer-events: none;
     }
 
-    .cat-pill {
-      width: 14px;
-      height: 14px;
-      border-radius: 999px;
-      border: 1px solid #6f7788;
-      background: #2f3340;
-      box-sizing: border-box;
-      flex-shrink: 0;
-      transition: border-color 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
+    .cat-copy {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 4px;
+      width: 100%;
     }
 
-    .cat.is-selected .cat-pill {
-      border-color: #56d5ad;
-      background: #43c89f;
-      box-shadow: 0 0 0 3px rgba(67, 200, 159, 0.2);
+    .cat-name {
+      display: block;
+      font-weight:700;
+      overflow-wrap: anywhere;
+      word-break: break-word;
     }
 
-    .cat-name { font-weight:700; }
-    .cat-count { color:var(--muted); font-size: 14px; }
+    .cat-count {
+      display: block;
+      color:var(--muted);
+      font-size: 14px;
+      overflow-wrap: anywhere;
+      word-break: break-word;
+    }
 
     .controls,
     .actions,
@@ -192,6 +202,10 @@
       <p id="setupStatus" class="status" role="status" aria-live="polite"></p>
 
       <section id="categoryGrid" class="grid" aria-label="Quiz quest categories"></section>
+      <div class="actions">
+        <button id="selectAllBtn" type="button">Select all</button>
+        <button id="deselectAllBtn" type="button">Deselect all</button>
+      </div>
 
       <div class="controls">
         <label for="questionCount" id="questionCountLabel">Question count
@@ -243,6 +257,8 @@
         selectedPool: 'Selected pool: {remaining} remaining of {total} total.',
         selectHint: 'Select at least one category to continue.',
         questionCount: 'Question count',
+        selectAll: 'Select all',
+        deselectAll: 'Deselect all',
         selectedPoolCount: 'Selected pool supports between 1 and {count} questions.',
         startQuest: 'Start quest',
         next: 'Next question',
@@ -276,6 +292,8 @@
         selectedPool: 'Valgt pool: {remaining} gjenstår av {total} totalt.',
         selectHint: 'Velg minst én kategori for å fortsette.',
         questionCount: 'Antall spørsmål',
+        selectAll: 'Velg alle',
+        deselectAll: 'Fjern alle',
         selectedPoolCount: 'Valgt pool støtter mellom 1 og {count} spørsmål.',
         startQuest: 'Start quest',
         next: 'Neste spørsmål',
@@ -324,6 +342,8 @@
     const poolStatus = document.getElementById('poolStatus');
     const setupStatus = document.getElementById('setupStatus');
     const categoryGrid = document.getElementById('categoryGrid');
+    const selectAllBtn = document.getElementById('selectAllBtn');
+    const deselectAllBtn = document.getElementById('deselectAllBtn');
     const questionCountLabel = document.getElementById('questionCountLabel');
     const questionCountInput = document.getElementById('questionCount');
     const countMeta = document.getElementById('countMeta');
@@ -512,6 +532,15 @@
       submitBtn.disabled = false;
     }
 
+    function setAllCategorySelection(selected) {
+      if (!state.categories.length) return;
+      for (const category of state.categories) {
+        category.selected = selected;
+      }
+      clearQuestionState();
+      renderCategories();
+    }
+
     function setQuestActive(active) {
       state.isQuestActive = active;
       setupView.classList.toggle('hidden', active);
@@ -549,12 +578,17 @@
         empty.className = 'muted';
         empty.textContent = ui().noCategories;
         categoryGrid.appendChild(empty);
+        selectAllBtn.disabled = true;
+        deselectAllBtn.disabled = true;
         startQuestBtn.disabled = true;
         renderPoolStatus();
         renderQuestionCountState();
         renderResetCategories();
         return;
       }
+
+      selectAllBtn.disabled = false;
+      deselectAllBtn.disabled = false;
 
       state.categories.forEach((category, index) => {
         const wrapper = document.createElement('article');
@@ -566,11 +600,8 @@
         checkbox.type = 'checkbox';
         checkbox.checked = category.selected;
 
-        const visualPill = document.createElement('span');
-        visualPill.className = 'cat-pill';
-        visualPill.setAttribute('aria-hidden', 'true');
-
         const textWrapper = document.createElement('span');
+        textWrapper.className = 'cat-copy';
         const nameEl = document.createElement('span');
         nameEl.className = 'cat-name';
         nameEl.textContent = category.name;
@@ -587,8 +618,8 @@
           renderQuestionCountState();
         });
 
-        textWrapper.append(nameEl, document.createElement('br'), countEl);
-        label.append(checkbox, visualPill, textWrapper);
+        textWrapper.append(nameEl, countEl);
+        label.append(checkbox, textWrapper);
         wrapper.appendChild(label);
         categoryGrid.appendChild(wrapper);
       });
@@ -620,10 +651,6 @@
           ...entry,
           selected: selectedBefore.size ? selectedBefore.has(entry.name) : false
         }));
-
-        if (!state.categories.some((category) => category.selected) && state.categories.length) {
-          state.categories[0].selected = true;
-        }
 
         renderCategories();
         setupStatus.className = 'status';
@@ -821,6 +848,8 @@
       introText.textContent = ui().intro;
       modeText.textContent = state.session ? ui().modeUser : ui().modeGuest;
       questionCountLabel.childNodes[0].nodeValue = `${ui().questionCount} `;
+      selectAllBtn.textContent = ui().selectAll;
+      deselectAllBtn.textContent = ui().deselectAll;
       startQuestBtn.textContent = ui().startQuest;
       nextBtn.textContent = ui().next;
       submitBtn.textContent = ui().submit;
@@ -831,6 +860,8 @@
     }
 
     questionCountInput.addEventListener('input', renderQuestionCountState);
+    selectAllBtn.addEventListener('click', () => setAllCategorySelection(true));
+    deselectAllBtn.addEventListener('click', () => setAllCategorySelection(false));
     nextBtn.addEventListener('click', proceedAfterAnswer);
     startQuestBtn.addEventListener('click', startQuest);
     answerForm.addEventListener('submit', submitAnswer);


### PR DESCRIPTION
### Motivation
- Provide a quick way for users to select or clear all quiz categories to streamline starting quizzes. 
- Improve the category grid responsiveness and visual consistency across quiz flows by adjusting card sizing and typography. 
- Make category selection behavior explicit (no implicit pre-selection) and ensure controls are disabled when no categories exist.

### Description
- Updated CSS for both `quiz-categories/index.html` and `quiz-quest/index.html` to use `repeat(auto-fit, minmax(220px, 1fr))`, added `justify-items`/`align-items`, increased gaps, and standardized `.cat` card sizing and inner layout (`.cat-copy`, `.cat-name`, `.cat-count`) while removing the old visual pill element. 
- Added `Select all` and `Deselect all` buttons to the category setup UIs, added i18n copy entries for English and Norwegian, and wired DOM references and click handlers (`setAllCategoriesSelected` / `setAllCategorySelection`) to toggle selection state and re-render. 
- Updated category rendering logic to enable/disable the new buttons when no categories are present, preserved previous selection state across refreshes in quest mode, and changed initial default selection in the categories overview to not pre-select categories.

### Testing
- No automated tests were added or run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2a922e92483339ba9b6e199ee4858)