### PR TITLE
Add contact form, admin inbox, privacy page, APIs and rate-limit for contact messages

### DIFF
--- a/admin/contact-messages/index.html
+++ b/admin/contact-messages/index.html
@@ -1,0 +1,268 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Contact messages | sarcasm.games</title>
+  <style>
+    :root { --bg:#0b0c10; --card:#1e1f25; --txt:#eaeaea; --bd:#2f313a; --accent:#4ecca3; --danger:#ff6b6b; --muted:#9aa0ad; }
+    body { margin:0; font:16px/1.4 system-ui, Segoe UI, Roboto, Arial; background:var(--bg); color:var(--txt); min-height:100dvh; }
+    main { max-width:1050px; margin:0 auto; padding:24px 16px 40px; }
+    .card { background:var(--card); border:1px solid var(--bd); border-radius:12px; padding:14px; margin-bottom:12px; }
+    .top-links { display:flex; gap:10px; margin-bottom:12px; }
+    .top-links a { color:var(--accent); }
+    .muted { color:var(--muted); }
+    table { width:100%; border-collapse:collapse; }
+    th, td { border-bottom:1px solid var(--bd); padding:8px; text-align:left; vertical-align:top; }
+    th { color:var(--muted); font-weight:600; }
+    button { border:0; border-radius:8px; padding:8px 12px; cursor:pointer; font-weight:700; }
+    .btn-neutral { background:var(--bd); color:var(--txt); }
+    .status { min-height:20px; color:var(--muted); }
+    .status.error { color:var(--danger); }
+    .details { margin-top:8px; border-top:1px dashed var(--bd); padding-top:8px; white-space:pre-wrap; }
+    .pill { display:inline-block; padding:2px 8px; border-radius:999px; border:1px solid var(--bd); font-size:.85rem; }
+  </style>
+</head>
+<body>
+  <main>
+    <div class="top-links">
+      <a href="/" id="backLink">← Home</a>
+      <a href="/insertquiz/" id="quizLink">Insert quiz</a>
+    </div>
+
+    <section class="card">
+      <h1 id="title">Contact messages</h1>
+      <p class="muted" id="subtitle">Admin-only inbox for contact form submissions.</p>
+      <div class="status" id="statusBox">Loading…</div>
+    </section>
+
+    <section class="card" id="tableCard" style="display:none">
+      <table>
+        <thead>
+          <tr>
+            <th id="thCreated">Created</th>
+            <th id="thName">Name</th>
+            <th id="thEmail">Email</th>
+            <th id="thStatus">Status</th>
+            <th id="thAction">Action</th>
+          </tr>
+        </thead>
+        <tbody id="tableBody"></tbody>
+      </table>
+    </section>
+  </main>
+
+  <script>
+    const QUIZ_LANGUAGE_KEY = 'quizLanguage';
+    let currentLanguage = 'en';
+
+    const I18N = {
+      en: {
+        backHome: '← Home',
+        insertQuiz: 'Insert quiz',
+        title: 'Contact messages',
+        subtitle: 'Admin-only inbox for contact form submissions.',
+        loading: 'Loading…',
+        forbidden: 'Access denied. Admin only.',
+        created: 'Created',
+        name: 'Name',
+        email: 'Email',
+        status: 'Status',
+        action: 'Action',
+        view: 'View',
+        hide: 'Hide',
+        empty: 'No messages yet.',
+        loadFailed: 'Failed to load messages.',
+        viewFailed: 'Failed to open message.'
+      },
+      no: {
+        backHome: '← Hjem',
+        insertQuiz: 'Sett inn quiz',
+        title: 'Kontaktmeldinger',
+        subtitle: 'Kun admin: innboks for meldinger fra kontaktskjemaet.',
+        loading: 'Laster…',
+        forbidden: 'Ingen tilgang. Kun admin.',
+        created: 'Opprettet',
+        name: 'Navn',
+        email: 'E-post',
+        status: 'Status',
+        action: 'Handling',
+        view: 'Vis',
+        hide: 'Skjul',
+        empty: 'Ingen meldinger ennå.',
+        loadFailed: 'Kunne ikke laste meldinger.',
+        viewFailed: 'Kunne ikke åpne melding.'
+      }
+    };
+
+    function getLanguage() {
+      const stored = window.localStorage.getItem(QUIZ_LANGUAGE_KEY);
+      return stored === 'no' ? 'no' : 'en';
+    }
+
+    function t() {
+      return I18N[currentLanguage] || I18N.en;
+    }
+
+    function setStatus(message, type = '') {
+      const statusBox = document.getElementById('statusBox');
+      statusBox.classList.remove('error');
+      if (type === 'error') statusBox.classList.add('error');
+      statusBox.textContent = message || '';
+    }
+
+    function formatDate(value) {
+      try {
+        return new Date(value).toLocaleString(currentLanguage === 'no' ? 'nb-NO' : 'en-US');
+      } catch {
+        return value || '-';
+      }
+    }
+
+    function applyTranslations() {
+      document.getElementById('backLink').textContent = t().backHome;
+      document.getElementById('quizLink').textContent = t().insertQuiz;
+      document.getElementById('title').textContent = t().title;
+      document.getElementById('subtitle').textContent = t().subtitle;
+      document.getElementById('thCreated').textContent = t().created;
+      document.getElementById('thName').textContent = t().name;
+      document.getElementById('thEmail').textContent = t().email;
+      document.getElementById('thStatus').textContent = t().status;
+      document.getElementById('thAction').textContent = t().action;
+    }
+
+    async function fetchMessage(id) {
+      const response = await fetch(`/api/admin/contact-messages/${id}`, { credentials: 'include' });
+      if (!response.ok) throw new Error('fetch_failed');
+      const data = await response.json();
+      return data.message;
+    }
+
+    async function markRead(id) {
+      await fetch(`/api/admin/contact-messages/${id}`, {
+        method: 'PATCH',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+
+    function renderTable(messages) {
+      const tableBody = document.getElementById('tableBody');
+      tableBody.innerHTML = '';
+
+      if (!messages.length) {
+        const row = document.createElement('tr');
+        const cell = document.createElement('td');
+        cell.colSpan = 5;
+        cell.textContent = t().empty;
+        row.appendChild(cell);
+        tableBody.appendChild(row);
+        return;
+      }
+
+      for (const entry of messages) {
+        const row = document.createElement('tr');
+
+        const created = document.createElement('td');
+        created.textContent = formatDate(entry.created_at);
+        row.appendChild(created);
+
+        const name = document.createElement('td');
+        name.textContent = entry.name;
+        row.appendChild(name);
+
+        const email = document.createElement('td');
+        email.textContent = entry.email;
+        row.appendChild(email);
+
+        const statusCell = document.createElement('td');
+        const statusPill = document.createElement('span');
+        statusPill.className = 'pill';
+        statusPill.textContent = entry.status;
+        statusCell.appendChild(statusPill);
+        row.appendChild(statusCell);
+
+        const action = document.createElement('td');
+        const btn = document.createElement('button');
+        btn.className = 'btn-neutral';
+        btn.textContent = t().view;
+        btn.type = 'button';
+
+        const detail = document.createElement('div');
+        detail.className = 'details';
+        detail.style.display = 'none';
+
+        btn.addEventListener('click', async () => {
+          if (detail.style.display === 'block') {
+            detail.style.display = 'none';
+            btn.textContent = t().view;
+            return;
+          }
+
+          try {
+            const fullMessage = await fetchMessage(entry.id);
+            detail.textContent = fullMessage.message;
+            detail.style.display = 'block';
+            btn.textContent = t().hide;
+
+            if (entry.status === 'new') {
+              await markRead(entry.id);
+              entry.status = 'read';
+              statusPill.textContent = 'read';
+            }
+          } catch {
+            setStatus(t().viewFailed, 'error');
+          }
+        });
+
+        action.appendChild(btn);
+        action.appendChild(detail);
+        row.appendChild(action);
+        tableBody.appendChild(row);
+      }
+    }
+
+    async function ensureAdmin() {
+      const response = await fetch('/api/auth/session', { credentials: 'include' });
+      if (!response.ok) {
+        window.location.replace('/?login=1&redirect=%2Fadmin%2Fcontact-messages%2F');
+        return null;
+      }
+
+      const data = await response.json();
+      if (data?.user?.role !== 'admin') {
+        setStatus(t().forbidden, 'error');
+        return null;
+      }
+
+      return data.user;
+    }
+
+    async function init() {
+      currentLanguage = getLanguage();
+      applyTranslations();
+      setStatus(t().loading);
+
+      const adminUser = await ensureAdmin();
+      if (!adminUser) return;
+
+      try {
+        const response = await fetch('/api/admin/contact-messages', { credentials: 'include' });
+        if (!response.ok) {
+          setStatus(t().loadFailed, 'error');
+          return;
+        }
+
+        const data = await response.json();
+        renderTable(data.messages || []);
+        document.getElementById('tableCard').style.display = 'block';
+        setStatus('');
+      } catch {
+        setStatus(t().loadFailed, 'error');
+      }
+    }
+
+    init();
+  </script>
+</body>
+</html>

--- a/api/_lib/rate-limit.js
+++ b/api/_lib/rate-limit.js
@@ -25,6 +25,10 @@ const SCOPE_LIMITS = {
     maxRequests: 180,
     burstWindowMs: 10 * 1000,
     burstMaxRequests: 36
+  },
+  'contact:create': {
+    windowMs: 10 * 60 * 1000,
+    maxRequests: 5
   }
 };
 

--- a/api/admin/contact-messages.js
+++ b/api/admin/contact-messages.js
@@ -1,0 +1,43 @@
+const { requireSession } = require('../_lib/auth');
+const { runQuery } = require('../_lib/db');
+
+function mapRow(row) {
+  return {
+    id: row.id,
+    created_at: row.created_at,
+    name: row.name,
+    email: row.email,
+    message: row.message,
+    status: row.status,
+    user_id: row.user_id
+  };
+}
+
+module.exports = async function handler(req, res) {
+  if (req.method !== 'GET') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const session = await requireSession(req, res);
+  if (!session) return;
+
+  if (session.role !== 'admin') {
+    res.status(403).json({ error: 'Forbidden' });
+    return;
+  }
+
+  try {
+    const result = await runQuery(
+      `SELECT id, created_at, user_id, name, email, message, status
+       FROM public.contact_messages
+       ORDER BY created_at DESC
+       LIMIT 200`
+    );
+
+    res.status(200).json({ messages: result.rows.map(mapRow) });
+  } catch (error) {
+    console.error('[admin/contact-messages] Failed to fetch messages:', error?.message);
+    res.status(500).json({ error: 'Failed to fetch contact messages' });
+  }
+};

--- a/api/admin/contact-messages/[id].js
+++ b/api/admin/contact-messages/[id].js
@@ -1,0 +1,81 @@
+const { requireSession } = require('../../_lib/auth');
+const { runQuery } = require('../../_lib/db');
+
+function parseId(value) {
+  const parsed = Number.parseInt(String(value || ''), 10);
+  if (!Number.isFinite(parsed) || parsed < 1) return null;
+  return parsed;
+}
+
+module.exports = async function handler(req, res) {
+  const id = parseId(req.query?.id);
+  if (!id) {
+    res.status(400).json({ error: 'Invalid message id' });
+    return;
+  }
+
+  const session = await requireSession(req, res);
+  if (!session) return;
+
+  if (session.role !== 'admin') {
+    res.status(403).json({ error: 'Forbidden' });
+    return;
+  }
+
+  try {
+    if (req.method === 'GET') {
+      const result = await runQuery(
+        `SELECT id, created_at, user_id, name, email, message, status
+         FROM public.contact_messages
+         WHERE id = $1
+         LIMIT 1`,
+        [id]
+      );
+
+      if (!result.rows[0]) {
+        res.status(404).json({ error: 'Message not found' });
+        return;
+      }
+
+      res.status(200).json({ message: result.rows[0] });
+      return;
+    }
+
+    if (req.method === 'PATCH') {
+      const updatedResult = await runQuery(
+        `UPDATE public.contact_messages
+         SET status = 'read'
+         WHERE id = $1
+           AND status = 'new'
+         RETURNING id, status`,
+        [id]
+      );
+
+      if (updatedResult.rows[0]) {
+        res.status(200).json({ message: updatedResult.rows[0] });
+        return;
+      }
+
+      const existingResult = await runQuery(
+        `SELECT id, status
+         FROM public.contact_messages
+         WHERE id = $1
+         LIMIT 1`,
+        [id]
+      );
+
+      if (!existingResult.rows[0]) {
+        res.status(404).json({ error: 'Message not found' });
+        return;
+      }
+
+      res.status(200).json({ message: existingResult.rows[0] });
+      return;
+    }
+
+    res.status(405).json({ error: 'Method not allowed' });
+  } catch (error) {
+    console.error('[admin/contact-messages/:id] Failed:', error?.message);
+    res.status(500).json({ error: 'Failed to process contact message' });
+  }
+};

--- a/api/contact/messages.js
+++ b/api/contact/messages.js
@@ -1,0 +1,78 @@
+const { requireSession } = require('../_lib/auth');
+const { runQuery } = require('../_lib/db');
+const { parseJsonBody } = require('../_lib/parse-body');
+const { isRateLimited } = require('../_lib/rate-limit');
+
+const NAME_MAX = 10;
+const EMAIL_MAX = 50;
+const MESSAGE_MAX = 100;
+
+function normalizeWhitespace(value) {
+  if (typeof value !== 'string') return null;
+  const normalized = value.replace(/\s+/g, ' ').trim();
+  return normalized || null;
+}
+
+function normalizeField(value, maxLength) {
+  const normalized = normalizeWhitespace(value);
+  if (!normalized || normalized.length > maxLength) return null;
+  return normalized;
+}
+
+function isValidEmail(value) {
+  if (typeof value !== 'string') return false;
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > EMAIL_MAX) return false;
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmed);
+}
+
+module.exports = async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const session = await requireSession(req, res);
+  if (!session) return;
+
+  if (await isRateLimited(req, 'contact:create')) {
+    res.status(429).json({
+      error: 'Too many contact messages. Please wait a bit before trying again.',
+      code: 'RATE_LIMITED'
+    });
+    return;
+  }
+
+  const body = parseJsonBody(req.body);
+  const name = normalizeField(body?.name, NAME_MAX);
+  const email = normalizeField(body?.email, EMAIL_MAX)?.toLowerCase() || null;
+  const message = normalizeField(body?.message, MESSAGE_MAX);
+
+  if (!name) {
+    res.status(400).json({ error: 'Name is required and must be 10 characters or fewer.' });
+    return;
+  }
+
+  if (!email || !isValidEmail(email)) {
+    res.status(400).json({ error: 'Email is required and must be valid, up to 50 characters.' });
+    return;
+  }
+
+  if (!message) {
+    res.status(400).json({ error: 'Message is required and must be 100 characters or fewer.' });
+    return;
+  }
+
+  try {
+    await runQuery(
+      `INSERT INTO public.contact_messages (user_id, name, email, message)
+       VALUES ($1, $2, $3, $4)`,
+      [session.id, name, email, message]
+    );
+
+    res.status(201).json({ ok: true });
+  } catch (error) {
+    console.error('[contact/messages] Failed to create message:', error?.message);
+    res.status(500).json({ error: 'Failed to submit message' });
+  }
+};

--- a/contact/index.html
+++ b/contact/index.html
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Contact | sarcasm.games</title>
+  <style>
+    :root { --bg:#0b0c10; --card:#1e1f25; --txt:#eaeaea; --bd:#2f313a; --accent:#4ecca3; --danger:#ff6b6b; --muted:#9aa0ad; }
+    body { margin:0; font:16px/1.4 system-ui, Segoe UI, Roboto, Arial; background:var(--bg); color:var(--txt); min-height:100dvh; }
+    main { max-width:720px; margin:0 auto; padding:26px 18px 40px; }
+    .card { background:var(--card); border:1px solid var(--bd); border-radius:12px; padding:16px; }
+    .top-links { display:flex; gap:10px; margin-bottom:12px; }
+    .top-links a { color:var(--accent); }
+    .field { margin-bottom:12px; }
+    label { display:block; margin-bottom:5px; color:var(--muted); font-size:.92rem; }
+    input, textarea { width:100%; box-sizing:border-box; border:1px solid var(--bd); border-radius:8px; background:var(--bg); color:var(--txt); padding:10px 12px; font:inherit; }
+    textarea { min-height:120px; resize:vertical; }
+    .submit-row { display:flex; justify-content:flex-end; }
+    button { border:0; border-radius:8px; padding:10px 14px; background:var(--accent); color:#111; font-weight:700; cursor:pointer; }
+    .status { min-height:20px; margin-top:10px; color:var(--muted); }
+    .status.error { color:var(--danger); }
+    .status.success { color:var(--accent); }
+  </style>
+</head>
+<body>
+  <main>
+    <div class="top-links">
+      <a href="/" id="backLink">← Home</a>
+      <a href="/gdpr/" id="gdprLink">Privacy</a>
+    </div>
+
+    <section class="card">
+      <h1 id="title">Contact us</h1>
+      <p id="subtitle" style="color:var(--muted)">Send a short message to the team.</p>
+
+      <form id="contactForm" novalidate>
+        <div class="field">
+          <label for="name" id="nameLabel">Name</label>
+          <input id="name" name="name" type="text" maxlength="10" required />
+        </div>
+
+        <div class="field">
+          <label for="email" id="emailLabel">Reply email</label>
+          <input id="email" name="email" type="email" maxlength="50" required />
+        </div>
+
+        <div class="field">
+          <label for="message" id="messageLabel">Message</label>
+          <textarea id="message" name="message" maxlength="100" required></textarea>
+        </div>
+
+        <div class="submit-row">
+          <button type="submit" id="submitBtn">Send message</button>
+        </div>
+      </form>
+
+      <div class="status" id="statusBox"></div>
+    </section>
+  </main>
+
+  <script>
+    const QUIZ_LANGUAGE_KEY = 'quizLanguage';
+    let currentLanguage = 'en';
+
+    const I18N = {
+      en: {
+        backHome: '← Home',
+        privacy: 'Privacy',
+        title: 'Contact us',
+        subtitle: 'Send a short message to the team.',
+        name: 'Name',
+        email: 'Reply email',
+        message: 'Message',
+        submit: 'Send message',
+        invalidName: 'Name is required and must be 10 characters or fewer.',
+        invalidEmail: 'Please enter a valid email (max 50 characters).',
+        invalidMessage: 'Message is required and must be 100 characters or fewer.',
+        success: 'Message sent. Thank you!',
+        failed: 'Could not send message. Please try again.',
+        rateLimited: 'Too many messages sent. Please wait a few minutes and try again.',
+        loginRedirect: 'Please log in to open the contact page.'
+      },
+      no: {
+        backHome: '← Hjem',
+        privacy: 'Personvern',
+        title: 'Kontakt oss',
+        subtitle: 'Send en kort melding til teamet.',
+        name: 'Navn',
+        email: 'E-post for svar',
+        message: 'Melding',
+        submit: 'Send melding',
+        invalidName: 'Navn er påkrevd og må være maks 10 tegn.',
+        invalidEmail: 'Skriv inn en gyldig e-post (maks 50 tegn).',
+        invalidMessage: 'Melding er påkrevd og må være maks 100 tegn.',
+        success: 'Meldingen er sendt. Takk!',
+        failed: 'Kunne ikke sende melding. Prøv igjen.',
+        rateLimited: 'For mange meldinger sendt. Vent noen minutter og prøv igjen.',
+        loginRedirect: 'Logg inn for å åpne kontaktsiden.'
+      }
+    };
+
+    function getLanguage() {
+      const stored = window.localStorage.getItem(QUIZ_LANGUAGE_KEY);
+      return stored === 'no' ? 'no' : 'en';
+    }
+
+    function t() {
+      return I18N[currentLanguage] || I18N.en;
+    }
+
+    function setStatus(message, type = '') {
+      const statusBox = document.getElementById('statusBox');
+      statusBox.classList.remove('error', 'success');
+      if (type) statusBox.classList.add(type);
+      statusBox.textContent = message || '';
+    }
+
+    function validateForm(name, email, message) {
+      if (!name || name.length > 10) return t().invalidName;
+      if (!email || email.length > 50 || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) return t().invalidEmail;
+      if (!message || message.length > 100) return t().invalidMessage;
+      return null;
+    }
+
+    function applyTranslations() {
+      document.getElementById('backLink').textContent = t().backHome;
+      document.getElementById('gdprLink').textContent = t().privacy;
+      document.getElementById('title').textContent = t().title;
+      document.getElementById('subtitle').textContent = t().subtitle;
+      document.getElementById('nameLabel').textContent = t().name;
+      document.getElementById('emailLabel').textContent = t().email;
+      document.getElementById('messageLabel').textContent = t().message;
+      document.getElementById('submitBtn').textContent = t().submit;
+    }
+
+    async function ensureLoggedIn() {
+      const response = await fetch('/api/auth/session', { credentials: 'include' });
+      if (response.ok) return true;
+
+      const redirect = encodeURIComponent('/contact/');
+      const status = encodeURIComponent(t().loginRedirect);
+      window.location.replace(`/?login=1&redirect=${redirect}&status=${status}`);
+      return false;
+    }
+
+    async function onSubmit(event) {
+      event.preventDefault();
+      setStatus('');
+
+      const name = document.getElementById('name').value.trim();
+      const email = document.getElementById('email').value.trim();
+      const message = document.getElementById('message').value.trim();
+
+      const validationError = validateForm(name, email, message);
+      if (validationError) {
+        setStatus(validationError, 'error');
+        return;
+      }
+
+      const response = await fetch('/api/contact/messages', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ name, email, message })
+      });
+
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        if (response.status === 429 || data.code === 'RATE_LIMITED') {
+          setStatus(t().rateLimited, 'error');
+          return;
+        }
+        setStatus(data.error || t().failed, 'error');
+        return;
+      }
+
+      document.getElementById('contactForm').reset();
+      setStatus(t().success, 'success');
+    }
+
+    async function init() {
+      currentLanguage = getLanguage();
+      applyTranslations();
+
+      const allowed = await ensureLoggedIn();
+      if (!allowed) return;
+
+      document.getElementById('contactForm').addEventListener('submit', onSubmit);
+    }
+
+    init().catch(() => setStatus(t().failed, 'error'));
+  </script>
+</body>
+</html>

--- a/gdpr/index.html
+++ b/gdpr/index.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Privacy | sarcasm.games</title>
+  <style>
+    :root { --bg:#0b0c10; --card:#1e1f25; --txt:#eaeaea; --bd:#2f313a; --accent:#4ecca3; --muted:#9aa0ad; }
+    body { margin:0; font:16px/1.5 system-ui, Segoe UI, Roboto, Arial; background:var(--bg); color:var(--txt); }
+    main { max-width:760px; margin:0 auto; padding:24px 18px 40px; }
+    .card { background:var(--card); border:1px solid var(--bd); border-radius:12px; padding:16px; }
+    .top-links { display:flex; gap:10px; margin-bottom:12px; }
+    .top-links a { color:var(--accent); }
+    h1 { margin-top:0; }
+    h2 { margin-top:18px; font-size:1.05rem; }
+    p { color:var(--muted); margin:8px 0; }
+  </style>
+</head>
+<body>
+  <main>
+    <div class="top-links">
+      <a href="/" id="backLink">← Home</a>
+      <a href="/contact/" id="contactLink">Contact</a>
+    </div>
+
+    <section class="card">
+      <h1 id="title">Privacy at sarcasm.games</h1>
+
+      <h2 id="h1">What we store</h2>
+      <p id="p1">Registered users can submit a contact message through sarcasm.games. When they do, we store the name, reply email, and message content they submit.</p>
+
+      <h2 id="h2">Account and login data</h2>
+      <p id="p2">We process account-related information needed for login and authentication so users can access their account and protected features.</p>
+
+      <h2 id="h3">How data is used</h2>
+      <p id="p3">Data may be used to operate the service, keep the site secure, and respond to contact messages sent by users.</p>
+
+      <h2 id="h4">Privacy questions</h2>
+      <p id="p4">If you have privacy questions, please use the contact page at sarcasm.games/contact after signing in.</p>
+    </section>
+  </main>
+
+  <script>
+    const QUIZ_LANGUAGE_KEY = 'quizLanguage';
+
+    const I18N = {
+      en: {
+        backHome: '← Home',
+        contact: 'Contact',
+        title: 'Privacy at sarcasm.games',
+        h1: 'What we store',
+        p1: 'Registered users can submit a contact message through sarcasm.games. When they do, we store the name, reply email, and message content they submit.',
+        h2: 'Account and login data',
+        p2: 'We process account-related information needed for login and authentication so users can access their account and protected features.',
+        h3: 'How data is used',
+        p3: 'Data may be used to operate the service, keep the site secure, and respond to contact messages sent by users.',
+        h4: 'Privacy questions',
+        p4: 'If you have privacy questions, please use the contact page at sarcasm.games/contact after signing in.'
+      },
+      no: {
+        backHome: '← Hjem',
+        contact: 'Kontakt',
+        title: 'Personvern hos sarcasm.games',
+        h1: 'Hva vi lagrer',
+        p1: 'Registrerte brukere kan sende kontaktmelding via sarcasm.games. Når de gjør det, lagrer vi navn, e-post for svar og meldingsinnholdet de sender inn.',
+        h2: 'Konto- og innloggingsdata',
+        p2: 'Vi behandler kontoinformasjon som trengs for innlogging og autentisering, slik at brukere kan få tilgang til kontoen sin og beskyttede funksjoner.',
+        h3: 'Hvordan data brukes',
+        p3: 'Data kan brukes for å drifte tjenesten, holde nettstedet sikkert og svare på kontaktmeldinger fra brukere.',
+        h4: 'Spørsmål om personvern',
+        p4: 'Hvis du har spørsmål om personvern, bruk kontaktsiden på sarcasm.games/contact etter innlogging.'
+      }
+    };
+
+    const lang = window.localStorage.getItem(QUIZ_LANGUAGE_KEY) === 'no' ? 'no' : 'en';
+    const texts = I18N[lang] || I18N.en;
+
+    Object.entries(texts).forEach(([key, value]) => {
+      const node = document.getElementById(key);
+      if (node) node.textContent = value;
+    });
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -48,6 +48,8 @@
     .season-grid{display:grid;gap:10px;grid-template-columns:repeat(auto-fit,minmax(150px,1fr))}
     .module-group{border:1px dashed var(--bd);border-radius:10px;padding:10px}
     .module-group h4{margin:0 0 8px}
+    .public-links{margin-top:16px;display:flex;gap:10px;justify-content:center;flex-wrap:wrap}
+    .public-links a{padding:10px 12px}
   </style>
 </head>
 <body>
@@ -74,6 +76,10 @@
       <h1>sarcasm.games</h1>
       <p id="pageSubtitle">Where do you want to go?</p>
       <div class="grid" id="gameGrid"></div>
+      <div class="public-links">
+        <a href="/contact/" id="contactLink" class="hidden">Contact</a>
+        <a href="/gdpr/" id="gdprLink">Privacy</a>
+      </div>
 
       <section class="season-card hidden" id="featureModulesSection">
         <h3 id="featureModulesTitle">Admin modules</h3>
@@ -227,6 +233,9 @@
         statusDeleteAccountConfirm: 'This will permanently delete your account. Continue?',
         statusDeleteAccountFailed: 'Could not delete account.',
         statusDeleteAccountOk: 'Your account has been deleted.',
+        contactLink: 'Contact',
+        privacyLink: 'Privacy',
+        statusMustLoginFirst: 'Please log in to continue.',
         captchaPool: [
           { id: 'site_first_word', question: 'What is the first word in this website name?' },
           { id: 'bil_reverse', question: 'Type the word BIL backwards' },
@@ -281,6 +290,9 @@
         statusDeleteAccountConfirm: 'Dette vil slette kontoen permanent. Vil du fortsette?',
         statusDeleteAccountFailed: 'Kunne ikke slette kontoen.',
         statusDeleteAccountOk: 'Kontoen din er slettet.',
+        contactLink: 'Kontakt',
+        privacyLink: 'Personvern',
+        statusMustLoginFirst: 'Logg inn for å fortsette.',
         captchaPool: [
           { id: 'site_first_word', question: 'Hva er første ord i nettsidens navn?' },
           { id: 'bil_reverse', question: 'Skriv ordet BIL baklengs' },
@@ -305,6 +317,7 @@
     let currentUser = null;
     let currentLanguage = 'en';
     let pendingConfirmationUsername = '';
+    let postLoginRedirect = null;
     let listenersBound = false;
 
     const statusBox = document.getElementById('statusBox');
@@ -324,6 +337,7 @@
     const languageSelect = document.getElementById('languageSelect');
     const activeLanguageLabel = document.getElementById('activeLanguageLabel');
     const gameGrid = document.getElementById('gameGrid');
+    const contactLink = document.getElementById('contactLink');
 
     function t() {
       return I18N[currentLanguage] || I18N.en;
@@ -519,6 +533,8 @@
       document.getElementById('registerBtn').textContent = texts.createAccountButton;
       document.getElementById('deleteAccountBtn').textContent = texts.deleteAccountButton;
       document.getElementById('logoutBtn').textContent = texts.logoutButton;
+      document.getElementById('contactLink').textContent = texts.contactLink;
+      document.getElementById('gdprLink').textContent = texts.privacyLink;
 
       if (authShell.classList.contains('hidden')) {
         toggleLoginBtn.textContent = texts.loginButton;
@@ -643,6 +659,7 @@
         deleteAccountBtn.classList.remove('hidden');
         logoutBtn.classList.remove('hidden');
         toggleLoginBtn.classList.add('hidden');
+        contactLink.classList.remove('hidden');
       } else {
         welcomeText.textContent = t().welcomeGuest;
         closeLoginPanel();
@@ -650,6 +667,7 @@
         logoutBtn.classList.add('hidden');
         toggleLoginBtn.classList.remove('hidden');
         toggleLoginBtn.textContent = t().loginButton;
+        contactLink.classList.add('hidden');
       }
 
       renderFeatureModules(user);
@@ -693,6 +711,12 @@
 
         const sessionUser = await fetchSession();
         await applyUserState(sessionUser || data.user);
+        if (postLoginRedirect && typeof postLoginRedirect === 'string' && postLoginRedirect.startsWith('/')) {
+          const destination = postLoginRedirect;
+          postLoginRedirect = null;
+          window.location.assign(destination);
+          return;
+        }
         setStatus('');
       } catch (error) {
         console.error('[index] Login request failed:', error);
@@ -896,6 +920,23 @@
       await applyUserState(null);
       const user = await fetchSession();
       if (user) await applyUserState(user);
+
+      const params = new URLSearchParams(window.location.search);
+      const requestedRedirect = params.get('redirect');
+      if (requestedRedirect && requestedRedirect.startsWith('/')) {
+        postLoginRedirect = requestedRedirect;
+      }
+
+      if (params.get('status')) {
+        setStatus(params.get('status'));
+      }
+
+      if (params.get('login') === '1' && !currentUser) {
+        toggleLoginPanel();
+        setStatus(params.get('status') || t().statusMustLoginFirst);
+      } else if (params.get('login') === '1' && currentUser && postLoginRedirect) {
+        window.location.assign(postLoginRedirect);
+      }
     }
 
     init().catch((error) => {


### PR DESCRIPTION
### Motivation
- Provide a simple, signed-in contact form and an admin-only inbox so the team can receive and manage user messages while exposing a privacy/FAQ page about stored data.
- Prevent abuse by adding a rate-limit scope for contact submissions and surface navigation links for contact/privacy in the main UI.

### Description
- Add a public contact page at `/contact/` with client-side validation, i18n, and a POST to `api/contact/messages` to submit messages from signed-in users.
- Add a static privacy page at `/gdpr/` describing what is stored and how contact messages are used.
- Implement server APIs: `api/contact/messages` (POST) to create contact messages with input normalization and validation, `api/admin/contact-messages` (GET) to list recent messages for admins, and `api/admin/contact-messages/[id]` (GET, PATCH) to fetch a message and mark it as read; all endpoints enforce session/auth checks.
- Add a new rate-limit scope `contact:create` and wire `isRateLimited` into the contact submission flow, and add the admin inbox UI at `/admin/contact-messages/` to view and mark messages read; update `index.html` to show contact/privacy links, translations, and post-login redirect handling.

### Testing
- No automated tests were added or executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c55623af2483338a0e09b09d016405)