### PR TITLE
Add admin members page and delete-user API; filtered profile listing and email masking

### DIFF
--- a/api/_lib/db.js
+++ b/api/_lib/db.js
@@ -331,11 +331,32 @@ async function upsertProfileFromAuthUser(authUser) {
   return result.rows[0] || null;
 }
 
-async function listProfiles() {
+async function listProfiles({ country = null, username = null, email = null } = {}) {
+  const clauses = [];
+  const params = [];
+
+  if (readString(country)) {
+    params.push(String(country).trim().toUpperCase());
+    clauses.push(`country = $${params.length}`);
+  }
+
+  if (readString(username)) {
+    params.push(`%${String(username).trim().toLowerCase()}%`);
+    clauses.push(`username_normalized LIKE $${params.length}`);
+  }
+
+  if (readString(email)) {
+    params.push(`%${String(email).trim().toLowerCase()}%`);
+    clauses.push(`email_normalized LIKE $${params.length}`);
+  }
+
+  const whereClause = clauses.length ? `WHERE ${clauses.join(' AND ')}` : '';
   const result = await runQuery(
     `SELECT auth_user_id, username, email, role, country, created_at
      FROM public.profiles
-     ORDER BY created_at ASC, username_normalized ASC`
+     ${whereClause}
+     ORDER BY created_at ASC, username_normalized ASC`,
+    params
   );
 
   return result.rows;

--- a/api/admin/delete-user.js
+++ b/api/admin/delete-user.js
@@ -1,0 +1,79 @@
+const { requireSession } = require('../_lib/auth');
+const { getProfileByAuthUserId } = require('../_lib/db');
+const { getSupabaseAdminClient } = require('../_lib/supabase');
+
+function parseRequestBody(body) {
+  if (!body) return {};
+  if (typeof body === 'string') {
+    try {
+      return JSON.parse(body);
+    } catch {
+      return {};
+    }
+  }
+  if (typeof body === 'object') return body;
+  return {};
+}
+
+function readString(value) {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+module.exports = async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const session = await requireSession(req, res);
+  if (!session) return;
+
+  if (session.role !== 'admin') {
+    res.status(403).json({ error: 'Forbidden' });
+    return;
+  }
+
+  const { userId } = parseRequestBody(req.body);
+  const targetUserId = readString(userId);
+  if (!targetUserId) {
+    res.status(400).json({ error: 'Invalid user id', code: 'INVALID_USER_ID' });
+    return;
+  }
+
+  if (targetUserId === session.id) {
+    res.status(403).json({ error: 'Cannot delete your own account', code: 'CANNOT_DELETE_SELF' });
+    return;
+  }
+
+  try {
+    const targetProfile = await getProfileByAuthUserId(targetUserId);
+    if (!targetProfile) {
+      res.status(404).json({ error: 'User not found', code: 'USER_NOT_FOUND' });
+      return;
+    }
+
+    if (readString(targetProfile.role) === 'admin') {
+      res.status(403).json({ error: 'Cannot delete admin user', code: 'CANNOT_DELETE_ADMIN' });
+      return;
+    }
+
+    const supabaseAdmin = getSupabaseAdminClient();
+    const { error } = await supabaseAdmin.auth.admin.deleteUser(targetUserId);
+    if (error) {
+      console.error('[admin/delete-user] Failed to delete user', {
+        targetUserId,
+        error: error.message
+      });
+      res.status(500).json({ error: 'Failed to delete user', code: 'DELETE_FAILED' });
+      return;
+    }
+
+    res.status(200).json({ ok: true });
+  } catch (error) {
+    console.error('[admin/delete-user] Failed to process delete', {
+      targetUserId,
+      error: error?.message
+    });
+    res.status(500).json({ error: 'Failed to delete user', code: 'DELETE_FAILED' });
+  }
+};

--- a/api/admin/users.js
+++ b/api/admin/users.js
@@ -5,11 +5,34 @@ function readString(value) {
   return typeof value === 'string' && value.trim() ? value.trim() : null;
 }
 
+function maskEmail(email) {
+  const safeEmail = readString(email);
+  if (!safeEmail) return '***';
+
+  const [localPartRaw = '', domainRaw = ''] = safeEmail.split('@');
+  const localPart = String(localPartRaw);
+  const domain = readString(domainRaw);
+
+  if (!domain) return '***';
+
+  const localPrefix = localPart.length >= 2
+    ? localPart.slice(0, 2)
+    : localPart.length === 1
+      ? localPart.slice(0, 1)
+      : '';
+
+  if (!localPrefix) {
+    return `***@${domain}`;
+  }
+
+  return `${localPrefix}***@${domain}`;
+}
+
 function mapMember(profile) {
   return {
     id: profile.auth_user_id,
     username: readString(profile.username) || 'user',
-    email: readString(profile.email),
+    email: maskEmail(profile.email),
     role: readString(profile.role) || 'user',
     country: readString(profile.country) || 'unknown'
   };
@@ -30,7 +53,11 @@ module.exports = async function handler(req, res) {
   }
 
   try {
-    const users = await listProfiles();
+    const users = await listProfiles({
+      country: readString(req.query?.country),
+      username: readString(req.query?.username),
+      email: readString(req.query?.email)
+    });
     res.status(200).json({ users: users.map(mapMember) });
   } catch (error) {
     console.error('[admin/users] Failed to load members:', error?.message);

--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
     a:hover{transform:translateY(-1px);border-color:#767a88}
     a:hover .tooltip-text{visibility:visible;opacity:1}
 
-    .season-card,.member-list{margin-top:24px;background:var(--card);border:1px solid var(--bd);border-radius:12px;padding:14px;text-align:left}
+    .season-card{margin-top:24px;background:var(--card);border:1px solid var(--bd);border-radius:12px;padding:14px;text-align:left}
     .season-grid{display:grid;gap:10px;grid-template-columns:repeat(auto-fit,minmax(150px,1fr))}
     .module-group{border:1px dashed var(--bd);border-radius:10px;padding:10px}
     .module-group h4{margin:0 0 8px}
@@ -86,10 +86,6 @@
         <div class="season-grid" id="featureModulesGrid"></div>
       </section>
 
-      <section id="memberListSection" class="member-list hidden">
-        <h3 id="memberListTitle">Member list (admin only)</h3>
-        <ul id="memberList"></ul>
-      </section>
     </div>
 
     <div id="authShell" class="auth-shell hidden">
@@ -196,7 +192,6 @@
         logoutButton: 'Logout',
         deleteAccountButton: 'Delete me',
         pageSubtitle: 'Where do you want to go?',
-        memberListTitle: 'Member list (admin only)',
         authTitle: 'Optional login',
         authSubtitle: 'Log in for personal or admin-only features.',
         tabLogin: 'Login',
@@ -253,7 +248,6 @@
         logoutButton: 'Logg ut',
         deleteAccountButton: 'Slett meg',
         pageSubtitle: 'Hvor vil du gå?',
-        memberListTitle: 'Medlemsliste (kun admin)',
         authTitle: 'Valgfri innlogging',
         authSubtitle: 'Logg inn for personlige eller admin-funksjoner.',
         tabLogin: 'Logg inn',
@@ -308,7 +302,8 @@
         adminOnly: true,
         links: [
           { href: '/insertquiz/', label: 'Insert quiz questions' },
-          { href: '/admin/contact-messages/', label: 'Contact messages' }
+          { href: '/admin/contact-messages/', label: 'Contact messages' },
+          { href: '/members/', label: 'Members' }
         ]
       }
     ];
@@ -324,8 +319,6 @@
     const statusBox = document.getElementById('statusBox');
     const authShell = document.getElementById('authShell');
     const welcomeText = document.getElementById('welcomeText');
-    const memberListSection = document.getElementById('memberListSection');
-    const memberList = document.getElementById('memberList');
     const featureModulesSection = document.getElementById('featureModulesSection');
     const featureModulesTitle = document.getElementById('featureModulesTitle');
     const featureModulesGrid = document.getElementById('featureModulesGrid');
@@ -506,7 +499,6 @@
       document.getElementById('languageLabel').textContent = texts.languageLabel;
       document.getElementById('themeToggle').textContent = texts.themeButton;
       document.getElementById('pageSubtitle').textContent = texts.pageSubtitle;
-      document.getElementById('memberListTitle').textContent = texts.memberListTitle;
       document.getElementById('authTitle').textContent = texts.authTitle;
       document.getElementById('authSubtitle').textContent = texts.authSubtitle;
 
@@ -619,38 +611,6 @@
       }
     }
 
-    async function renderMemberList(user) {
-      if (!user || user.role !== 'admin') {
-        memberListSection.classList.add('hidden');
-        memberList.innerHTML = '';
-        return;
-      }
-
-      try {
-        const response = await fetch('/api/admin/users', { credentials: 'include' });
-        if (!response.ok) {
-          memberListSection.classList.add('hidden');
-          memberList.innerHTML = '';
-          return;
-        }
-
-        const data = await response.json();
-        memberList.innerHTML = '';
-
-        for (const member of data.users || []) {
-          const li = document.createElement('li');
-          li.textContent = `${member.username}${member.role === 'admin' ? ' (admin)' : ''} (${member.email}) - ${t().countryLabel}: ${member.country || t().unknownCountry}`;
-          memberList.appendChild(li);
-        }
-
-        memberListSection.classList.remove('hidden');
-      } catch (error) {
-        console.error('[index] Failed to render member list:', error);
-        memberListSection.classList.add('hidden');
-        memberList.innerHTML = '';
-      }
-    }
-
     async function applyUserState(user) {
       currentUser = user;
 
@@ -672,7 +632,6 @@
       }
 
       renderFeatureModules(user);
-      await renderMemberList(user);
     }
 
     async function login() {

--- a/members/index.html
+++ b/members/index.html
@@ -1,0 +1,343 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Members | sarcasm.games</title>
+  <style>
+    :root { --bg:#0b0c10; --card:#1e1f25; --txt:#eaeaea; --bd:#2f313a; --accent:#4ecca3; --danger:#ff6b6b; --muted:#9aa0ad; }
+    body { margin:0; font:16px/1.4 system-ui, Segoe UI, Roboto, Arial; background:var(--bg); color:var(--txt); min-height:100dvh; }
+    main { max-width:1100px; margin:0 auto; padding:24px 16px 40px; }
+    .top-links { display:flex; gap:10px; margin-bottom:12px; }
+    .top-links a { color:var(--accent); }
+    .card { background:var(--card); border:1px solid var(--bd); border-radius:12px; padding:14px; margin-bottom:12px; }
+    .muted { color:var(--muted); }
+    .status { min-height:20px; color:var(--muted); }
+    .status.error { color:var(--danger); }
+    .filters { display:grid; gap:10px; grid-template-columns:repeat(auto-fit,minmax(180px,1fr)); align-items:end; margin-top:12px; }
+    label { display:block; margin-bottom:4px; color:var(--muted); font-size:.9rem; }
+    input, select { width:100%; box-sizing:border-box; background:var(--bg); border:1px solid var(--bd); color:var(--txt); padding:8px 10px; border-radius:8px; }
+    button { border:0; border-radius:8px; padding:8px 12px; cursor:pointer; font-weight:700; }
+    .btn-primary { background:var(--accent); color:#111; }
+    .btn-danger { background:var(--danger); color:#fff; }
+    .btn-neutral { background:var(--bd); color:var(--txt); }
+    .btn-danger:disabled { opacity:.5; cursor:not-allowed; }
+    table { width:100%; border-collapse:collapse; }
+    th, td { border-bottom:1px solid var(--bd); padding:8px; text-align:left; }
+    th { color:var(--muted); font-weight:600; }
+  </style>
+</head>
+<body>
+  <main>
+    <div class="top-links">
+      <a href="/" id="backLink">← Home</a>
+    </div>
+
+    <section class="card">
+      <h1 id="title">Members</h1>
+      <p class="muted" id="subtitle">Admin-only member list.</p>
+      <div class="filters">
+        <div>
+          <label for="countryFilter" id="countryLabel">Filter by country</label>
+          <select id="countryFilter"></select>
+        </div>
+        <div>
+          <label for="usernameSearch" id="usernameLabel">Search by username</label>
+          <input id="usernameSearch" type="text" autocomplete="off" />
+        </div>
+        <div>
+          <label for="emailSearch" id="emailLabel">Search by email</label>
+          <input id="emailSearch" type="text" autocomplete="off" />
+        </div>
+        <div>
+          <button type="button" class="btn-primary" id="searchBtn">Search</button>
+        </div>
+      </div>
+      <div class="status" id="statusBox"></div>
+    </section>
+
+    <section class="card" id="tableCard" style="display:none">
+      <table>
+        <thead>
+          <tr>
+            <th id="thUsername">Username</th>
+            <th id="thEmail">Email</th>
+            <th id="thCountry">Country</th>
+            <th id="thRole">Role</th>
+            <th id="thAction">Action</th>
+          </tr>
+        </thead>
+        <tbody id="tableBody"></tbody>
+      </table>
+    </section>
+  </main>
+
+  <script>
+    const QUIZ_LANGUAGE_KEY = 'quizLanguage';
+    let currentLanguage = 'en';
+
+    const I18N = {
+      en: {
+        backHome: '← Home',
+        title: 'Members',
+        subtitle: 'Admin-only member list.',
+        search: 'Search',
+        searchEmail: 'Search by email',
+        searchUsername: 'Search by username',
+        filterCountry: 'Filter by country',
+        loading: 'Loading…',
+        forbidden: 'Access denied. Admin only.',
+        noResults: 'No results.',
+        username: 'Username',
+        email: 'Email',
+        country: 'Country',
+        role: 'Role',
+        action: 'Action',
+        delete: 'Delete',
+        cannotDeleteAdmin: 'Cannot delete admin',
+        cannotDeleteSelf: 'Cannot delete yourself',
+        confirmDelete: 'Delete this member?',
+        loadFailed: 'Failed to load members.',
+        deleteFailed: 'Failed to delete member.',
+        allCountries: 'All countries'
+      },
+      no: {
+        backHome: '← Hjem',
+        title: 'Medlemmer',
+        subtitle: 'Kun admin: medlemsliste.',
+        search: 'Søk',
+        searchEmail: 'Søk på e-post',
+        searchUsername: 'Søk på brukernavn',
+        filterCountry: 'Filtrer på land',
+        loading: 'Laster…',
+        forbidden: 'Ingen tilgang. Kun admin.',
+        noResults: 'Ingen treff.',
+        username: 'Brukernavn',
+        email: 'E-post',
+        country: 'Land',
+        role: 'Rolle',
+        action: 'Handling',
+        delete: 'Slett',
+        cannotDeleteAdmin: 'Kan ikke slette admin',
+        cannotDeleteSelf: 'Kan ikke slette deg selv',
+        confirmDelete: 'Slette dette medlemmet?',
+        loadFailed: 'Kunne ikke laste medlemmer.',
+        deleteFailed: 'Kunne ikke slette medlem.',
+        allCountries: 'Alle land'
+      }
+    };
+
+    function getLanguage() {
+      const stored = window.localStorage.getItem(QUIZ_LANGUAGE_KEY);
+      return stored === 'no' ? 'no' : 'en';
+    }
+
+    function t() {
+      return I18N[currentLanguage] || I18N.en;
+    }
+
+    function setStatus(message, type = '') {
+      const statusBox = document.getElementById('statusBox');
+      statusBox.classList.remove('error');
+      if (type === 'error') statusBox.classList.add('error');
+      statusBox.textContent = message || '';
+    }
+
+    function applyTranslations() {
+      document.getElementById('backLink').textContent = t().backHome;
+      document.getElementById('title').textContent = t().title;
+      document.getElementById('subtitle').textContent = t().subtitle;
+      document.getElementById('countryLabel').textContent = t().filterCountry;
+      document.getElementById('usernameLabel').textContent = t().searchUsername;
+      document.getElementById('emailLabel').textContent = t().searchEmail;
+      document.getElementById('searchBtn').textContent = t().search;
+      document.getElementById('thUsername').textContent = t().username;
+      document.getElementById('thEmail').textContent = t().email;
+      document.getElementById('thCountry').textContent = t().country;
+      document.getElementById('thRole').textContent = t().role;
+      document.getElementById('thAction').textContent = t().action;
+    }
+
+    async function ensureAdmin() {
+      const response = await fetch('/api/auth/session', { credentials: 'include' });
+      if (!response.ok) {
+        window.location.replace('/?login=1&redirect=%2Fmembers%2F');
+        return null;
+      }
+
+      const data = await response.json();
+      if (data?.user?.role !== 'admin') {
+        setStatus(t().forbidden, 'error');
+        return null;
+      }
+
+      return data.user;
+    }
+
+    function getFilters() {
+      return {
+        country: document.getElementById('countryFilter').value.trim(),
+        username: document.getElementById('usernameSearch').value.trim(),
+        email: document.getElementById('emailSearch').value.trim()
+      };
+    }
+
+    async function fetchMembers() {
+      const filters = getFilters();
+      const params = new URLSearchParams();
+      if (filters.country) params.set('country', filters.country);
+      if (filters.username) params.set('username', filters.username);
+      if (filters.email) params.set('email', filters.email);
+
+      const queryString = params.toString();
+      const response = await fetch(`/api/admin/users${queryString ? `?${queryString}` : ''}`, { credentials: 'include' });
+      if (!response.ok) throw new Error('load_failed');
+      const data = await response.json();
+      return Array.isArray(data.users) ? data.users : [];
+    }
+
+    function renderCountryOptions(users) {
+      const select = document.getElementById('countryFilter');
+      const selectedValue = select.value;
+      const countries = [...new Set(users.map((entry) => (entry.country || '').trim()).filter(Boolean))].sort();
+
+      select.innerHTML = '';
+      const allOption = document.createElement('option');
+      allOption.value = '';
+      allOption.textContent = t().allCountries;
+      select.appendChild(allOption);
+
+      for (const country of countries) {
+        const option = document.createElement('option');
+        option.value = country;
+        option.textContent = country;
+        select.appendChild(option);
+      }
+
+      select.value = countries.includes(selectedValue) ? selectedValue : '';
+    }
+
+    async function deleteMember(userId) {
+      const response = await fetch('/api/admin/delete-user', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userId })
+      });
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        throw new Error(data.code || 'DELETE_FAILED');
+      }
+    }
+
+    function renderTable(users) {
+      const tableBody = document.getElementById('tableBody');
+      tableBody.innerHTML = '';
+
+      if (!users.length) {
+        const row = document.createElement('tr');
+        const cell = document.createElement('td');
+        cell.colSpan = 5;
+        cell.textContent = t().noResults;
+        row.appendChild(cell);
+        tableBody.appendChild(row);
+        return;
+      }
+
+      for (const member of users) {
+        const row = document.createElement('tr');
+
+        const username = document.createElement('td');
+        username.textContent = member.username || '-';
+        row.appendChild(username);
+
+        const email = document.createElement('td');
+        email.textContent = member.email || '-';
+        row.appendChild(email);
+
+        const country = document.createElement('td');
+        country.textContent = member.country || '-';
+        row.appendChild(country);
+
+        const role = document.createElement('td');
+        role.textContent = member.role || 'user';
+        row.appendChild(role);
+
+        const action = document.createElement('td');
+        const btn = document.createElement('button');
+        btn.type = 'button';
+
+        if (member.role === 'admin') {
+          btn.className = 'btn-neutral';
+          btn.textContent = t().cannotDeleteAdmin;
+          btn.disabled = true;
+        } else {
+          btn.className = 'btn-danger';
+          btn.textContent = t().delete;
+          btn.addEventListener('click', async () => {
+            if (!window.confirm(t().confirmDelete)) return;
+
+            try {
+              await deleteMember(member.id);
+              await loadMembers();
+            } catch (error) {
+              if (error?.message === 'CANNOT_DELETE_ADMIN') {
+                setStatus(t().cannotDeleteAdmin, 'error');
+                return;
+              }
+              if (error?.message === 'CANNOT_DELETE_SELF') {
+                setStatus(t().cannotDeleteSelf, 'error');
+                return;
+              }
+              setStatus(t().deleteFailed, 'error');
+            }
+          });
+        }
+
+        action.appendChild(btn);
+        row.appendChild(action);
+        tableBody.appendChild(row);
+      }
+    }
+
+    async function loadMembers() {
+      setStatus(t().loading);
+
+      try {
+        const users = await fetchMembers();
+        renderTable(users);
+        document.getElementById('tableCard').style.display = 'block';
+        setStatus('');
+      } catch {
+        setStatus(t().loadFailed, 'error');
+      }
+    }
+
+    async function init() {
+      currentLanguage = getLanguage();
+      applyTranslations();
+
+      const adminUser = await ensureAdmin();
+      if (!adminUser) return;
+
+      const initialUsers = await fetchMembers().catch(() => []);
+      renderCountryOptions(initialUsers);
+      document.getElementById('countryFilter').addEventListener('change', loadMembers);
+      document.getElementById('searchBtn').addEventListener('click', loadMembers);
+      document.getElementById('usernameSearch').addEventListener('keydown', (event) => {
+        if (event.key === 'Enter') loadMembers();
+      });
+      document.getElementById('emailSearch').addEventListener('keydown', (event) => {
+        if (event.key === 'Enter') loadMembers();
+      });
+
+      renderTable(initialUsers);
+      document.getElementById('tableCard').style.display = 'block';
+      setStatus('');
+    }
+
+    init();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation

- Provide admins with a dedicated members management page to view, filter and remove accounts. 
- Allow server-side filtering of profiles by `country`, `username`, and `email` to support the new UI and limit data returned. 
- Improve privacy in admin listings by masking user email addresses.

### Description

- Extended `listProfiles` in `api/_lib/db.js` to accept optional filters `{ country, username, email }` and build a parameterized `WHERE` clause for server-side filtering. 
- Updated `api/admin/users.js` to accept query parameters, call `listProfiles` with filters, and added `maskEmail` to obscure emails in responses. 
- Added a new endpoint `api/admin/delete-user.js` that enforces admin-only access, prevents self- and admin-deletion, and deletes users via the Supabase admin client with proper error handling and response codes. 
- Updated the public site `index.html` to remove the inline member list and add a link to the new members admin page, and added a full-featured client page at `members/index.html` that provides filtering, listing, and deletion UI for admins.

### Testing

- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c59901dcfc83338dae654a7a71ed76)