### PR TITLE
Redirect ikke-admin brukere fra admin-sider til sarcasm.games

### DIFF
--- a/admin/contact-messages/index.html
+++ b/admin/contact-messages/index.html
@@ -222,16 +222,20 @@
       }
     }
 
+    function redirectToHome() {
+      window.location.replace('https://sarcasm.games/');
+    }
+
     async function ensureAdmin() {
       const response = await fetch('/api/auth/session', { credentials: 'include' });
       if (!response.ok) {
-        window.location.replace('/?login=1&redirect=%2Fadmin%2Fcontact-messages%2F');
+        redirectToHome();
         return null;
       }
 
       const data = await response.json();
       if (data?.user?.role !== 'admin') {
-        setStatus(t().forbidden, 'error');
+        redirectToHome();
         return null;
       }
 

--- a/insertquiz/index.html
+++ b/insertquiz/index.html
@@ -234,19 +234,21 @@
       };
     }
 
+    function redirectToHome() {
+      window.location.replace('https://sarcasm.games/');
+    }
+
     async function ensureAdminAccess() {
       try {
         const response = await fetch('/api/auth/session', { credentials: 'include' });
         if (!response.ok) {
-          accessStatus.textContent = 'Access denied. Please log in as admin.';
-          accessStatus.classList.add('error');
+          redirectToHome();
           return;
         }
 
         const data = await response.json();
         if (data?.user?.role !== 'admin') {
-          accessStatus.textContent = 'Access denied. This page is admin-only.';
-          accessStatus.classList.add('error');
+          redirectToHome();
           return;
         }
 
@@ -256,8 +258,7 @@
         queueCard.classList.remove('hidden');
         renderQueue();
       } catch (error) {
-        accessStatus.textContent = 'Could not verify access due to a network error.';
-        accessStatus.classList.add('error');
+        redirectToHome();
       }
     }
 

--- a/members/index.html
+++ b/members/index.html
@@ -158,16 +158,20 @@
       document.getElementById('thAction').textContent = t().action;
     }
 
+    function redirectToHome() {
+      window.location.replace('https://sarcasm.games/');
+    }
+
     async function ensureAdmin() {
       const response = await fetch('/api/auth/session', { credentials: 'include' });
       if (!response.ok) {
-        window.location.replace('/?login=1&redirect=%2Fmembers%2F');
+        redirectToHome();
         return null;
       }
 
       const data = await response.json();
       if (data?.user?.role !== 'admin') {
-        setStatus(t().forbidden, 'error');
+        redirectToHome();
         return null;
       }
 


### PR DESCRIPTION
### Motivation
- Forhindre at ikke-innloggede eller ikke-admin brukere ser admin-grensesnittet ved å besøke URL-ene direkte, og send dem tilbake til den offentlige siden `https://sarcasm.games/`.
- Erstatte synlige "du må være innlogget" / "forbidden" meldinger med en sterkere blokkering som ikke viser admin-sideinnhold.

### Description
- La til en liten helper `redirectToHome()` i `insertquiz/index.html`, `admin/contact-messages/index.html` og `members/index.html` som kjører `window.location.replace('https://sarcasm.games/')`.
- Endret tilgangssjekkene slik at ved manglende session, feil rolle eller session-/nettverksfeil kalles `redirectToHome()` i stedet for å vise inline feilmeldinger eller lokale login-redirects.
- Spesifikt bruk av redirect er anvendt for: session ikke ok, `data?.user?.role !== 'admin'`, og i `insertquiz` også på catch-blokk ved nettverksfeil.

### Testing
- Kjørte `git diff --check` for å validere diffen, og den ga ingen feil.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c638ea78e483339f8f2b976fb45e55)