### PR TITLE
Guard admin pages: hide UI until auth and redirect non-admins to homepage

### DIFF
--- a/admin/contact-messages/index.html
+++ b/admin/contact-messages/index.html
@@ -4,8 +4,12 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Contact messages | sarcasm.games</title>
+  <script>
+    document.documentElement.classList.add('auth-pending');
+  </script>
   <style>
     :root { --bg:#0b0c10; --card:#1e1f25; --txt:#eaeaea; --bd:#2f313a; --accent:#4ecca3; --danger:#ff6b6b; --muted:#9aa0ad; }
+    .auth-pending body { visibility: hidden; }
     body { margin:0; font:16px/1.4 system-ui, Segoe UI, Roboto, Arial; background:var(--bg); color:var(--txt); min-height:100dvh; }
     main { max-width:1050px; margin:0 auto; padding:24px 16px 40px; }
     .card { background:var(--card); border:1px solid var(--bd); border-radius:12px; padding:14px; margin-bottom:12px; }
@@ -222,16 +226,24 @@
       }
     }
 
+    function redirectToHome() {
+      window.location.replace('https://sarcasm.games/');
+    }
+
+    function revealProtectedPage() {
+      document.documentElement.classList.remove('auth-pending');
+    }
+
     async function ensureAdmin() {
       const response = await fetch('/api/auth/session', { credentials: 'include' });
       if (!response.ok) {
-        window.location.replace('/?login=1&redirect=%2Fadmin%2Fcontact-messages%2F');
+        redirectToHome();
         return null;
       }
 
       const data = await response.json();
       if (data?.user?.role !== 'admin') {
-        setStatus(t().forbidden, 'error');
+        redirectToHome();
         return null;
       }
 
@@ -245,6 +257,7 @@
 
       const adminUser = await ensureAdmin();
       if (!adminUser) return;
+      revealProtectedPage();
 
       try {
         const response = await fetch('/api/admin/contact-messages', { credentials: 'include' });

--- a/insertquiz/index.html
+++ b/insertquiz/index.html
@@ -4,8 +4,12 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Insert quiz question</title>
+  <script>
+    document.documentElement.classList.add('auth-pending');
+  </script>
   <style>
     :root { --bg:#0b0c10; --card:#1e1f25; --txt:#eaeaea; --bd:#2f313a; --accent:#4ecca3; --danger:#ff6b6b; --muted:#9aa0ad; }
+    .auth-pending body { visibility: hidden; }
     body { margin:0; font:16px/1.4 system-ui, Segoe UI, Roboto, Arial; background:var(--bg); color:var(--txt); min-height:100dvh; }
     main { max-width: 920px; margin: 0 auto; padding: 28px 18px 40px; }
     .card { background:var(--card); border:1px solid var(--bd); border-radius:12px; padding:16px; margin-bottom:14px; }
@@ -234,30 +238,36 @@
       };
     }
 
+    function redirectToHome() {
+      window.location.replace('https://sarcasm.games/');
+    }
+
+    function revealProtectedPage() {
+      document.documentElement.classList.remove('auth-pending');
+    }
+
     async function ensureAdminAccess() {
       try {
         const response = await fetch('/api/auth/session', { credentials: 'include' });
         if (!response.ok) {
-          accessStatus.textContent = 'Access denied. Please log in as admin.';
-          accessStatus.classList.add('error');
+          redirectToHome();
           return;
         }
 
         const data = await response.json();
         if (data?.user?.role !== 'admin') {
-          accessStatus.textContent = 'Access denied. This page is admin-only.';
-          accessStatus.classList.add('error');
+          redirectToHome();
           return;
         }
 
+        revealProtectedPage();
         accessStatus.textContent = `Admin access confirmed for ${data.user.username}.`;
         accessStatus.classList.add('success');
         formCard.classList.remove('hidden');
         queueCard.classList.remove('hidden');
         renderQueue();
       } catch (error) {
-        accessStatus.textContent = 'Could not verify access due to a network error.';
-        accessStatus.classList.add('error');
+        redirectToHome();
       }
     }
 

--- a/members/index.html
+++ b/members/index.html
@@ -4,8 +4,12 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Members | sarcasm.games</title>
+  <script>
+    document.documentElement.classList.add('auth-pending');
+  </script>
   <style>
     :root { --bg:#0b0c10; --card:#1e1f25; --txt:#eaeaea; --bd:#2f313a; --accent:#4ecca3; --danger:#ff6b6b; --muted:#9aa0ad; }
+    .auth-pending body { visibility: hidden; }
     body { margin:0; font:16px/1.4 system-ui, Segoe UI, Roboto, Arial; background:var(--bg); color:var(--txt); min-height:100dvh; }
     main { max-width:1100px; margin:0 auto; padding:24px 16px 40px; }
     .top-links { display:flex; gap:10px; margin-bottom:12px; }
@@ -158,16 +162,24 @@
       document.getElementById('thAction').textContent = t().action;
     }
 
+    function redirectToHome() {
+      window.location.replace('https://sarcasm.games/');
+    }
+
+    function revealProtectedPage() {
+      document.documentElement.classList.remove('auth-pending');
+    }
+
     async function ensureAdmin() {
       const response = await fetch('/api/auth/session', { credentials: 'include' });
       if (!response.ok) {
-        window.location.replace('/?login=1&redirect=%2Fmembers%2F');
+        redirectToHome();
         return null;
       }
 
       const data = await response.json();
       if (data?.user?.role !== 'admin') {
-        setStatus(t().forbidden, 'error');
+        redirectToHome();
         return null;
       }
 
@@ -320,6 +332,7 @@
 
       const adminUser = await ensureAdmin();
       if (!adminUser) return;
+      revealProtectedPage();
 
       const initialUsers = await fetchMembers().catch(() => []);
       renderCountryOptions(initialUsers);


### PR DESCRIPTION
### Motivation
- Prevent flicker/leak of protected admin UI while authentication is being checked by hiding page content until the session is verified.
- Ensure unauthenticated or non-admin users are redirected to the public homepage instead of showing admin-only UI or error messages.

### Description
- Added an `auth-pending` class on `document.documentElement` and CSS rule `.auth-pending body { visibility: hidden; }` to `admin/contact-messages/index.html`, `insertquiz/index.html`, and `members/index.html` so the body is hidden until auth is confirmed.
- Introduced `redirectToHome()` and `revealProtectedPage()` helper functions and call `revealProtectedPage()` after successful admin verification to unhide the page.
- Updated authentication checks (`ensureAdmin`, `ensureAdminAccess`) to call `redirectToHome()` when the session fetch fails or the user is not an admin, replacing prior inline status messages or login redirects.
- Replaced some error-handling branches that previously showed local error text with a homepage redirect to centralize behavior for unauthenticated access.

### Testing
- Manual smoke-tested the three modified pages to verify the body remains hidden until a successful admin session response triggers `revealProtectedPage()` and that non-admin or unauthenticated responses trigger `redirectToHome()`; behavior observed as expected.
- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c638ea78e483339f8f2b976fb45e55)