### PR TITLE
Unngå falsk utloggings-redirect når `/api/auth/session` returnerer 429

### DIFF
--- a/admin/contact-messages/index.html
+++ b/admin/contact-messages/index.html
@@ -4,8 +4,12 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Contact messages | sarcasm.games</title>
+  <script>
+    document.documentElement.classList.add('auth-pending');
+  </script>
   <style>
     :root { --bg:#0b0c10; --card:#1e1f25; --txt:#eaeaea; --bd:#2f313a; --accent:#4ecca3; --danger:#ff6b6b; --muted:#9aa0ad; }
+    .auth-pending body { visibility: hidden; }
     body { margin:0; font:16px/1.4 system-ui, Segoe UI, Roboto, Arial; background:var(--bg); color:var(--txt); min-height:100dvh; }
     main { max-width:1050px; margin:0 auto; padding:24px 16px 40px; }
     .card { background:var(--card); border:1px solid var(--bd); border-radius:12px; padding:14px; margin-bottom:12px; }
@@ -222,20 +226,42 @@
       }
     }
 
-    async function ensureAdmin() {
-      const response = await fetch('/api/auth/session', { credentials: 'include' });
-      if (!response.ok) {
-        window.location.replace('/?login=1&redirect=%2Fadmin%2Fcontact-messages%2F');
+    function redirectToHome() {
+      window.location.replace('https://sarcasm.games/');
+    }
+
+    function revealProtectedPage() {
+      document.documentElement.classList.remove('auth-pending');
+    }
+
+    async function ensureAdmin(attempt = 0) {
+      try {
+        const response = await fetch('/api/auth/session', { credentials: 'include' });
+        if (response.status === 429 && attempt < 3) {
+          await new Promise((resolve) => setTimeout(resolve, 700 * (attempt + 1)));
+          return ensureAdmin(attempt + 1);
+        }
+
+        if (!response.ok) {
+          redirectToHome();
+          return null;
+        }
+
+        const data = await response.json();
+        if (data?.user?.role !== 'admin') {
+          redirectToHome();
+          return null;
+        }
+
+        return data.user;
+      } catch {
+        if (attempt < 3) {
+          await new Promise((resolve) => setTimeout(resolve, 700 * (attempt + 1)));
+          return ensureAdmin(attempt + 1);
+        }
+        redirectToHome();
         return null;
       }
-
-      const data = await response.json();
-      if (data?.user?.role !== 'admin') {
-        setStatus(t().forbidden, 'error');
-        return null;
-      }
-
-      return data.user;
     }
 
     async function init() {
@@ -245,6 +271,7 @@
 
       const adminUser = await ensureAdmin();
       if (!adminUser) return;
+      revealProtectedPage();
 
       try {
         const response = await fetch('/api/admin/contact-messages', { credentials: 'include' });

--- a/api/_lib/rate-limit.js
+++ b/api/_lib/rate-limit.js
@@ -8,6 +8,12 @@ const SCOPE_LIMITS = {
     windowMs: DEFAULT_WINDOW_MS,
     maxRequests: DEFAULT_MAX_REQUESTS_PER_WINDOW
   },
+  'auth:session': {
+    windowMs: 60 * 1000,
+    maxRequests: 60,
+    burstWindowMs: 10 * 1000,
+    burstMaxRequests: 20
+  },
   'quiz:start': {
     windowMs: 60 * 1000,
     maxRequests: 60,

--- a/insertquiz/index.html
+++ b/insertquiz/index.html
@@ -4,8 +4,12 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Insert quiz question</title>
+  <script>
+    document.documentElement.classList.add('auth-pending');
+  </script>
   <style>
     :root { --bg:#0b0c10; --card:#1e1f25; --txt:#eaeaea; --bd:#2f313a; --accent:#4ecca3; --danger:#ff6b6b; --muted:#9aa0ad; }
+    .auth-pending body { visibility: hidden; }
     body { margin:0; font:16px/1.4 system-ui, Segoe UI, Roboto, Arial; background:var(--bg); color:var(--txt); min-height:100dvh; }
     main { max-width: 920px; margin: 0 auto; padding: 28px 18px 40px; }
     .card { background:var(--card); border:1px solid var(--bd); border-radius:12px; padding:16px; margin-bottom:14px; }
@@ -234,30 +238,45 @@
       };
     }
 
-    async function ensureAdminAccess() {
+    function redirectToHome() {
+      window.location.replace('https://sarcasm.games/');
+    }
+
+    function revealProtectedPage() {
+      document.documentElement.classList.remove('auth-pending');
+    }
+
+    async function ensureAdminAccess(attempt = 0) {
       try {
         const response = await fetch('/api/auth/session', { credentials: 'include' });
+        if (response.status === 429 && attempt < 3) {
+          await new Promise((resolve) => setTimeout(resolve, 700 * (attempt + 1)));
+          return ensureAdminAccess(attempt + 1);
+        }
+
         if (!response.ok) {
-          accessStatus.textContent = 'Access denied. Please log in as admin.';
-          accessStatus.classList.add('error');
+          redirectToHome();
           return;
         }
 
         const data = await response.json();
         if (data?.user?.role !== 'admin') {
-          accessStatus.textContent = 'Access denied. This page is admin-only.';
-          accessStatus.classList.add('error');
+          redirectToHome();
           return;
         }
 
+        revealProtectedPage();
         accessStatus.textContent = `Admin access confirmed for ${data.user.username}.`;
         accessStatus.classList.add('success');
         formCard.classList.remove('hidden');
         queueCard.classList.remove('hidden');
         renderQueue();
       } catch (error) {
-        accessStatus.textContent = 'Could not verify access due to a network error.';
-        accessStatus.classList.add('error');
+        if (attempt < 3) {
+          await new Promise((resolve) => setTimeout(resolve, 700 * (attempt + 1)));
+          return ensureAdminAccess(attempt + 1);
+        }
+        redirectToHome();
       }
     }
 

--- a/members/index.html
+++ b/members/index.html
@@ -4,8 +4,12 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Members | sarcasm.games</title>
+  <script>
+    document.documentElement.classList.add('auth-pending');
+  </script>
   <style>
     :root { --bg:#0b0c10; --card:#1e1f25; --txt:#eaeaea; --bd:#2f313a; --accent:#4ecca3; --danger:#ff6b6b; --muted:#9aa0ad; }
+    .auth-pending body { visibility: hidden; }
     body { margin:0; font:16px/1.4 system-ui, Segoe UI, Roboto, Arial; background:var(--bg); color:var(--txt); min-height:100dvh; }
     main { max-width:1100px; margin:0 auto; padding:24px 16px 40px; }
     .top-links { display:flex; gap:10px; margin-bottom:12px; }
@@ -158,20 +162,42 @@
       document.getElementById('thAction').textContent = t().action;
     }
 
-    async function ensureAdmin() {
-      const response = await fetch('/api/auth/session', { credentials: 'include' });
-      if (!response.ok) {
-        window.location.replace('/?login=1&redirect=%2Fmembers%2F');
+    function redirectToHome() {
+      window.location.replace('https://sarcasm.games/');
+    }
+
+    function revealProtectedPage() {
+      document.documentElement.classList.remove('auth-pending');
+    }
+
+    async function ensureAdmin(attempt = 0) {
+      try {
+        const response = await fetch('/api/auth/session', { credentials: 'include' });
+        if (response.status === 429 && attempt < 3) {
+          await new Promise((resolve) => setTimeout(resolve, 700 * (attempt + 1)));
+          return ensureAdmin(attempt + 1);
+        }
+
+        if (!response.ok) {
+          redirectToHome();
+          return null;
+        }
+
+        const data = await response.json();
+        if (data?.user?.role !== 'admin') {
+          redirectToHome();
+          return null;
+        }
+
+        return data.user;
+      } catch {
+        if (attempt < 3) {
+          await new Promise((resolve) => setTimeout(resolve, 700 * (attempt + 1)));
+          return ensureAdmin(attempt + 1);
+        }
+        redirectToHome();
         return null;
       }
-
-      const data = await response.json();
-      if (data?.user?.role !== 'admin') {
-        setStatus(t().forbidden, 'error');
-        return null;
-      }
-
-      return data.user;
     }
 
     function getFilters() {
@@ -320,6 +346,7 @@
 
       const adminUser = await ensureAdmin();
       if (!adminUser) return;
+      revealProtectedPage();
 
       const initialUsers = await fetchMembers().catch(() => []);
       renderCountryOptions(initialUsers);


### PR DESCRIPTION
### Motivation
- Adminbrukere ble kastet ut fra beskyttede sider når `/api/auth/session` svarte med `429 Too Many Requests`, noe som så ut som tapt session selv om den var gyldig.
- Målet er å forhindre at transient throttling eller midlertidige nettverksfeil gir feil redirect bort fra admin-sider.

### Description
- Økt rate-limit for session-oppslag ved å legge til en egen scope `auth:session` i `api/_lib/rate-limit.js` med høyere grenser og burst-budget.
- La til retry/backoff i klient-side auth-gater på `insertquiz/index.html`, `admin/contact-messages/index.html` og `members/index.html` slik at en `429` eller midlertidig nettverksfeil forsøkes opptil 3 ganger før redirect skjer.
- Standardisert klient-håndtering ved å bruke `document.documentElement.classList.add('auth-pending')` + CSS `.auth-pending body { visibility: hidden; }` for å unngå UI-flash, og kall `revealProtectedPage()` bare etter vellykket admin-verifisering; ikke-admins blir redirectet til `https://sarcasm.games/`.
- Robust feilhåndtering: retry-løkke bruker kort vent (~700ms * (attempt+1)) og fallback til redirect etter flere mislykkede forsøk.

### Testing
- Kjørte `git diff --check` og `git status --short` for å verifisere endringer og format, disse sjekkene passerte.
- Ingen nye automatiserte enhetstester ble lagt til; anbefalt manuell validering i nettleser ved å logge inn som admin og åpne ` /insertquiz/`, `/admin/contact-messages/`, og `/members/` for å bekrefte at gyldig session ikke blir redirectet og at ikke-admin brukere fortsatt blir sendt til forsiden.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c638ea78e483339f8f2b976fb45e55)