### PR TITLE
Admin pages: auth-gating, session rate-limit, and contact message deletion

### DIFF
--- a/admin/contact-messages/index.html
+++ b/admin/contact-messages/index.html
@@ -4,8 +4,12 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Contact messages | sarcasm.games</title>
+  <script>
+    document.documentElement.classList.add('auth-pending');
+  </script>
   <style>
     :root { --bg:#0b0c10; --card:#1e1f25; --txt:#eaeaea; --bd:#2f313a; --accent:#4ecca3; --danger:#ff6b6b; --muted:#9aa0ad; }
+    .auth-pending body { visibility: hidden; }
     body { margin:0; font:16px/1.4 system-ui, Segoe UI, Roboto, Arial; background:var(--bg); color:var(--txt); min-height:100dvh; }
     main { max-width:1050px; margin:0 auto; padding:24px 16px 40px; }
     .card { background:var(--card); border:1px solid var(--bd); border-radius:12px; padding:14px; margin-bottom:12px; }
@@ -17,10 +21,12 @@
     th { color:var(--muted); font-weight:600; }
     button { border:0; border-radius:8px; padding:8px 12px; cursor:pointer; font-weight:700; }
     .btn-neutral { background:var(--bd); color:var(--txt); }
+    .btn-danger { background:var(--danger); color:#fff; }
     .status { min-height:20px; color:var(--muted); }
     .status.error { color:var(--danger); }
     .details { margin-top:8px; border-top:1px dashed var(--bd); padding-top:8px; white-space:pre-wrap; }
     .pill { display:inline-block; padding:2px 8px; border-radius:999px; border:1px solid var(--bd); font-size:.85rem; }
+    .action-buttons { display:flex; gap:8px; flex-wrap:wrap; }
   </style>
 </head>
 <body>
@@ -71,6 +77,9 @@
         action: 'Action',
         view: 'View',
         hide: 'Hide',
+        delete: 'Delete',
+        confirmDelete: 'Delete this message?',
+        deleteFailed: 'Failed to delete message.',
         empty: 'No messages yet.',
         loadFailed: 'Failed to load messages.',
         viewFailed: 'Failed to open message.'
@@ -89,6 +98,9 @@
         action: 'Handling',
         view: 'Vis',
         hide: 'Skjul',
+        delete: 'Slett',
+        confirmDelete: 'Slette denne meldingen?',
+        deleteFailed: 'Kunne ikke slette melding.',
         empty: 'Ingen meldinger ennå.',
         loadFailed: 'Kunne ikke laste meldinger.',
         viewFailed: 'Kunne ikke åpne melding.'
@@ -146,6 +158,17 @@
       });
     }
 
+    async function deleteMessage(id) {
+      const response = await fetch(`/api/admin/contact-messages/${id}`, {
+        method: 'DELETE',
+        credentials: 'include'
+      });
+
+      if (!response.ok) {
+        throw new Error('delete_failed');
+      }
+    }
+
     function renderTable(messages) {
       const tableBody = document.getElementById('tableBody');
       tableBody.innerHTML = '';
@@ -183,10 +206,18 @@
         row.appendChild(statusCell);
 
         const action = document.createElement('td');
+        const actionButtons = document.createElement('div');
+        actionButtons.className = 'action-buttons';
+
         const btn = document.createElement('button');
         btn.className = 'btn-neutral';
         btn.textContent = t().view;
         btn.type = 'button';
+
+        const deleteBtn = document.createElement('button');
+        deleteBtn.className = 'btn-danger';
+        deleteBtn.textContent = t().delete;
+        deleteBtn.type = 'button';
 
         const detail = document.createElement('div');
         detail.className = 'details';
@@ -215,27 +246,65 @@
           }
         });
 
-        action.appendChild(btn);
+        deleteBtn.addEventListener('click', async () => {
+          if (!window.confirm(t().confirmDelete)) return;
+          try {
+            await deleteMessage(entry.id);
+            row.remove();
+            const hasRows = document.querySelectorAll('#tableBody tr').length > 0;
+            if (!hasRows) {
+              renderTable([]);
+            }
+          } catch {
+            setStatus(t().deleteFailed, 'error');
+          }
+        });
+
+        actionButtons.appendChild(btn);
+        actionButtons.appendChild(deleteBtn);
+        action.appendChild(actionButtons);
         action.appendChild(detail);
         row.appendChild(action);
         tableBody.appendChild(row);
       }
     }
 
-    async function ensureAdmin() {
-      const response = await fetch('/api/auth/session', { credentials: 'include' });
-      if (!response.ok) {
-        window.location.replace('/?login=1&redirect=%2Fadmin%2Fcontact-messages%2F');
+    function redirectToHome() {
+      window.location.replace('https://sarcasm.games/');
+    }
+
+    function revealProtectedPage() {
+      document.documentElement.classList.remove('auth-pending');
+    }
+
+    async function ensureAdmin(attempt = 0) {
+      try {
+        const response = await fetch('/api/auth/session', { credentials: 'include' });
+        if (response.status === 429 && attempt < 3) {
+          await new Promise((resolve) => setTimeout(resolve, 700 * (attempt + 1)));
+          return ensureAdmin(attempt + 1);
+        }
+
+        if (!response.ok) {
+          redirectToHome();
+          return null;
+        }
+
+        const data = await response.json();
+        if (data?.user?.role !== 'admin') {
+          redirectToHome();
+          return null;
+        }
+
+        return data.user;
+      } catch {
+        if (attempt < 3) {
+          await new Promise((resolve) => setTimeout(resolve, 700 * (attempt + 1)));
+          return ensureAdmin(attempt + 1);
+        }
+        redirectToHome();
         return null;
       }
-
-      const data = await response.json();
-      if (data?.user?.role !== 'admin') {
-        setStatus(t().forbidden, 'error');
-        return null;
-      }
-
-      return data.user;
     }
 
     async function init() {
@@ -245,6 +314,7 @@
 
       const adminUser = await ensureAdmin();
       if (!adminUser) return;
+      revealProtectedPage();
 
       try {
         const response = await fetch('/api/admin/contact-messages', { credentials: 'include' });

--- a/api/_lib/rate-limit.js
+++ b/api/_lib/rate-limit.js
@@ -8,6 +8,12 @@ const SCOPE_LIMITS = {
     windowMs: DEFAULT_WINDOW_MS,
     maxRequests: DEFAULT_MAX_REQUESTS_PER_WINDOW
   },
+  'auth:session': {
+    windowMs: 60 * 1000,
+    maxRequests: 60,
+    burstWindowMs: 10 * 1000,
+    burstMaxRequests: 20
+  },
   'quiz:start': {
     windowMs: 60 * 1000,
     maxRequests: 60,

--- a/api/admin/contact-messages/[id].js
+++ b/api/admin/contact-messages/[id].js
@@ -73,6 +73,23 @@ module.exports = async function handler(req, res) {
       return;
     }
 
+    if (req.method === 'DELETE') {
+      const deleteResult = await runQuery(
+        `DELETE FROM public.contact_messages
+         WHERE id = $1
+         RETURNING id`,
+        [id]
+      );
+
+      if (!deleteResult.rows[0]) {
+        res.status(404).json({ error: 'Message not found' });
+        return;
+      }
+
+      res.status(200).json({ deleted: true, id });
+      return;
+    }
+
     res.status(405).json({ error: 'Method not allowed' });
   } catch (error) {
     console.error('[admin/contact-messages/:id] Failed:', error?.message);

--- a/insertquiz/index.html
+++ b/insertquiz/index.html
@@ -4,8 +4,12 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Insert quiz question</title>
+  <script>
+    document.documentElement.classList.add('auth-pending');
+  </script>
   <style>
     :root { --bg:#0b0c10; --card:#1e1f25; --txt:#eaeaea; --bd:#2f313a; --accent:#4ecca3; --danger:#ff6b6b; --muted:#9aa0ad; }
+    .auth-pending body { visibility: hidden; }
     body { margin:0; font:16px/1.4 system-ui, Segoe UI, Roboto, Arial; background:var(--bg); color:var(--txt); min-height:100dvh; }
     main { max-width: 920px; margin: 0 auto; padding: 28px 18px 40px; }
     .card { background:var(--card); border:1px solid var(--bd); border-radius:12px; padding:16px; margin-bottom:14px; }
@@ -234,30 +238,45 @@
       };
     }
 
-    async function ensureAdminAccess() {
+    function redirectToHome() {
+      window.location.replace('https://sarcasm.games/');
+    }
+
+    function revealProtectedPage() {
+      document.documentElement.classList.remove('auth-pending');
+    }
+
+    async function ensureAdminAccess(attempt = 0) {
       try {
         const response = await fetch('/api/auth/session', { credentials: 'include' });
+        if (response.status === 429 && attempt < 3) {
+          await new Promise((resolve) => setTimeout(resolve, 700 * (attempt + 1)));
+          return ensureAdminAccess(attempt + 1);
+        }
+
         if (!response.ok) {
-          accessStatus.textContent = 'Access denied. Please log in as admin.';
-          accessStatus.classList.add('error');
+          redirectToHome();
           return;
         }
 
         const data = await response.json();
         if (data?.user?.role !== 'admin') {
-          accessStatus.textContent = 'Access denied. This page is admin-only.';
-          accessStatus.classList.add('error');
+          redirectToHome();
           return;
         }
 
+        revealProtectedPage();
         accessStatus.textContent = `Admin access confirmed for ${data.user.username}.`;
         accessStatus.classList.add('success');
         formCard.classList.remove('hidden');
         queueCard.classList.remove('hidden');
         renderQueue();
       } catch (error) {
-        accessStatus.textContent = 'Could not verify access due to a network error.';
-        accessStatus.classList.add('error');
+        if (attempt < 3) {
+          await new Promise((resolve) => setTimeout(resolve, 700 * (attempt + 1)));
+          return ensureAdminAccess(attempt + 1);
+        }
+        redirectToHome();
       }
     }
 

--- a/members/index.html
+++ b/members/index.html
@@ -4,8 +4,12 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Members | sarcasm.games</title>
+  <script>
+    document.documentElement.classList.add('auth-pending');
+  </script>
   <style>
     :root { --bg:#0b0c10; --card:#1e1f25; --txt:#eaeaea; --bd:#2f313a; --accent:#4ecca3; --danger:#ff6b6b; --muted:#9aa0ad; }
+    .auth-pending body { visibility: hidden; }
     body { margin:0; font:16px/1.4 system-ui, Segoe UI, Roboto, Arial; background:var(--bg); color:var(--txt); min-height:100dvh; }
     main { max-width:1100px; margin:0 auto; padding:24px 16px 40px; }
     .top-links { display:flex; gap:10px; margin-bottom:12px; }
@@ -158,20 +162,42 @@
       document.getElementById('thAction').textContent = t().action;
     }
 
-    async function ensureAdmin() {
-      const response = await fetch('/api/auth/session', { credentials: 'include' });
-      if (!response.ok) {
-        window.location.replace('/?login=1&redirect=%2Fmembers%2F');
+    function redirectToHome() {
+      window.location.replace('https://sarcasm.games/');
+    }
+
+    function revealProtectedPage() {
+      document.documentElement.classList.remove('auth-pending');
+    }
+
+    async function ensureAdmin(attempt = 0) {
+      try {
+        const response = await fetch('/api/auth/session', { credentials: 'include' });
+        if (response.status === 429 && attempt < 3) {
+          await new Promise((resolve) => setTimeout(resolve, 700 * (attempt + 1)));
+          return ensureAdmin(attempt + 1);
+        }
+
+        if (!response.ok) {
+          redirectToHome();
+          return null;
+        }
+
+        const data = await response.json();
+        if (data?.user?.role !== 'admin') {
+          redirectToHome();
+          return null;
+        }
+
+        return data.user;
+      } catch {
+        if (attempt < 3) {
+          await new Promise((resolve) => setTimeout(resolve, 700 * (attempt + 1)));
+          return ensureAdmin(attempt + 1);
+        }
+        redirectToHome();
         return null;
       }
-
-      const data = await response.json();
-      if (data?.user?.role !== 'admin') {
-        setStatus(t().forbidden, 'error');
-        return null;
-      }
-
-      return data.user;
     }
 
     function getFilters() {
@@ -320,6 +346,7 @@
 
       const adminUser = await ensureAdmin();
       if (!adminUser) return;
+      revealProtectedPage();
 
       const initialUsers = await fetchMembers().catch(() => []);
       renderCountryOptions(initialUsers);


### PR DESCRIPTION
### Motivation
- Prevent briefly-flashed admin UIs before auth is confirmed by hiding protected pages until the session check completes.
- Allow admins to remove contact form messages from the inbox via the UI and API.
- Reduce session endpoint throttling issues by adding a dedicated rate-limit scope and client retry/backoff logic.

### Description
- Add `auth-pending` script/CSS to `admin/contact-messages/index.html`, `insertquiz/index.html`, and `members/index.html` to hide page content until authorization is verified, and implement `revealProtectedPage`/`redirectToHome` helpers to reveal or redirect after checks.
- Update client-side admin session checks (`ensureAdmin` / `ensureAdminAccess`) to retry on `429` and network errors with incremental backoff and to redirect non-admin or failed checks to the site home; apply `revealProtectedPage` on success. (files: `admin/contact-messages/index.html`, `insertquiz/index.html`, `members/index.html`)
- Add contact message deletion UI: new `Delete` button, translations, confirmation prompt, and client `deleteMessage` call that removes the row and updates the table if empty. (file: `admin/contact-messages/index.html`)
- Implement server-side `DELETE` handler for `/api/admin/contact-messages/[id]` to remove messages and return `200` or `404`. (file: `api/admin/contact-messages/[id].js`)
- Add a dedicated rate-limit scope `auth:session` with burst settings to `api/_lib/rate-limit.js` to allow more frequent session checks without hitting global auth limits. (file: `api/_lib/rate-limit.js`)

### Testing
- Ran the repository automated test suite with `npm test` and the linter with `npm run lint`, and both completed successfully.
- Existing server-side tests covering admin endpoints passed after adding the `DELETE` handler and rate-limit configuration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c638ea78e483339f8f2b976fb45e55)