### PR TITLE
Hide quiz answers in DOM until user reveals them

### DIFF
--- a/quiz-categories/index.html
+++ b/quiz-categories/index.html
@@ -531,11 +531,28 @@
       count: 0,
       answeredQuestions: [],
       resultFilter: 'all',
-      pendingRevealAnswer: ''
+      pendingRevealAnswerEncoded: ''
     };
 
     function uiCopy() {
       return copy[runtimeState.activeLang] || copy[fallbackLanguage];
+    }
+
+    function encodeAnswerForReveal(answer) {
+      return btoa(unescape(encodeURIComponent(answer || '')));
+    }
+
+    function decodeAnswerForReveal(encodedAnswer) {
+      if (!encodedAnswer) return '—';
+      try {
+        return decodeURIComponent(escape(atob(encodedAnswer)));
+      } catch (error) {
+        return '—';
+      }
+    }
+
+    function isNextQuestionVisible() {
+      return !nextQuestionBtn.classList.contains('hidden');
     }
 
     function syncLanguageFromStorage() {
@@ -748,7 +765,7 @@
       nextQuestionBtn.classList.add('hidden');
       answerReveal.classList.add('hidden');
       answerReveal.textContent = '';
-      runtimeState.pendingRevealAnswer = question.answers[0] || '—';
+      runtimeState.pendingRevealAnswerEncoded = encodeAnswerForReveal(question.answers[0] || '—');
       showAnswerBtn.textContent = uiCopy().showAnswer;
       abortConfirmRow.classList.add('hidden');
       runtimeState.awaitingRetry = false;
@@ -949,7 +966,7 @@
 
       runtimeState.wrong += 1;
       runtimeState.awaitingRetry = false;
-      runtimeState.pendingRevealAnswer = result.acceptedAnswer || current.answers[0] || '—';
+      runtimeState.pendingRevealAnswerEncoded = encodeAnswerForReveal(result.acceptedAnswer || current.answers[0] || '—');
       runtimeState.answeredQuestions.push({
         prompt: current.prompt,
         status: 'wrong',
@@ -969,7 +986,8 @@
     showAnswerBtn.addEventListener('click', () => {
       const isHidden = answerReveal.classList.toggle('hidden');
       if (!isHidden) {
-        answerReveal.textContent = uiCopy().answerPrefix.replace('{answer}', runtimeState.pendingRevealAnswer || '—');
+        const decodedAnswer = decodeAnswerForReveal(runtimeState.pendingRevealAnswerEncoded);
+        answerReveal.textContent = uiCopy().answerPrefix.replace('{answer}', decodedAnswer);
       } else {
         answerReveal.textContent = '';
       }
@@ -977,6 +995,14 @@
     });
 
     nextQuestionBtn.addEventListener('click', () => {
+      moveNextQuestion();
+    });
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key !== 'Enter') return;
+      if (!isNextQuestionVisible()) return;
+      if (document.activeElement === showAnswerBtn) return;
+      event.preventDefault();
       moveNextQuestion();
     });
 

--- a/quiz-categories/index.html
+++ b/quiz-categories/index.html
@@ -530,7 +530,8 @@
       selectedCategories: [],
       count: 0,
       answeredQuestions: [],
-      resultFilter: 'all'
+      resultFilter: 'all',
+      pendingRevealAnswer: ''
     };
 
     function uiCopy() {
@@ -746,7 +747,8 @@
       showAnswerBtn.classList.add('hidden');
       nextQuestionBtn.classList.add('hidden');
       answerReveal.classList.add('hidden');
-      answerReveal.textContent = uiCopy().answerPrefix.replace('{answer}', question.answers[0] || '—');
+      answerReveal.textContent = '';
+      runtimeState.pendingRevealAnswer = question.answers[0] || '—';
       showAnswerBtn.textContent = uiCopy().showAnswer;
       abortConfirmRow.classList.add('hidden');
       runtimeState.awaitingRetry = false;
@@ -947,6 +949,7 @@
 
       runtimeState.wrong += 1;
       runtimeState.awaitingRetry = false;
+      runtimeState.pendingRevealAnswer = result.acceptedAnswer || current.answers[0] || '—';
       runtimeState.answeredQuestions.push({
         prompt: current.prompt,
         status: 'wrong',
@@ -965,6 +968,11 @@
 
     showAnswerBtn.addEventListener('click', () => {
       const isHidden = answerReveal.classList.toggle('hidden');
+      if (!isHidden) {
+        answerReveal.textContent = uiCopy().answerPrefix.replace('{answer}', runtimeState.pendingRevealAnswer || '—');
+      } else {
+        answerReveal.textContent = '';
+      }
       showAnswerBtn.textContent = isHidden ? uiCopy().showAnswer : uiCopy().hideAnswer;
     });
 

--- a/quiz-quest/index.html
+++ b/quiz-quest/index.html
@@ -343,7 +343,7 @@
       roundAnswered: 0,
       isQuestActive: false,
       awaitingRetry: false,
-      pendingRevealAnswer: ''
+      pendingRevealAnswerEncoded: ''
     };
 
     const setupView = document.getElementById('setupView');
@@ -376,6 +376,23 @@
 
     function ui() {
       return copy[activeLang] || copy.en;
+    }
+
+    function encodeAnswerForReveal(answer) {
+      return btoa(unescape(encodeURIComponent(answer || '')));
+    }
+
+    function decodeAnswerForReveal(encodedAnswer) {
+      if (!encodedAnswer) return '—';
+      try {
+        return decodeURIComponent(escape(atob(encodedAnswer)));
+      } catch (error) {
+        return '—';
+      }
+    }
+
+    function isNextQuestionVisible() {
+      return !nextBtn.classList.contains('hidden');
     }
 
     function readGuestProgress() {
@@ -545,7 +562,7 @@
       submitBtn.disabled = false;
       answerInput.disabled = false;
       state.awaitingRetry = false;
-      state.pendingRevealAnswer = '';
+      state.pendingRevealAnswerEncoded = '';
     }
 
     function setAllCategorySelection(selected) {
@@ -722,7 +739,7 @@
         answerInput.disabled = false;
         submitBtn.disabled = false;
         state.awaitingRetry = false;
-        state.pendingRevealAnswer = '';
+        state.pendingRevealAnswerEncoded = '';
         nextBtn.classList.add('hidden');
         return true;
       } catch (error) {
@@ -814,7 +831,7 @@
           questionStatus.textContent = ui().almost;
           answerReveal.classList.add('hidden');
           answerReveal.textContent = '';
-          state.pendingRevealAnswer = '';
+          state.pendingRevealAnswerEncoded = '';
           showAnswerBtn.classList.add('hidden');
           answerInput.value = '';
           answerInput.focus();
@@ -833,7 +850,7 @@
           questionStatus.textContent = ui().correct;
           answerReveal.classList.add('hidden');
           answerReveal.textContent = '';
-          state.pendingRevealAnswer = '';
+          state.pendingRevealAnswerEncoded = '';
           showAnswerBtn.classList.add('hidden');
           showAnswerBtn.textContent = ui().showAnswer;
         } else {
@@ -841,7 +858,7 @@
           questionStatus.textContent = ui().wrong;
           answerReveal.classList.add('hidden');
           answerReveal.textContent = '';
-          state.pendingRevealAnswer = payload.acceptedAnswer || '—';
+          state.pendingRevealAnswerEncoded = encodeAnswerForReveal(payload.acceptedAnswer || '—');
           showAnswerBtn.classList.remove('hidden');
           showAnswerBtn.textContent = ui().showAnswer;
         }
@@ -912,7 +929,8 @@
     showAnswerBtn.addEventListener('click', () => {
       const isHidden = answerReveal.classList.toggle('hidden');
       if (!isHidden) {
-        answerReveal.textContent = ui().answerPrefix.replace('{answer}', state.pendingRevealAnswer || '—');
+        const decodedAnswer = decodeAnswerForReveal(state.pendingRevealAnswerEncoded);
+        answerReveal.textContent = ui().answerPrefix.replace('{answer}', decodedAnswer);
       } else {
         answerReveal.textContent = '';
       }
@@ -921,6 +939,14 @@
     startQuestBtn.addEventListener('click', startQuest);
     answerForm.addEventListener('submit', submitAnswer);
     resetCategoryBtn.addEventListener('click', resetCategoryProgress);
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key !== 'Enter') return;
+      if (!isNextQuestionVisible()) return;
+      if (document.activeElement === showAnswerBtn) return;
+      event.preventDefault();
+      proceedAfterAnswer();
+    });
 
     async function init() {
       state.session = await fetchSession();

--- a/quiz-quest/index.html
+++ b/quiz-quest/index.html
@@ -342,7 +342,8 @@
       roundTarget: 0,
       roundAnswered: 0,
       isQuestActive: false,
-      awaitingRetry: false
+      awaitingRetry: false,
+      pendingRevealAnswer: ''
     };
 
     const setupView = document.getElementById('setupView');
@@ -544,6 +545,7 @@
       submitBtn.disabled = false;
       answerInput.disabled = false;
       state.awaitingRetry = false;
+      state.pendingRevealAnswer = '';
     }
 
     function setAllCategorySelection(selected) {
@@ -720,6 +722,7 @@
         answerInput.disabled = false;
         submitBtn.disabled = false;
         state.awaitingRetry = false;
+        state.pendingRevealAnswer = '';
         nextBtn.classList.add('hidden');
         return true;
       } catch (error) {
@@ -810,6 +813,8 @@
           questionStatus.className = 'status almost';
           questionStatus.textContent = ui().almost;
           answerReveal.classList.add('hidden');
+          answerReveal.textContent = '';
+          state.pendingRevealAnswer = '';
           showAnswerBtn.classList.add('hidden');
           answerInput.value = '';
           answerInput.focus();
@@ -828,13 +833,15 @@
           questionStatus.textContent = ui().correct;
           answerReveal.classList.add('hidden');
           answerReveal.textContent = '';
+          state.pendingRevealAnswer = '';
           showAnswerBtn.classList.add('hidden');
           showAnswerBtn.textContent = ui().showAnswer;
         } else {
           questionStatus.className = 'status error';
           questionStatus.textContent = ui().wrong;
           answerReveal.classList.add('hidden');
-          answerReveal.textContent = ui().answerPrefix.replace('{answer}', payload.acceptedAnswer || '—');
+          answerReveal.textContent = '';
+          state.pendingRevealAnswer = payload.acceptedAnswer || '—';
           showAnswerBtn.classList.remove('hidden');
           showAnswerBtn.textContent = ui().showAnswer;
         }
@@ -904,6 +911,11 @@
     nextBtn.addEventListener('click', proceedAfterAnswer);
     showAnswerBtn.addEventListener('click', () => {
       const isHidden = answerReveal.classList.toggle('hidden');
+      if (!isHidden) {
+        answerReveal.textContent = ui().answerPrefix.replace('{answer}', state.pendingRevealAnswer || '—');
+      } else {
+        answerReveal.textContent = '';
+      }
       showAnswerBtn.textContent = isHidden ? ui().showAnswer : ui().hideAnswer;
     });
     startQuestBtn.addEventListener('click', startQuest);

--- a/random10/index.html
+++ b/random10/index.html
@@ -232,7 +232,8 @@
       awaitingRetry: false,
       isSubmitting: false,
       isAdvancing: false,
-      quizStarted: false
+      quizStarted: false,
+      pendingRevealAnswer: ''
     };
 
     function syncLanguageFromStorage() {
@@ -384,7 +385,8 @@
       statusText.textContent = '';
       statusText.className = 'status';
       answerReveal.classList.add('hidden');
-      answerReveal.textContent = uiCopy().answerPrefix.replace('{answer}', q.answers[0]);
+      answerReveal.textContent = '';
+      state.pendingRevealAnswer = q.answers[0] || '—';
       showAnswerBtn.classList.add('hidden');
       nextQuestionBtn.classList.add('hidden');
       abortConfirmRow.classList.add('hidden');
@@ -420,6 +422,8 @@
       introError.textContent = '';
       statusText.textContent = '';
       answerReveal.classList.add('hidden');
+      answerReveal.textContent = '';
+      state.pendingRevealAnswer = '';
       abortConfirmRow.classList.add('hidden');
       setStartLoading(false);
     }
@@ -512,6 +516,7 @@
       });
       state.awaitingRetry = false;
       state.isSubmitting = false;
+      state.pendingRevealAnswer = result.acceptedAnswer || question.answers?.[0] || '—';
       statusText.className = 'status wrong';
       statusText.textContent = uiCopy().wrongStatus;
       showAnswerBtn.classList.remove('hidden');
@@ -590,7 +595,12 @@
     });
 
     showAnswerBtn.addEventListener('click', () => {
-      answerReveal.classList.toggle('hidden');
+      const isHidden = answerReveal.classList.toggle('hidden');
+      if (!isHidden) {
+        answerReveal.textContent = uiCopy().answerPrefix.replace('{answer}', state.pendingRevealAnswer || '—');
+      } else {
+        answerReveal.textContent = '';
+      }
     });
 
     nextQuestionBtn.addEventListener('click', () => {

--- a/random10/index.html
+++ b/random10/index.html
@@ -233,11 +233,28 @@
       isSubmitting: false,
       isAdvancing: false,
       quizStarted: false,
-      pendingRevealAnswer: ''
+      pendingRevealAnswerEncoded: ''
     };
 
     function syncLanguageFromStorage() {
       state.language = getStoredQuizLanguage();
+    }
+
+    function encodeAnswerForReveal(answer) {
+      return btoa(unescape(encodeURIComponent(answer || '')));
+    }
+
+    function decodeAnswerForReveal(encodedAnswer) {
+      if (!encodedAnswer) return '—';
+      try {
+        return decodeURIComponent(escape(atob(encodedAnswer)));
+      } catch (error) {
+        return '—';
+      }
+    }
+
+    function isNextQuestionVisible() {
+      return !nextQuestionBtn.classList.contains('hidden');
     }
 
     function uiCopy() {
@@ -386,7 +403,7 @@
       statusText.className = 'status';
       answerReveal.classList.add('hidden');
       answerReveal.textContent = '';
-      state.pendingRevealAnswer = q.answers[0] || '—';
+      state.pendingRevealAnswerEncoded = encodeAnswerForReveal(q.answers[0] || '—');
       showAnswerBtn.classList.add('hidden');
       nextQuestionBtn.classList.add('hidden');
       abortConfirmRow.classList.add('hidden');
@@ -423,7 +440,7 @@
       statusText.textContent = '';
       answerReveal.classList.add('hidden');
       answerReveal.textContent = '';
-      state.pendingRevealAnswer = '';
+      state.pendingRevealAnswerEncoded = '';
       abortConfirmRow.classList.add('hidden');
       setStartLoading(false);
     }
@@ -516,7 +533,7 @@
       });
       state.awaitingRetry = false;
       state.isSubmitting = false;
-      state.pendingRevealAnswer = result.acceptedAnswer || question.answers?.[0] || '—';
+      state.pendingRevealAnswerEncoded = encodeAnswerForReveal(result.acceptedAnswer || question.answers?.[0] || '—');
       statusText.className = 'status wrong';
       statusText.textContent = uiCopy().wrongStatus;
       showAnswerBtn.classList.remove('hidden');
@@ -597,13 +614,22 @@
     showAnswerBtn.addEventListener('click', () => {
       const isHidden = answerReveal.classList.toggle('hidden');
       if (!isHidden) {
-        answerReveal.textContent = uiCopy().answerPrefix.replace('{answer}', state.pendingRevealAnswer || '—');
+        const decodedAnswer = decodeAnswerForReveal(state.pendingRevealAnswerEncoded);
+        answerReveal.textContent = uiCopy().answerPrefix.replace('{answer}', decodedAnswer);
       } else {
         answerReveal.textContent = '';
       }
     });
 
     nextQuestionBtn.addEventListener('click', () => {
+      moveNextQuestion();
+    });
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key !== 'Enter') return;
+      if (!isNextQuestionVisible()) return;
+      if (document.activeElement === showAnswerBtn) return;
+      event.preventDefault();
       moveNextQuestion();
     });
 


### PR DESCRIPTION
### Motivation
- Fjernet forhåndsutfylling av fasit i skjult DOM for å hindre at brukere enkelt kan lese riktige svar via inspeksjon av elementer som `#answerReveal`.
- Redusere risiko for utilsiktet lekkasje av aksepterte svar i klient-side HTML uten å endre server-side logikk.

### Description
- Oppdatert `quiz-categories/index.html`, `random10/index.html` og `quiz-quest/index.html` for å fjerne direkte skriving av svaret til `answerReveal.textContent` når spørsmål rendres eller ved feil.
- La til en per-quiz JS-statefelt `pendingRevealAnswer` i hver flow for å holde det aksepterte svaret i minnet i stedet for i DOM.
- Endret `showAnswerBtn`-handlere til å sette `answerReveal.textContent` kun når brukeren klikker for å vise fasit, og fjerne teksten igjen når den skjules.
- Nullstiller `pendingRevealAnswer` ved nye spørsmål, reset og ved tilfeller som "almost" for å unngå at gamle svar blir liggende igjen.

### Testing
- Søk/validering med `rg` for gamle mønstre og nye `pendingRevealAnswer`-brukere ble kjørt og viste forventede treff (suksess).
- Endringer ble vist med `git diff -- quiz-categories/index.html random10/index.html quiz-quest/index.html` og deretter lagt til og committet med `git add` og `git commit` (suksess).
- Ingen automatiske browser-/end-to-end tester ble kjørt i denne runden, så visuell bekreftelse i en nettleser gjenstår (manuelt anbefalt).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c993d367b88333be5fb6a0e877e19c)