### PR TITLE
Legg til multiple-choice-støtte i eksisterende quiz-endepunkter og UI

### DIFF
--- a/api/quiz/answer.js
+++ b/api/quiz/answer.js
@@ -34,6 +34,36 @@ function extractAcceptedAnswers(row) {
     });
 }
 
+async function evaluateMultipleChoiceAnswer(questionId, rawAnswer) {
+  const selectedOptionId = Number(rawAnswer);
+  if (!Number.isInteger(selectedOptionId) || selectedOptionId < 1) {
+    return { error: 'option_id_required' };
+  }
+
+  const optionResult = await runQuery(
+    `SELECT id, option_en, is_correct
+     FROM quiz_question_options
+     WHERE question_id = $1
+       AND (id = $2 OR is_correct = TRUE)`,
+    [questionId, selectedOptionId]
+  );
+
+  const rows = optionResult.rows || [];
+  const selectedOption = rows.find((row) => Number(row.id) === selectedOptionId) || null;
+  const correctOption = rows.find((row) => Boolean(row.is_correct)) || null;
+
+  if (!selectedOption) {
+    return { error: 'option_not_found' };
+  }
+
+  const isCorrect = Boolean(selectedOption.is_correct);
+  return {
+    status: isCorrect ? 'correct' : 'wrong',
+    retryAvailable: false,
+    acceptedAnswer: isCorrect ? null : (correctOption?.option_en || null)
+  };
+}
+
 async function persistProgress(userId, questionId, isCorrect) {
   try {
     await runQuery(
@@ -74,7 +104,7 @@ module.exports = async function handler(req, res) {
     }
 
     const questionResult = await runQuery(
-      `SELECT id, answers_en
+      `SELECT id, answers_en, question_type
        FROM quiz_questions
        WHERE id = $1
        LIMIT 1`,
@@ -87,12 +117,32 @@ module.exports = async function handler(req, res) {
       return;
     }
 
-    const acceptedAnswers = extractAcceptedAnswers(question);
-    const evaluation = evaluateAnswer({
-      userAnswer: answer,
-      acceptedAnswers,
-      retryAvailable: body.retryAvailable !== false
-    });
+    const questionType = question.question_type === 'multiple_choice' ? 'multiple_choice' : 'text';
+    let evaluation;
+    let acceptedAnswers = [];
+
+    if (questionType === 'multiple_choice') {
+      const multipleChoiceEvaluation = await evaluateMultipleChoiceAnswer(questionId, answer);
+
+      if (multipleChoiceEvaluation.error === 'option_id_required') {
+        res.status(400).json({ error: 'questionId and answer are required' });
+        return;
+      }
+
+      if (multipleChoiceEvaluation.error === 'option_not_found') {
+        res.status(400).json({ error: 'Invalid option for question' });
+        return;
+      }
+
+      evaluation = multipleChoiceEvaluation;
+    } else {
+      acceptedAnswers = extractAcceptedAnswers(question);
+      evaluation = evaluateAnswer({
+        userAnswer: answer,
+        acceptedAnswers,
+        retryAvailable: body.retryAvailable !== false
+      });
+    }
 
     const session = await getSessionFromCookies(req, res, { allowRefresh: true });
 
@@ -105,7 +155,7 @@ module.exports = async function handler(req, res) {
       status: evaluation.status,
       retryAvailable: evaluation.retryAvailable,
       acceptedAnswer: evaluation.status === 'wrong'
-        ? (evaluation.matchedAnswer || acceptedAnswers[0] || null)
+        ? (evaluation.acceptedAnswer || evaluation.matchedAnswer || acceptedAnswers[0] || null)
         : null
     });
   } catch (error) {

--- a/api/quiz/quest.js
+++ b/api/quiz/quest.js
@@ -50,6 +50,10 @@ function normalizeAnswerValues(value) {
     .filter(Boolean);
 }
 
+function obfuscateAnswerValue(value) {
+  return Buffer.from(String(value || ''), 'utf8').toString('base64');
+}
+
 function extractAnswers(row, lang) {
   const preferred = [row.answers_en];
 
@@ -64,21 +68,60 @@ function extractAnswers(row, lang) {
     });
 }
 
-function mapQuestion(row, lang) {
+function shuffleInPlace(values) {
+  for (let index = values.length - 1; index > 0; index -= 1) {
+    const targetIndex = randomIndex(index + 1);
+    [values[index], values[targetIndex]] = [values[targetIndex], values[index]];
+  }
+  return values;
+}
+
+function mapQuestion(row, lang, options = []) {
   const prompt = lang === 'no'
     ? row.question_no || row.question_en || ''
     : row.question_en || row.question_no || '';
+  const questionType = row.question_type === 'multiple_choice' ? 'multiple_choice' : 'text';
 
-  return {
+  const baseQuestion = {
     id: row.id,
     category: row.category || 'General',
     prompt,
-    answers: extractAnswers(row, lang)
+    difficulty: Number(row.difficulty) || null,
+    question_type: questionType
+  };
+
+  if (questionType === 'multiple_choice') {
+    const shuffledOptions = shuffleInPlace([...options]).map((option) => ({
+      option_id: Number(option.id),
+      option_en: option.option_en
+    }));
+    const obfuscatedCorrectOptionIds = options
+      .filter((option) => option.is_correct)
+      .map((option) => obfuscateAnswerValue(option.id));
+
+    return {
+      ...baseQuestion,
+      answers: obfuscatedCorrectOptionIds,
+      options: shuffledOptions
+    };
+  }
+
+  return {
+    ...baseQuestion,
+    answers: extractAnswers(row, lang).map((answer) => obfuscateAnswerValue(answer))
   };
 }
 
 function isQuestionValid(question) {
-  return Boolean(question && question.prompt && Array.isArray(question.answers) && question.answers.length);
+  if (!question || !question.prompt || !Array.isArray(question.answers) || !question.answers.length) {
+    return false;
+  }
+
+  if (question.question_type === 'multiple_choice') {
+    return Array.isArray(question.options) && question.options.length > 1;
+  }
+
+  return true;
 }
 
 
@@ -126,7 +169,7 @@ async function getNextQuestionCandidateFromPivot({ userId, categories, solvedQue
   if (userId) {
     const result = await runQuery(
       `WITH preferred AS (
-         SELECT q.id, q.category, q.question_en, q.question_no, q.answers_en
+         SELECT q.id, q.category, q.question_en, q.question_no, q.answers_en, q.difficulty, q.question_type
          FROM quiz_questions q
          LEFT JOIN user_answers ua
            ON ua.question_id = q.id
@@ -137,7 +180,7 @@ async function getNextQuestionCandidateFromPivot({ userId, categories, solvedQue
          ORDER BY q.id ASC
          LIMIT 1
        ), fallback AS (
-         SELECT q.id, q.category, q.question_en, q.question_no, q.answers_en
+         SELECT q.id, q.category, q.question_en, q.question_no, q.answers_en, q.difficulty, q.question_type
          FROM quiz_questions q
          LEFT JOIN user_answers ua
            ON ua.question_id = q.id
@@ -161,7 +204,7 @@ async function getNextQuestionCandidateFromPivot({ userId, categories, solvedQue
   const excludedIds = solvedQuestionIds.length ? solvedQuestionIds : [0];
   const result = await runQuery(
     `WITH preferred AS (
-       SELECT q.id, q.category, q.question_en, q.question_no, q.answers_en
+       SELECT q.id, q.category, q.question_en, q.question_no, q.answers_en, q.difficulty, q.question_type
        FROM quiz_questions q
        WHERE q.category = ANY($1)
          AND NOT (q.id = ANY($2::int[]))
@@ -169,7 +212,7 @@ async function getNextQuestionCandidateFromPivot({ userId, categories, solvedQue
        ORDER BY q.id ASC
        LIMIT 1
      ), fallback AS (
-       SELECT q.id, q.category, q.question_en, q.question_no, q.answers_en
+       SELECT q.id, q.category, q.question_en, q.question_no, q.answers_en, q.difficulty, q.question_type
        FROM quiz_questions q
        WHERE q.category = ANY($1)
          AND NOT (q.id = ANY($2::int[]))
@@ -185,6 +228,21 @@ async function getNextQuestionCandidateFromPivot({ userId, categories, solvedQue
   );
 
   return result.rows[0] || null;
+}
+
+async function fetchQuestionOptions(questionId) {
+  const result = await runQuery(
+    `SELECT id, option_en, is_correct
+     FROM quiz_question_options
+     WHERE question_id = $1`,
+    [questionId]
+  );
+
+  return result.rows.map((row) => ({
+    id: Number(row.id),
+    option_en: row.option_en,
+    is_correct: Boolean(row.is_correct)
+  }));
 }
 
 function createGuestProgressToken() {
@@ -351,7 +409,10 @@ module.exports = async function handler(req, res) {
         });
 
         if (!row) continue;
-        const mapped = mapQuestion(row, lang);
+        const options = row.question_type === 'multiple_choice'
+          ? await fetchQuestionOptions(row.id)
+          : [];
+        const mapped = mapQuestion(row, lang, options);
         if (!isQuestionValid(mapped)) continue;
         question = mapped;
         break;

--- a/api/quiz/start.js
+++ b/api/quiz/start.js
@@ -17,6 +17,10 @@ function normalizeAnswerValues(value) {
     .filter(Boolean);
 }
 
+function obfuscateAnswerValue(value) {
+  return Buffer.from(String(value || ''), 'utf8').toString('base64');
+}
+
 function extractAnswers(row, lang) {
   const preferred = [row.answers_en];
 
@@ -31,17 +35,40 @@ function extractAnswers(row, lang) {
     });
 }
 
-function mapQuestion(row, lang) {
+function mapQuestion(row, lang, optionsByQuestionId = new Map()) {
   const prompt = lang === 'no'
     ? row.question_no || row.question_en || ''
     : row.question_en || row.question_no || '';
+  const questionType = row.question_type === 'multiple_choice' ? 'multiple_choice' : 'text';
 
-  return {
+  const baseQuestion = {
     id: row.id,
     category: row.category || 'General',
     prompt,
-    answers: extractAnswers(row, lang),
-    difficulty: Number(row.difficulty) || null
+    difficulty: Number(row.difficulty) || null,
+    question_type: questionType
+  };
+
+  if (questionType === 'multiple_choice') {
+    const options = optionsByQuestionId.get(Number(row.id)) || [];
+    const shuffledOptions = shuffleInPlace([...options]).map((option) => ({
+      option_id: Number(option.id),
+      option_en: option.option_en
+    }));
+    const obfuscatedCorrectOptionIds = options
+      .filter((option) => option.is_correct)
+      .map((option) => obfuscateAnswerValue(option.id));
+
+    return {
+      ...baseQuestion,
+      answers: obfuscatedCorrectOptionIds,
+      options: shuffledOptions
+    };
+  }
+
+  return {
+    ...baseQuestion,
+    answers: extractAnswers(row, lang).map((answer) => obfuscateAnswerValue(answer))
   };
 }
 
@@ -182,6 +209,30 @@ async function pickRandomQuestionIds({ count, category, categories, difficulty }
   return sampleWithoutReplacement(ids, count);
 }
 
+async function fetchOptionsByQuestionId(questionIds) {
+  if (!questionIds.length) return new Map();
+
+  const result = await runQuery(
+    `SELECT id, question_id, option_en, is_correct
+     FROM quiz_question_options
+     WHERE question_id = ANY($1::int[])`,
+    [questionIds]
+  );
+
+  const grouped = new Map();
+  for (const row of result.rows) {
+    const questionId = Number(row.question_id);
+    if (!grouped.has(questionId)) grouped.set(questionId, []);
+    grouped.get(questionId).push({
+      id: Number(row.id),
+      option_en: row.option_en,
+      is_correct: Boolean(row.is_correct)
+    });
+  }
+
+  return grouped;
+}
+
 module.exports = async function handler(req, res) {
   const flushEndpointMetric = createEndpointMetric(req, res, 'quiz/start');
 
@@ -286,7 +337,7 @@ module.exports = async function handler(req, res) {
 
       const query = selectedIds.length
         ? await runQuery(
-          `SELECT id, category, question_en, question_no, answers_en, difficulty
+          `SELECT id, category, question_en, question_no, answers_en, difficulty, question_type
            FROM quiz_questions
            WHERE id = ANY($1::int[])`,
           [selectedIds]
@@ -294,9 +345,10 @@ module.exports = async function handler(req, res) {
         : { rows: [] };
 
       const orderedRows = orderRowsByIdList(query.rows, selectedIds);
+      const optionsByQuestionId = await fetchOptionsByQuestionId(orderedRows.map((row) => Number(row.id)));
       const questions = orderedRows
-        .map((row) => mapQuestion(row, lang))
-        .filter((row) => row.prompt && row.answers.length);
+        .map((row) => mapQuestion(row, lang, optionsByQuestionId))
+        .filter((row) => row.prompt && row.answers.length && (row.question_type !== 'multiple_choice' || row.options?.length));
 
       res.status(200).json({
         mode: 'categories',
@@ -328,7 +380,7 @@ module.exports = async function handler(req, res) {
 
     const query = selectedIds.length
       ? await runQuery(
-        `SELECT id, category, question_en, question_no, answers_en, difficulty
+        `SELECT id, category, question_en, question_no, answers_en, difficulty, question_type
          FROM quiz_questions
          WHERE id = ANY($1::int[])`,
         [selectedIds]
@@ -336,9 +388,10 @@ module.exports = async function handler(req, res) {
       : { rows: [] };
 
     const orderedRows = orderRowsByIdList(query.rows, selectedIds);
+    const optionsByQuestionId = await fetchOptionsByQuestionId(orderedRows.map((row) => Number(row.id)));
     const questions = orderedRows
-      .map((row) => mapQuestion(row, lang))
-      .filter((row) => row.prompt && row.answers.length);
+      .map((row) => mapQuestion(row, lang, optionsByQuestionId))
+      .filter((row) => row.prompt && row.answers.length && (row.question_type !== 'multiple_choice' || row.options?.length));
 
     res.status(200).json({
       mode,

--- a/quiz-categories/index.html
+++ b/quiz-categories/index.html
@@ -321,6 +321,7 @@
       </div>
       <form id="answerForm">
         <input id="answerInput" type="text" placeholder="Write your answer" autocomplete="off" />
+        <div id="mcOptions" class="hidden" style="display:grid;gap:8px;margin-top:10px;"></div>
         <div class="btn-row">
           <button id="submitBtn" class="btn-primary" type="submit">Submit answer</button>
           <button id="showAnswerBtn" class="hidden" type="button">Show answer</button>
@@ -492,6 +493,7 @@
     const questionDifficulty = document.getElementById('questionDifficulty');
     const answerForm = document.getElementById('answerForm');
     const answerInput = document.getElementById('answerInput');
+    const mcOptions = document.getElementById('mcOptions');
     const submitBtn = document.getElementById('submitBtn');
     const showAnswerBtn = document.getElementById('showAnswerBtn');
     const nextQuestionBtn = document.getElementById('nextQuestionBtn');
@@ -553,6 +555,49 @@
 
     function isNextQuestionVisible() {
       return !nextQuestionBtn.classList.contains('hidden');
+    }
+
+    function getQuestionType(question) {
+      return question?.question_type === 'multiple_choice' ? 'multiple_choice' : 'text';
+    }
+
+    function getSelectedOptionId() {
+      const selected = mcOptions.querySelector('input[name="mcOption"]:checked');
+      return selected ? Number(selected.value) : null;
+    }
+
+    function renderMcOptions(question) {
+      mcOptions.innerHTML = '';
+      for (const option of (question?.options || [])) {
+        const label = document.createElement('label');
+        label.style.display = 'flex';
+        label.style.gap = '8px';
+        label.style.padding = '10px';
+        label.style.border = '1px solid var(--bd)';
+        label.style.borderRadius = '8px';
+        label.style.background = 'var(--bg)';
+
+        const input = document.createElement('input');
+        input.type = 'radio';
+        input.name = 'mcOption';
+        input.value = String(option.option_id);
+
+        const text = document.createElement('span');
+        text.textContent = option.option_en || '';
+
+        label.append(input, text);
+        mcOptions.appendChild(label);
+      }
+    }
+
+    function getRevealAnswerText(question, encodedAnswer) {
+      const decoded = decodeAnswerForReveal(encodedAnswer);
+      if (getQuestionType(question) === 'multiple_choice') {
+        const selectedId = Number(decoded);
+        const match = (question.options || []).find((option) => Number(option.option_id) === selectedId);
+        return match?.option_en || '—';
+      }
+      return decoded || '—';
     }
 
     function syncLanguageFromStorage() {
@@ -757,7 +802,17 @@
       questionDifficulty.classList.remove('hidden');
 
       answerInput.value = '';
-      answerInput.disabled = false;
+      if (getQuestionType(question) === 'multiple_choice') {
+        answerInput.classList.add('hidden');
+        answerInput.disabled = true;
+        mcOptions.classList.remove('hidden');
+        renderMcOptions(question);
+      } else {
+        answerInput.classList.remove('hidden');
+        answerInput.disabled = false;
+        mcOptions.classList.add('hidden');
+        mcOptions.innerHTML = '';
+      }
       submitBtn.disabled = false;
       questionStatus.textContent = '';
       questionStatus.className = 'status';
@@ -765,11 +820,13 @@
       nextQuestionBtn.classList.add('hidden');
       answerReveal.classList.add('hidden');
       answerReveal.textContent = '';
-      runtimeState.pendingRevealAnswerEncoded = encodeAnswerForReveal(question.answers[0] || '—');
+      runtimeState.pendingRevealAnswerEncoded = question.answers?.[0] || '';
       showAnswerBtn.textContent = uiCopy().showAnswer;
       abortConfirmRow.classList.add('hidden');
       runtimeState.awaitingRetry = false;
-      answerInput.focus();
+      if (getQuestionType(question) === 'text') {
+        answerInput.focus();
+      }
     }
 
     function moveNextQuestion() {
@@ -923,10 +980,17 @@
       event.preventDefault();
       if (submitBtn.disabled) return;
 
-      const userAnswer = answerInput.value.trim();
-      if (!userAnswer) return;
-
       const current = runtimeState.questions[runtimeState.index];
+      const questionType = getQuestionType(current);
+      let userAnswer = '';
+      if (questionType === 'multiple_choice') {
+        const selectedOptionId = getSelectedOptionId();
+        if (!Number.isInteger(selectedOptionId)) return;
+        userAnswer = String(selectedOptionId);
+      } else {
+        userAnswer = answerInput.value.trim();
+        if (!userAnswer) return;
+      }
       let result;
 
       try {
@@ -943,7 +1007,9 @@
           prompt: current.prompt,
           status: 'correct',
           userAnswer,
-          acceptedAnswer: current.answers[0] || null,
+          acceptedAnswer: getQuestionType(current) === 'multiple_choice'
+            ? getRevealAnswerText(current, current.answers?.[0] || '')
+            : decodeAnswerForReveal(current.answers?.[0] || ''),
           category: current.category || 'General',
           difficulty: current.difficulty ?? null
         });
@@ -959,19 +1025,25 @@
         runtimeState.awaitingRetry = true;
         questionStatus.className = 'status almost';
         questionStatus.textContent = uiCopy().almostStatus;
-        answerInput.value = '';
-        answerInput.focus();
+        if (questionType === 'text') {
+          answerInput.value = '';
+          answerInput.focus();
+        }
         return;
       }
 
       runtimeState.wrong += 1;
       runtimeState.awaitingRetry = false;
-      runtimeState.pendingRevealAnswerEncoded = encodeAnswerForReveal(result.acceptedAnswer || current.answers[0] || '—');
+      runtimeState.pendingRevealAnswerEncoded = questionType === 'multiple_choice'
+        ? (current.answers?.[0] || '')
+        : encodeAnswerForReveal(result.acceptedAnswer || decodeAnswerForReveal(current.answers?.[0] || '') || '—');
       runtimeState.answeredQuestions.push({
         prompt: current.prompt,
         status: 'wrong',
         userAnswer,
-        acceptedAnswer: result.acceptedAnswer || current.answers[0] || null,
+        acceptedAnswer: getQuestionType(current) === 'multiple_choice'
+          ? getRevealAnswerText(current, current.answers?.[0] || '')
+          : (result.acceptedAnswer || decodeAnswerForReveal(current.answers?.[0] || '') || null),
         category: current.category || 'General',
         difficulty: current.difficulty ?? null
       });
@@ -981,12 +1053,18 @@
       nextQuestionBtn.classList.remove('hidden');
       submitBtn.disabled = true;
       answerInput.disabled = true;
+      for (const input of mcOptions.querySelectorAll('input[name="mcOption"]')) {
+        input.disabled = true;
+      }
     });
 
     showAnswerBtn.addEventListener('click', () => {
       const isHidden = answerReveal.classList.toggle('hidden');
       if (!isHidden) {
-        const decodedAnswer = decodeAnswerForReveal(runtimeState.pendingRevealAnswerEncoded);
+        const decodedAnswer = getRevealAnswerText(
+          runtimeState.questions[runtimeState.index],
+          runtimeState.pendingRevealAnswerEncoded
+        );
         answerReveal.textContent = uiCopy().answerPrefix.replace('{answer}', decodedAnswer);
       } else {
         answerReveal.textContent = '';

--- a/quiz-quest/index.html
+++ b/quiz-quest/index.html
@@ -163,6 +163,23 @@
       padding:12px;
     }
 
+    .mc-options {
+      display: grid;
+      gap: 8px;
+      margin-top: 10px;
+    }
+
+    .mc-option {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      border: 1px solid var(--bd);
+      border-radius: 8px;
+      padding: 10px;
+      background: var(--bg);
+      cursor: pointer;
+    }
+
     button,
     .link-btn {
       font-weight:700;
@@ -233,6 +250,7 @@
       <h2 id="questionPrompt">Question</h2>
       <form id="answerForm">
         <input id="answerInput" type="text" placeholder="Write your answer" autocomplete="off" />
+        <div id="mcOptions" class="mc-options hidden" role="radiogroup" aria-label="Multiple choice options"></div>
         <div class="btn-row">
           <button id="submitBtn" type="submit" class="btn-primary">Submit</button>
           <button id="showAnswerBtn" type="button" class="hidden">Show answer</button>
@@ -287,6 +305,7 @@
         wrong: '❌ Wrong. You can reveal the answer and move to another random question.',
         answerPrefix: 'Accepted answer: {answer}',
         yourAnswerMissing: 'Write an answer first.',
+        optionMissing: 'Choose an option first.',
         placeholder: 'Write your answer',
         noCategories: 'No categories available.'
       },
@@ -325,6 +344,7 @@
         wrong: '❌ Feil. Du kan vise fasit og gå videre til et nytt tilfeldig spørsmål.',
         answerPrefix: 'Godkjent svar: {answer}',
         yourAnswerMissing: 'Skriv et svar først.',
+        optionMissing: 'Velg et alternativ først.',
         placeholder: 'Skriv svaret ditt',
         noCategories: 'Ingen kategorier tilgjengelig.'
       }
@@ -368,6 +388,7 @@
     const questionPrompt = document.getElementById('questionPrompt');
     const answerForm = document.getElementById('answerForm');
     const answerInput = document.getElementById('answerInput');
+    const mcOptions = document.getElementById('mcOptions');
     const submitBtn = document.getElementById('submitBtn');
     const showAnswerBtn = document.getElementById('showAnswerBtn');
     const nextBtn = document.getElementById('nextBtn');
@@ -393,6 +414,59 @@
 
     function isNextQuestionVisible() {
       return !nextBtn.classList.contains('hidden');
+    }
+
+    function getQuestionType(question) {
+      return question?.question_type === 'multiple_choice' ? 'multiple_choice' : 'text';
+    }
+
+    function getSelectedOptionId() {
+      const selected = mcOptions.querySelector('input[name="mcOption"]:checked');
+      return selected ? Number(selected.value) : null;
+    }
+
+    function decodeRevealToken(encodedAnswer) {
+      if (!encodedAnswer) return '';
+      try {
+        return decodeURIComponent(escape(atob(encodedAnswer)));
+      } catch (error) {
+        return '';
+      }
+    }
+
+    function getRevealAnswerText(question, encodedAnswer) {
+      const decoded = decodeRevealToken(encodedAnswer);
+      if (!decoded) return '—';
+
+      if (getQuestionType(question) === 'multiple_choice') {
+        const selectedId = Number(decoded);
+        const options = Array.isArray(question?.options) ? question.options : [];
+        const match = options.find((option) => Number(option.option_id) === selectedId);
+        return match?.option_en || '—';
+      }
+
+      return decoded;
+    }
+
+    function renderMultipleChoiceOptions(question) {
+      mcOptions.innerHTML = '';
+      const options = Array.isArray(question?.options) ? question.options : [];
+
+      for (const option of options) {
+        const label = document.createElement('label');
+        label.className = 'mc-option';
+
+        const input = document.createElement('input');
+        input.type = 'radio';
+        input.name = 'mcOption';
+        input.value = String(option.option_id);
+
+        const text = document.createElement('span');
+        text.textContent = option.option_en || '';
+
+        label.append(input, text);
+        mcOptions.appendChild(label);
+      }
     }
 
     function readGuestProgress() {
@@ -561,6 +635,9 @@
       nextBtn.classList.add('hidden');
       submitBtn.disabled = false;
       answerInput.disabled = false;
+      answerInput.classList.remove('hidden');
+      mcOptions.classList.add('hidden');
+      mcOptions.innerHTML = '';
       state.awaitingRetry = false;
       state.pendingRevealAnswerEncoded = '';
     }
@@ -729,7 +806,18 @@
         questionPrompt.textContent = question.prompt;
         answerInput.value = '';
         answerInput.placeholder = ui().placeholder;
-        answerInput.focus();
+        if (getQuestionType(question) === 'multiple_choice') {
+          answerInput.classList.add('hidden');
+          answerInput.disabled = true;
+          mcOptions.classList.remove('hidden');
+          renderMultipleChoiceOptions(question);
+        } else {
+          answerInput.classList.remove('hidden');
+          answerInput.disabled = false;
+          mcOptions.classList.add('hidden');
+          mcOptions.innerHTML = '';
+          answerInput.focus();
+        }
         questionStatus.textContent = '';
         questionStatus.className = 'status';
         answerReveal.classList.add('hidden');
@@ -796,7 +884,22 @@
       event.preventDefault();
       if (!state.currentQuestion || state.isSubmitting) return;
 
-      const answer = answerInput.value.trim();
+      const questionType = getQuestionType(state.currentQuestion);
+      let answer = '';
+
+      if (questionType === 'multiple_choice') {
+        const selectedOptionId = getSelectedOptionId();
+        if (!Number.isInteger(selectedOptionId)) {
+          questionStatus.className = 'status error';
+          questionStatus.textContent = ui().optionMissing;
+          return;
+        }
+
+        answer = String(selectedOptionId);
+      } else {
+        answer = answerInput.value.trim();
+      }
+
       if (!answer) {
         questionStatus.className = 'status error';
         questionStatus.textContent = ui().yourAnswerMissing;
@@ -833,8 +936,10 @@
           answerReveal.textContent = '';
           state.pendingRevealAnswerEncoded = '';
           showAnswerBtn.classList.add('hidden');
-          answerInput.value = '';
-          answerInput.focus();
+          if (questionType === 'text') {
+            answerInput.value = '';
+            answerInput.focus();
+          }
           submitBtn.disabled = false;
           return;
         }
@@ -858,7 +963,11 @@
           questionStatus.textContent = ui().wrong;
           answerReveal.classList.add('hidden');
           answerReveal.textContent = '';
-          state.pendingRevealAnswerEncoded = encodeAnswerForReveal(payload.acceptedAnswer || '—');
+          if (questionType === 'multiple_choice') {
+            state.pendingRevealAnswerEncoded = state.currentQuestion.answers?.[0] || '';
+          } else {
+            state.pendingRevealAnswerEncoded = encodeAnswerForReveal(payload.acceptedAnswer || '—');
+          }
           showAnswerBtn.classList.remove('hidden');
           showAnswerBtn.textContent = ui().showAnswer;
         }
@@ -866,6 +975,11 @@
         state.roundAnswered += 1;
         nextBtn.classList.remove('hidden');
         answerInput.disabled = true;
+        const selectedInput = mcOptions.querySelector('input[name="mcOption"]:checked');
+        if (selectedInput) selectedInput.disabled = true;
+        for (const input of mcOptions.querySelectorAll('input[name="mcOption"]')) {
+          input.disabled = true;
+        }
         submitBtn.disabled = true;
       } catch (error) {
         questionStatus.className = 'status error';
@@ -929,7 +1043,7 @@
     showAnswerBtn.addEventListener('click', () => {
       const isHidden = answerReveal.classList.toggle('hidden');
       if (!isHidden) {
-        const decodedAnswer = decodeAnswerForReveal(state.pendingRevealAnswerEncoded);
+        const decodedAnswer = getRevealAnswerText(state.currentQuestion, state.pendingRevealAnswerEncoded);
         answerReveal.textContent = ui().answerPrefix.replace('{answer}', decodedAnswer);
       } else {
         answerReveal.textContent = '';

--- a/random10/index.html
+++ b/random10/index.html
@@ -62,6 +62,7 @@
       <p id="questionCategory" class="muted"></p>
       <form id="answerForm">
         <input id="answerInput" type="text" placeholder="Write your answer here" autocomplete="off" />
+        <div id="mcOptions" class="hidden" style="display:grid;gap:8px;margin-top:10px;"></div>
         <div class="btn-row">
           <button id="submitBtn" type="submit" class="btn-primary">Submit answer</button>
           <button id="showAnswerBtn" type="button" class="hidden">Show answer</button>
@@ -197,6 +198,7 @@
     const questionTitle = document.getElementById('questionTitle');
     const questionCategory = document.getElementById('questionCategory');
     const answerInput = document.getElementById('answerInput');
+    const mcOptions = document.getElementById('mcOptions');
     const statusText = document.getElementById('statusText');
     const answerReveal = document.getElementById('answerReveal');
     const showAnswerBtn = document.getElementById('showAnswerBtn');
@@ -255,6 +257,50 @@
 
     function isNextQuestionVisible() {
       return !nextQuestionBtn.classList.contains('hidden');
+    }
+
+    function getQuestionType(question) {
+      return question?.question_type === 'multiple_choice' ? 'multiple_choice' : 'text';
+    }
+
+    function getSelectedOptionId() {
+      const selected = mcOptions.querySelector('input[name="mcOption"]:checked');
+      return selected ? Number(selected.value) : null;
+    }
+
+    function renderMcOptions(question) {
+      mcOptions.innerHTML = '';
+      const options = Array.isArray(question?.options) ? question.options : [];
+      for (const option of options) {
+        const label = document.createElement('label');
+        label.style.display = 'flex';
+        label.style.gap = '8px';
+        label.style.padding = '10px';
+        label.style.border = '1px solid var(--bd)';
+        label.style.borderRadius = '8px';
+        label.style.background = 'var(--bg)';
+
+        const input = document.createElement('input');
+        input.type = 'radio';
+        input.name = 'mcOption';
+        input.value = String(option.option_id);
+
+        const text = document.createElement('span');
+        text.textContent = option.option_en || '';
+
+        label.append(input, text);
+        mcOptions.appendChild(label);
+      }
+    }
+
+    function getRevealAnswerText(question, encodedAnswer) {
+      const decoded = decodeAnswerForReveal(encodedAnswer);
+      if (getQuestionType(question) === 'multiple_choice') {
+        const selectedId = Number(decoded);
+        const match = (question.options || []).find((option) => Number(option.option_id) === selectedId);
+        return match?.option_en || '—';
+      }
+      return decoded || '—';
     }
 
     function uiCopy() {
@@ -333,7 +379,9 @@
         category: raw.category || 'General',
         difficulty,
         prompt: raw.prompt || raw.question || raw.question_en || raw.question_no || 'Missing question text',
-        answers
+        answers,
+        question_type: raw.question_type === 'multiple_choice' ? 'multiple_choice' : 'text',
+        options: Array.isArray(raw.options) ? raw.options : []
       };
     }
 
@@ -394,8 +442,18 @@
       questionTitle.textContent = q.prompt;
       questionCategory.textContent = formatCategoryLine(q);
       answerInput.value = '';
-      answerInput.disabled = false;
-      answerInput.focus();
+      if (getQuestionType(q) === 'multiple_choice') {
+        answerInput.classList.add('hidden');
+        answerInput.disabled = true;
+        mcOptions.classList.remove('hidden');
+        renderMcOptions(q);
+      } else {
+        answerInput.classList.remove('hidden');
+        answerInput.disabled = false;
+        mcOptions.classList.add('hidden');
+        mcOptions.innerHTML = '';
+        answerInput.focus();
+      }
       state.awaitingRetry = false;
       state.isSubmitting = false;
       state.isAdvancing = false;
@@ -403,7 +461,7 @@
       statusText.className = 'status';
       answerReveal.classList.add('hidden');
       answerReveal.textContent = '';
-      state.pendingRevealAnswerEncoded = encodeAnswerForReveal(q.answers[0] || '—');
+      state.pendingRevealAnswerEncoded = q.answers[0] || '';
       showAnswerBtn.classList.add('hidden');
       nextQuestionBtn.classList.add('hidden');
       abortConfirmRow.classList.add('hidden');
@@ -473,9 +531,17 @@
     async function onSubmitAnswer() {
       if (submitBtn.disabled || state.isSubmitting || state.isAdvancing) return;
 
-      const userAnswer = answerInput.value.trim();
-      if (!userAnswer) return;
       const question = state.questions[state.index];
+      const questionType = getQuestionType(question);
+      let userAnswer = '';
+      if (questionType === 'multiple_choice') {
+        const selectedOptionId = getSelectedOptionId();
+        if (!Number.isInteger(selectedOptionId)) return;
+        userAnswer = String(selectedOptionId);
+      } else {
+        userAnswer = answerInput.value.trim();
+        if (!userAnswer) return;
+      }
       const submittedIndex = state.index;
       state.isSubmitting = true;
 
@@ -502,7 +568,9 @@
           prompt: question.prompt,
           status: 'correct',
           userAnswer,
-          acceptedAnswer: question.answers[0] || null
+          acceptedAnswer: getQuestionType(question) === 'multiple_choice'
+            ? getRevealAnswerText(question, question.answers?.[0] || '')
+            : decodeAnswerForReveal(question.answers?.[0] || '')
         });
         state.isSubmitting = false;
         state.isAdvancing = true;
@@ -519,8 +587,10 @@
         state.isSubmitting = false;
         statusText.className = 'status almost';
         statusText.textContent = uiCopy().almostStatus;
-        answerInput.value = '';
-        answerInput.focus();
+        if (questionType === 'text') {
+          answerInput.value = '';
+          answerInput.focus();
+        }
         return;
       }
 
@@ -529,16 +599,23 @@
         prompt: question.prompt,
         status: 'wrong',
         userAnswer,
-        acceptedAnswer: result.acceptedAnswer || null
+        acceptedAnswer: getQuestionType(question) === 'multiple_choice'
+          ? getRevealAnswerText(question, question.answers?.[0] || '')
+          : (result.acceptedAnswer || decodeAnswerForReveal(question.answers?.[0] || '') || null)
       });
       state.awaitingRetry = false;
       state.isSubmitting = false;
-      state.pendingRevealAnswerEncoded = encodeAnswerForReveal(result.acceptedAnswer || question.answers?.[0] || '—');
+      state.pendingRevealAnswerEncoded = questionType === 'multiple_choice'
+        ? (question.answers?.[0] || '')
+        : encodeAnswerForReveal(result.acceptedAnswer || decodeAnswerForReveal(question.answers?.[0] || '') || '—');
       statusText.className = 'status wrong';
       statusText.textContent = uiCopy().wrongStatus;
       showAnswerBtn.classList.remove('hidden');
       nextQuestionBtn.classList.remove('hidden');
       submitBtn.disabled = true;
+      for (const input of mcOptions.querySelectorAll('input[name="mcOption"]')) {
+        input.disabled = true;
+      }
     }
 
     function applyCopy() {
@@ -614,7 +691,7 @@
     showAnswerBtn.addEventListener('click', () => {
       const isHidden = answerReveal.classList.toggle('hidden');
       if (!isHidden) {
-        const decodedAnswer = decodeAnswerForReveal(state.pendingRevealAnswerEncoded);
+        const decodedAnswer = getRevealAnswerText(state.questions[state.index], state.pendingRevealAnswerEncoded);
         answerReveal.textContent = uiCopy().answerPrefix.replace('{answer}', decodedAnswer);
       } else {
         answerReveal.textContent = '';


### PR DESCRIPTION
### Motivation
- Støtte både eksisterende tekstspørsmål og nye `multiple_choice`-spørsmål i samme quizflyt uten å endre database-skjema eller eksisterende tekst-validering.
- Unngå ekstra DB-kall for å vise fasit ved å inkludere obfuskert korrekt-svar-data i samme API-respons, samtidig som `is_correct` aldri eksponeres i klartekst.

### Description
- Backend: oppdaterte `api/quiz/start.js` og `api/quiz/quest.js` til å returnere `question_type` for hver spørsmålspost og å inkludere flervalg-alternativer (`option_id`, `option_en`) hentet fra `quiz_question_options`, med alternativer shufflet og korrekte option-ids obfuskert med Base64 (`Buffer.from(...).toString('base64')`).
- Backend: la til `evaluateMultipleChoiceAnswer` i `api/quiz/answer.js` for å validere innsending av `option_id` mot `quiz_question_options` og returnere samme svarformat (`questionId`, `status`, `retryAvailable`, `acceptedAnswer`) som tekstmodus uten å eksponere `is_correct`.
- Frontend: minimal endring i eksisterende UI-filer (`quiz-quest/index.html`, `random10/index.html`, `quiz-categories/index.html`) for å rendre multiple-choice alternativer som radios, sende valgt `option_id` som `answer` til `/api/quiz/answer`, og bruke den obfuskerte verdien fra API-responsen for client-side reveal uten ekstra DB-kall.
- Beholdt tekst-spørsmålene uendret internt: tekstsvar fortsetter å bruke samme evaluator (`lib/server/quiz-answer-evaluator.js`) og samme obfuskering/avkoding-mekanisme i klienten for reveal; flervalg bruker en tilsvarende obfuskert token (base64) som representerer riktig option id.

### Testing
- Syntaks- og statisk-sjekk: kjørt `node --check api/quiz/start.js && node --check api/quiz/quest.js && node --check api/quiz/answer.js`, og sjekken lykkedes uten syntax-feil.
- Prosjekt-tester: `npm test --silent` feilet fordi prosjektet ikke har et definert `test`-skript i `package.json`, så ingen enhetstester ble kjørt.
- Røyk/verifisering: manuelt gjennomgått endringer i start/quest/answer endepunktene og oppdatert klientlogikk for å sikre at eksisterende tekstflyt og reveal-mekanisme fortsatt bruker obfuskert answer-payload og at flervalg aldri eksponerer `is_correct` i responsene.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69caae1d090483339eca8c6d23bcb8aa)