### PR TITLE
Add optional voice input mode to quizzes (Web Speech API)

### DIFF
--- a/quiz-categories/index.html
+++ b/quiz-categories/index.html
@@ -219,6 +219,39 @@
       line-height:1;
     }
 
+    .input-mode {
+      display: inline-flex;
+      border: 1px solid var(--bd);
+      border-radius: 999px;
+      overflow: hidden;
+      margin: 4px 0 10px;
+    }
+
+    .mode-btn {
+      border: 0;
+      border-radius: 0;
+      padding: 8px 12px;
+      background: transparent;
+      color: var(--txt);
+    }
+
+    .mode-btn.is-active {
+      background: var(--accent);
+      color: #111;
+    }
+
+    .voice-status {
+      min-height: 1.25rem;
+      margin: 0 0 10px;
+      color: var(--muted);
+      font-size: 14px;
+      font-weight: 600;
+    }
+
+    .voice-status.error { color: var(--danger); }
+    .voice-status.ok { color: #80ed99; }
+    .input-disabled { opacity: 0.65; cursor: not-allowed; }
+
     .result-filter {
       margin-top: 10px;
     }
@@ -319,6 +352,11 @@
         <span id="questionCategory" class="question-meta-chip"></span>
         <span id="questionDifficulty" class="question-meta-chip hidden"></span>
       </div>
+      <div class="input-mode" role="group" aria-label="Input mode toggle">
+        <button id="textModeBtn" type="button" class="mode-btn is-active">Text</button>
+        <button id="voiceModeBtn" type="button" class="mode-btn">Voice</button>
+      </div>
+      <p id="voiceStatus" class="voice-status" aria-live="polite"></p>
       <form id="answerForm">
         <input id="answerInput" type="text" placeholder="Write your answer" autocomplete="off" />
         <div id="mcOptions" class="hidden" style="display:grid;gap:8px;margin-top:10px;"></div>
@@ -414,7 +452,14 @@
         almostStatus: 'Almost! You get one more try.',
         correctStatus: 'Correct!',
         wrongStatus: 'Not quite. You can reveal the answer and continue.',
-        noQuestions: 'No questions were returned for your selection.'
+        noQuestions: 'No questions were returned for your selection.',
+        inputModeText: 'Text',
+        inputModeVoice: 'Voice',
+        voiceListening: '🎙️ Listening…',
+        voiceProcessing: '⏳ Processing speech…',
+        voiceUnsupported: 'Voice mode is not supported in this browser.',
+        voicePermissionDenied: 'Microphone access denied. Switch to text mode or allow microphone access.',
+        voiceOptionNoMatch: 'Could not map speech to an option. Try letter, number or option text.'
       },
       no: {
         title: 'Quizkategorier',
@@ -472,7 +517,14 @@
         almostStatus: 'Nesten! Du får ett forsøk til.',
         correctStatus: 'Riktig!',
         wrongStatus: 'Ikke helt. Du kan vise fasit og gå videre.',
-        noQuestions: 'Ingen spørsmål ble returnert for valget ditt.'
+        noQuestions: 'Ingen spørsmål ble returnert for valget ditt.',
+        inputModeText: 'Tekst',
+        inputModeVoice: 'Stemmen',
+        voiceListening: '🎙️ Lytter…',
+        voiceProcessing: '⏳ Behandler tale…',
+        voiceUnsupported: 'Stemmemodus støttes ikke i denne nettleseren.',
+        voicePermissionDenied: 'Mikrofontilgang ble avslått. Bytt til tekstmodus eller tillat mikrofon.',
+        voiceOptionNoMatch: 'Klarte ikke å mappe talen til et alternativ. Prøv bokstav, tall eller alternativtekst.'
       }
     };
 
@@ -492,6 +544,9 @@
     const questionCategory = document.getElementById('questionCategory');
     const questionDifficulty = document.getElementById('questionDifficulty');
     const answerForm = document.getElementById('answerForm');
+    const textModeBtn = document.getElementById('textModeBtn');
+    const voiceModeBtn = document.getElementById('voiceModeBtn');
+    const voiceStatus = document.getElementById('voiceStatus');
     const answerInput = document.getElementById('answerInput');
     const mcOptions = document.getElementById('mcOptions');
     const submitBtn = document.getElementById('submitBtn');
@@ -533,7 +588,21 @@
       count: 0,
       answeredQuestions: [],
       resultFilter: 'all',
-      pendingRevealAnswerEncoded: ''
+      pendingRevealAnswerEncoded: '',
+      isSubmitting: false,
+      inputMode: 'text',
+      voice: {
+        supported: false,
+        recognition: null,
+        isListening: false,
+        isProcessing: false,
+        shouldListen: false,
+        restartTimer: null,
+        restartAttempts: 0,
+        permissionDenied: false,
+        lastQuestionKey: '',
+        lastSubmittedTranscript: ''
+      }
     };
 
     function uiCopy() {
@@ -564,6 +633,34 @@
     function getSelectedOptionId() {
       const selected = mcOptions.querySelector('input[name="mcOption"]:checked');
       return selected ? Number(selected.value) : null;
+    }
+
+    function normalizeVoiceText(value) {
+      return String(value || '')
+        .toLowerCase()
+        .trim()
+        .replace(/[.,/#!$%^&*;:{}=\-_`~()?"'[\]\\]/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim();
+    }
+
+    function getCurrentQuestionKey() {
+      const question = runtimeState.questions[runtimeState.index];
+      return question ? `${question.id}:${runtimeState.index}` : '';
+    }
+
+    function isVoiceNextCommand(transcript) {
+      const normalized = normalizeVoiceText(transcript);
+      if (!normalized) return false;
+      return new Set([
+        'next',
+        'next question',
+        'continue',
+        'go next',
+        'neste',
+        'neste spørsmål',
+        'fortsett'
+      ]).has(normalized);
     }
 
     function renderMcOptions(question) {
@@ -606,6 +703,325 @@
       return match?.option_en || String(selectedOptionId || '');
     }
 
+    function renderVoiceStatus() {
+      voiceStatus.className = 'voice-status';
+      if (runtimeState.inputMode !== 'voice') {
+        voiceStatus.textContent = '';
+        return;
+      }
+      const c = uiCopy();
+      if (!runtimeState.voice.supported) {
+        voiceStatus.classList.add('error');
+        voiceStatus.textContent = c.voiceUnsupported;
+      } else if (runtimeState.voice.permissionDenied) {
+        voiceStatus.classList.add('error');
+        voiceStatus.textContent = c.voicePermissionDenied;
+      } else if (runtimeState.voice.isProcessing) {
+        voiceStatus.textContent = c.voiceProcessing;
+      } else if (runtimeState.voice.isListening) {
+        voiceStatus.classList.add('ok');
+        voiceStatus.textContent = c.voiceListening;
+      } else {
+        voiceStatus.textContent = '';
+      }
+    }
+
+    function syncInputModeUi() {
+      const question = runtimeState.questions[runtimeState.index];
+      const isVoice = runtimeState.inputMode === 'voice';
+      textModeBtn.classList.toggle('is-active', !isVoice);
+      voiceModeBtn.classList.toggle('is-active', isVoice);
+      if (!question) {
+        renderVoiceStatus();
+        return;
+      }
+
+      if (getQuestionType(question) === 'text') {
+        answerInput.disabled = isVoice || submitBtn.disabled;
+        answerInput.classList.toggle('input-disabled', isVoice);
+      }
+      if (getQuestionType(question) === 'multiple_choice') {
+        for (const input of mcOptions.querySelectorAll('input[name="mcOption"]')) {
+          if (isVoice && !submitBtn.disabled) input.disabled = true;
+        }
+      }
+      renderVoiceStatus();
+    }
+
+    function stopVoiceListening() {
+      runtimeState.voice.shouldListen = false;
+      if (runtimeState.voice.restartTimer) {
+        clearTimeout(runtimeState.voice.restartTimer);
+        runtimeState.voice.restartTimer = null;
+      }
+      if (runtimeState.voice.recognition && runtimeState.voice.isListening) {
+        runtimeState.voice.recognition.stop();
+      }
+      runtimeState.voice.isListening = false;
+      renderVoiceStatus();
+    }
+
+    function scheduleVoiceRestart(delayMs = 300) {
+      const question = runtimeState.questions[runtimeState.index];
+      if (!runtimeState.voice.supported || !runtimeState.voice.recognition) return;
+      if (!runtimeState.quizStarted || !question || runtimeState.inputMode !== 'voice') return;
+      if (!runtimeState.voice.shouldListen || runtimeState.voice.permissionDenied) return;
+      if (submitBtn.disabled && !isNextQuestionVisible()) return;
+      if (runtimeState.voice.restartTimer || runtimeState.voice.restartAttempts >= 8) return;
+      runtimeState.voice.restartTimer = setTimeout(() => {
+        runtimeState.voice.restartTimer = null;
+        startVoiceListening();
+      }, delayMs);
+    }
+
+    function startVoiceListening() {
+      const question = runtimeState.questions[runtimeState.index];
+      if (!runtimeState.voice.supported || !runtimeState.voice.recognition) return;
+      if (!runtimeState.quizStarted || !question || runtimeState.inputMode !== 'voice') return;
+      if (!runtimeState.voice.shouldListen || runtimeState.voice.permissionDenied) return;
+      if (submitBtn.disabled && !isNextQuestionVisible()) return;
+      if (runtimeState.voice.isListening) return;
+      try {
+        runtimeState.voice.recognition.start();
+      } catch (error) {
+        runtimeState.voice.restartAttempts += 1;
+        scheduleVoiceRestart(600 + (runtimeState.voice.restartAttempts * 200));
+      }
+    }
+
+    function setInputMode(mode) {
+      const nextMode = mode === 'voice' ? 'voice' : 'text';
+      if (nextMode === 'voice' && !runtimeState.voice.supported) {
+        runtimeState.inputMode = 'text';
+        renderVoiceStatus();
+        return;
+      }
+      runtimeState.inputMode = nextMode;
+      runtimeState.voice.isProcessing = false;
+      if (runtimeState.inputMode === 'voice') {
+        runtimeState.voice.shouldListen = true;
+        runtimeState.voice.restartAttempts = 0;
+        startVoiceListening();
+      } else {
+        stopVoiceListening();
+      }
+      syncInputModeUi();
+    }
+
+    function resolveSpokenMultipleChoice(transcript, question) {
+      const normalized = normalizeVoiceText(transcript);
+      if (!normalized) return null;
+      const options = Array.isArray(question?.options) ? question.options : [];
+      if (!options.length) return null;
+      const letterMap = new Map([['a', 0], ['ay', 0], ['b', 1], ['bee', 1], ['c', 2], ['see', 2], ['d', 3], ['dee', 3]]);
+      const numberMap = new Map([['1', 0], ['one', 0], ['en', 0], ['2', 1], ['two', 1], ['to', 1], ['3', 2], ['three', 2], ['tre', 2], ['4', 3], ['four', 3], ['fire', 3]]);
+      const tokens = normalized.split(' ').filter(Boolean);
+      for (const token of tokens) {
+        if (letterMap.has(token)) {
+          const idx = letterMap.get(token);
+          if (idx < options.length) return String(options[idx].option_id);
+        }
+      }
+      for (const token of tokens) {
+        if (numberMap.has(token)) {
+          const idx = numberMap.get(token);
+          if (idx < options.length) return String(options[idx].option_id);
+        }
+      }
+      const normalizedOptions = options.map((option) => ({ id: String(option.option_id), text: normalizeVoiceText(option.option_en || '') }));
+      const exactMatch = normalizedOptions.find((option) => option.text === normalized);
+      if (exactMatch) return exactMatch.id;
+      const containsMatches = normalizedOptions.filter((option) => option.text && (option.text.includes(normalized) || normalized.includes(option.text)));
+      return containsMatches.length === 1 ? containsMatches[0].id : null;
+    }
+
+    async function submitCurrentAnswer(forcedAnswer = null) {
+      if (submitBtn.disabled || runtimeState.isSubmitting) return;
+      const current = runtimeState.questions[runtimeState.index];
+      const questionType = getQuestionType(current);
+      let userAnswer = '';
+      let userAnswerForSummary = '';
+      if (typeof forcedAnswer === 'string' && forcedAnswer.trim()) {
+        userAnswer = forcedAnswer.trim();
+      } else if (questionType === 'multiple_choice') {
+        const selectedOptionId = getSelectedOptionId();
+        if (!Number.isInteger(selectedOptionId)) return;
+        userAnswer = String(selectedOptionId);
+        userAnswerForSummary = getSelectedOptionText(current, selectedOptionId);
+      } else {
+        userAnswer = answerInput.value.trim();
+        if (!userAnswer) return;
+        userAnswerForSummary = userAnswer;
+      }
+
+      stopVoiceListening();
+      runtimeState.isSubmitting = true;
+      let result;
+      try {
+        result = await evaluateAnswer(current.id, userAnswer, !runtimeState.awaitingRetry);
+      } catch (error) {
+        questionStatus.className = 'status error';
+        questionStatus.textContent = error.message;
+        runtimeState.isSubmitting = false;
+        if (runtimeState.inputMode === 'voice') {
+          runtimeState.voice.shouldListen = true;
+          scheduleVoiceRestart(300);
+        }
+        return;
+      }
+
+      if (result.status === 'correct') {
+        runtimeState.correct += 1;
+        runtimeState.answeredQuestions.push({
+          prompt: current.prompt,
+          status: 'correct',
+          userAnswer: userAnswerForSummary,
+          acceptedAnswer: getQuestionType(current) === 'multiple_choice'
+            ? getRevealAnswerText(current, current.answers?.[0] || '')
+            : decodeAnswerForReveal(current.answers?.[0] || ''),
+          category: current.category || 'General',
+          difficulty: current.difficulty ?? null
+        });
+        questionStatus.className = 'status ok';
+        questionStatus.textContent = uiCopy().correctStatus;
+        submitBtn.disabled = true;
+        answerInput.disabled = true;
+        runtimeState.isSubmitting = false;
+        setTimeout(() => moveNextQuestion(), 600);
+        return;
+      }
+
+      if (result.status === 'almost' && !runtimeState.awaitingRetry) {
+        runtimeState.awaitingRetry = true;
+        questionStatus.className = 'status almost';
+        questionStatus.textContent = uiCopy().almostStatus;
+        if (questionType === 'text') {
+          answerInput.value = '';
+          if (runtimeState.inputMode !== 'voice') answerInput.focus();
+        }
+        runtimeState.isSubmitting = false;
+        if (runtimeState.inputMode === 'voice') {
+          runtimeState.voice.lastSubmittedTranscript = '';
+          runtimeState.voice.shouldListen = true;
+          scheduleVoiceRestart(250);
+        }
+        return;
+      }
+
+      runtimeState.wrong += 1;
+      runtimeState.awaitingRetry = false;
+      runtimeState.pendingRevealAnswerEncoded = questionType === 'multiple_choice'
+        ? (current.answers?.[0] || '')
+        : encodeAnswerForReveal(result.acceptedAnswer || decodeAnswerForReveal(current.answers?.[0] || '') || '—');
+      runtimeState.answeredQuestions.push({
+        prompt: current.prompt,
+        status: 'wrong',
+        userAnswer: userAnswerForSummary,
+        acceptedAnswer: getQuestionType(current) === 'multiple_choice'
+          ? getRevealAnswerText(current, current.answers?.[0] || '')
+          : (result.acceptedAnswer || decodeAnswerForReveal(current.answers?.[0] || '') || null),
+        category: current.category || 'General',
+        difficulty: current.difficulty ?? null
+      });
+      questionStatus.className = 'status error';
+      questionStatus.textContent = uiCopy().wrongStatus;
+      showAnswerBtn.classList.remove('hidden');
+      nextQuestionBtn.classList.remove('hidden');
+      submitBtn.disabled = true;
+      answerInput.disabled = true;
+      for (const input of mcOptions.querySelectorAll('input[name="mcOption"]')) input.disabled = true;
+      runtimeState.isSubmitting = false;
+      syncInputModeUi();
+      if (runtimeState.inputMode === 'voice') {
+        runtimeState.voice.shouldListen = true;
+        scheduleVoiceRestart(250);
+      }
+    }
+
+    async function handleVoiceTranscript(rawTranscript) {
+      const transcript = normalizeVoiceText(rawTranscript);
+      const question = runtimeState.questions[runtimeState.index];
+      if (!transcript || runtimeState.inputMode !== 'voice' || !question || runtimeState.isSubmitting) return;
+      if (isNextQuestionVisible()) {
+        if (isVoiceNextCommand(transcript)) {
+          runtimeState.voice.lastSubmittedTranscript = transcript;
+          moveNextQuestion();
+        }
+        return;
+      }
+      const questionKey = getCurrentQuestionKey();
+      if (runtimeState.voice.lastQuestionKey !== questionKey) {
+        runtimeState.voice.lastQuestionKey = questionKey;
+        runtimeState.voice.lastSubmittedTranscript = '';
+      }
+      if (runtimeState.voice.lastSubmittedTranscript === transcript) return;
+
+      let answer = transcript;
+      if (getQuestionType(question) === 'multiple_choice') {
+        answer = resolveSpokenMultipleChoice(transcript, question);
+        if (!answer) {
+          questionStatus.className = 'status error';
+          questionStatus.textContent = uiCopy().voiceOptionNoMatch;
+          return;
+        }
+        const selectedInput = mcOptions.querySelector(`input[name="mcOption"][value="${CSS.escape(answer)}"]`);
+        if (selectedInput) selectedInput.checked = true;
+      } else {
+        answerInput.value = rawTranscript.trim();
+      }
+
+      runtimeState.voice.lastSubmittedTranscript = transcript;
+      runtimeState.voice.isProcessing = true;
+      renderVoiceStatus();
+      await submitCurrentAnswer(answer);
+      runtimeState.voice.isProcessing = false;
+      renderVoiceStatus();
+    }
+
+    function setupVoiceRecognition() {
+      const SpeechRecognitionCtor = window.SpeechRecognition || window.webkitSpeechRecognition;
+      if (!SpeechRecognitionCtor) {
+        runtimeState.voice.supported = false;
+        renderVoiceStatus();
+        return;
+      }
+      runtimeState.voice.supported = true;
+      const recognition = new SpeechRecognitionCtor();
+      recognition.continuous = true;
+      recognition.interimResults = false;
+      recognition.maxAlternatives = 1;
+      recognition.lang = runtimeState.activeLang === 'no' ? 'nb-NO' : 'en-US';
+      recognition.onstart = () => {
+        runtimeState.voice.isListening = true;
+        runtimeState.voice.restartAttempts = 0;
+        renderVoiceStatus();
+      };
+      recognition.onresult = async (event) => {
+        const results = Array.from(event.results || []);
+        const finalResult = [...results].reverse().find((result) => result.isFinal);
+        const transcript = finalResult?.[0]?.transcript || '';
+        if (!transcript) return;
+        await handleVoiceTranscript(transcript);
+      };
+      recognition.onerror = (event) => {
+        runtimeState.voice.isListening = false;
+        if (event?.error === 'not-allowed' || event?.error === 'service-not-allowed') {
+          runtimeState.voice.permissionDenied = true;
+          setInputMode('text');
+          return;
+        }
+        runtimeState.voice.restartAttempts += 1;
+        renderVoiceStatus();
+      };
+      recognition.onend = () => {
+        runtimeState.voice.isListening = false;
+        renderVoiceStatus();
+        scheduleVoiceRestart(400);
+      };
+      runtimeState.voice.recognition = recognition;
+      renderVoiceStatus();
+    }
+
     function syncLanguageFromStorage() {
       runtimeState.activeLang = readQuizLanguage();
     }
@@ -614,6 +1030,12 @@
       setupView.classList.toggle('hidden', name !== 'setup');
       questionView.classList.toggle('hidden', name !== 'question');
       resultView.classList.toggle('hidden', name !== 'result');
+      if (name !== 'question') {
+        stopVoiceListening();
+      } else if (runtimeState.inputMode === 'voice') {
+        runtimeState.voice.shouldListen = true;
+        scheduleVoiceRestart(200);
+      }
     }
 
     function getSelectedCategories() {
@@ -830,8 +1252,15 @@
       showAnswerBtn.textContent = uiCopy().showAnswer;
       abortConfirmRow.classList.add('hidden');
       runtimeState.awaitingRetry = false;
+      runtimeState.voice.isProcessing = false;
+      runtimeState.voice.lastQuestionKey = getCurrentQuestionKey();
+      runtimeState.voice.lastSubmittedTranscript = '';
+      syncInputModeUi();
+      if (runtimeState.inputMode === 'voice') {
+        startVoiceListening();
+      }
       if (getQuestionType(question) === 'text') {
-        answerInput.focus();
+        if (runtimeState.inputMode !== 'voice') answerInput.focus();
       }
     }
 
@@ -984,87 +1413,7 @@
 
     answerForm.addEventListener('submit', async (event) => {
       event.preventDefault();
-      if (submitBtn.disabled) return;
-
-      const current = runtimeState.questions[runtimeState.index];
-      const questionType = getQuestionType(current);
-      let userAnswer = '';
-      let userAnswerForSummary = '';
-      if (questionType === 'multiple_choice') {
-        const selectedOptionId = getSelectedOptionId();
-        if (!Number.isInteger(selectedOptionId)) return;
-        userAnswer = String(selectedOptionId);
-        userAnswerForSummary = getSelectedOptionText(current, selectedOptionId);
-      } else {
-        userAnswer = answerInput.value.trim();
-        if (!userAnswer) return;
-        userAnswerForSummary = userAnswer;
-      }
-      let result;
-
-      try {
-        result = await evaluateAnswer(current.id, userAnswer, !runtimeState.awaitingRetry);
-      } catch (error) {
-        questionStatus.className = 'status error';
-        questionStatus.textContent = error.message;
-        return;
-      }
-
-      if (result.status === 'correct') {
-        runtimeState.correct += 1;
-        runtimeState.answeredQuestions.push({
-          prompt: current.prompt,
-          status: 'correct',
-          userAnswer: userAnswerForSummary,
-          acceptedAnswer: getQuestionType(current) === 'multiple_choice'
-            ? getRevealAnswerText(current, current.answers?.[0] || '')
-            : decodeAnswerForReveal(current.answers?.[0] || ''),
-          category: current.category || 'General',
-          difficulty: current.difficulty ?? null
-        });
-        questionStatus.className = 'status ok';
-        questionStatus.textContent = uiCopy().correctStatus;
-        submitBtn.disabled = true;
-        answerInput.disabled = true;
-        setTimeout(() => moveNextQuestion(), 600);
-        return;
-      }
-
-      if (result.status === 'almost' && !runtimeState.awaitingRetry) {
-        runtimeState.awaitingRetry = true;
-        questionStatus.className = 'status almost';
-        questionStatus.textContent = uiCopy().almostStatus;
-        if (questionType === 'text') {
-          answerInput.value = '';
-          answerInput.focus();
-        }
-        return;
-      }
-
-      runtimeState.wrong += 1;
-      runtimeState.awaitingRetry = false;
-      runtimeState.pendingRevealAnswerEncoded = questionType === 'multiple_choice'
-        ? (current.answers?.[0] || '')
-        : encodeAnswerForReveal(result.acceptedAnswer || decodeAnswerForReveal(current.answers?.[0] || '') || '—');
-      runtimeState.answeredQuestions.push({
-        prompt: current.prompt,
-        status: 'wrong',
-        userAnswer: userAnswerForSummary,
-        acceptedAnswer: getQuestionType(current) === 'multiple_choice'
-          ? getRevealAnswerText(current, current.answers?.[0] || '')
-          : (result.acceptedAnswer || decodeAnswerForReveal(current.answers?.[0] || '') || null),
-        category: current.category || 'General',
-        difficulty: current.difficulty ?? null
-      });
-      questionStatus.className = 'status error';
-      questionStatus.textContent = uiCopy().wrongStatus;
-      showAnswerBtn.classList.remove('hidden');
-      nextQuestionBtn.classList.remove('hidden');
-      submitBtn.disabled = true;
-      answerInput.disabled = true;
-      for (const input of mcOptions.querySelectorAll('input[name="mcOption"]')) {
-        input.disabled = true;
-      }
+      await submitCurrentAnswer();
     });
 
     showAnswerBtn.addEventListener('click', () => {
@@ -1140,7 +1489,7 @@
 
     cancelAbortBtn.addEventListener('click', () => {
       abortConfirmRow.classList.add('hidden');
-      answerInput.focus();
+      if (runtimeState.inputMode !== 'voice') answerInput.focus();
     });
 
     function applyCopy() {
@@ -1163,6 +1512,8 @@
       questionTitle.textContent = c.questionTitle;
       answerInput.placeholder = c.answerPlaceholder;
       submitBtn.textContent = c.submitAnswer;
+      textModeBtn.textContent = c.inputModeText;
+      voiceModeBtn.textContent = c.inputModeVoice;
       showAnswerBtn.textContent = c.showAnswer;
       nextQuestionBtn.textContent = c.nextQuestion;
       resultHeading.textContent = c.quizComplete;
@@ -1173,12 +1524,25 @@
       resultCounterItems[0].lastChild.textContent = ` ${c.correctLabel}`;
       resultCounterItems[1].lastChild.textContent = ` ${c.wrongLabel}`;
       playAgainBtn.textContent = c.playAgain;
+      renderVoiceStatus();
     }
 
     syncLanguageFromStorage();
     applyCopy();
+    setupVoiceRecognition();
+    setInputMode('text');
     loadOverview();
     showView('setup');
+    textModeBtn.addEventListener('click', () => setInputMode('text'));
+    voiceModeBtn.addEventListener('click', () => setInputMode('voice'));
+    document.addEventListener('visibilitychange', () => {
+      if (document.hidden) {
+        stopVoiceListening();
+      } else if (runtimeState.inputMode === 'voice') {
+        runtimeState.voice.shouldListen = true;
+        scheduleVoiceRestart(400);
+      }
+    });
     window.quizCategoriesState = runtimeState;
   </script>
 

--- a/quiz-quest/index.html
+++ b/quiz-quest/index.html
@@ -207,6 +207,48 @@
       background:#181920;
       margin-top: 14px;
     }
+
+    .input-mode {
+      display: inline-flex;
+      border: 1px solid var(--bd);
+      border-radius: 999px;
+      overflow: hidden;
+      margin: 4px 0 10px;
+    }
+
+    .mode-btn {
+      border: 0;
+      border-radius: 0;
+      padding: 8px 12px;
+      background: transparent;
+      color: var(--txt);
+    }
+
+    .mode-btn.is-active {
+      background: var(--accent);
+      color: #111;
+    }
+
+    .voice-status {
+      min-height: 1.25rem;
+      margin: 0 0 10px;
+      color: var(--muted);
+      font-size: 14px;
+      font-weight: 600;
+    }
+
+    .voice-status.error {
+      color: var(--danger);
+    }
+
+    .voice-status.ok {
+      color: var(--ok);
+    }
+
+    .input-disabled {
+      opacity: 0.65;
+      cursor: not-allowed;
+    }
   </style>
 </head>
 <body>
@@ -248,6 +290,11 @@
       <p id="progressText" class="muted"></p>
       <p id="questionCategory" class="muted"></p>
       <h2 id="questionPrompt">Question</h2>
+      <div class="input-mode" role="group" aria-label="Input mode toggle">
+        <button id="textModeBtn" type="button" class="mode-btn is-active">Text</button>
+        <button id="voiceModeBtn" type="button" class="mode-btn">Voice</button>
+      </div>
+      <p id="voiceStatus" class="voice-status" aria-live="polite"></p>
       <form id="answerForm">
         <input id="answerInput" type="text" placeholder="Write your answer" autocomplete="off" />
         <div id="mcOptions" class="mc-options hidden" role="radiogroup" aria-label="Multiple choice options"></div>
@@ -307,7 +354,14 @@
         yourAnswerMissing: 'Write an answer first.',
         optionMissing: 'Choose an option first.',
         placeholder: 'Write your answer',
-        noCategories: 'No categories available.'
+        noCategories: 'No categories available.',
+        inputModeText: 'Text',
+        inputModeVoice: 'Voice',
+        voiceListening: '🎙️ Listening…',
+        voiceProcessing: '⏳ Processing speech…',
+        voiceUnsupported: 'Voice mode is not supported in this browser.',
+        voicePermissionDenied: 'Microphone access denied. Switch to text mode or allow microphone access.',
+        voiceOptionNoMatch: 'Could not map speech to an option. Try saying letter, number or option text.'
       },
       no: {
         intro: 'Velg én eller flere kategorier og svar til poolen er fullført.',
@@ -346,7 +400,14 @@
         yourAnswerMissing: 'Skriv et svar først.',
         optionMissing: 'Velg et alternativ først.',
         placeholder: 'Skriv svaret ditt',
-        noCategories: 'Ingen kategorier tilgjengelig.'
+        noCategories: 'Ingen kategorier tilgjengelig.',
+        inputModeText: 'Tekst',
+        inputModeVoice: 'Stemmen',
+        voiceListening: '🎙️ Lytter…',
+        voiceProcessing: '⏳ Behandler tale…',
+        voiceUnsupported: 'Stemmemodus støttes ikke i denne nettleseren.',
+        voicePermissionDenied: 'Mikrofontilgang ble avslått. Bytt til tekstmodus eller tillat mikrofon.',
+        voiceOptionNoMatch: 'Klarte ikke å mappe talen til et alternativ. Prøv bokstav, tall eller alternativtekst.'
       }
     };
 
@@ -363,7 +424,20 @@
       roundAnswered: 0,
       isQuestActive: false,
       awaitingRetry: false,
-      pendingRevealAnswerEncoded: ''
+      pendingRevealAnswerEncoded: '',
+      inputMode: 'text',
+      voice: {
+        supported: false,
+        recognition: null,
+        isListening: false,
+        isProcessing: false,
+        shouldListen: false,
+        restartTimer: null,
+        restartAttempts: 0,
+        permissionDenied: false,
+        lastQuestionKey: '',
+        lastSubmittedTranscript: ''
+      }
     };
 
     const setupView = document.getElementById('setupView');
@@ -386,6 +460,9 @@
     const progressText = document.getElementById('progressText');
     const questionCategory = document.getElementById('questionCategory');
     const questionPrompt = document.getElementById('questionPrompt');
+    const textModeBtn = document.getElementById('textModeBtn');
+    const voiceModeBtn = document.getElementById('voiceModeBtn');
+    const voiceStatus = document.getElementById('voiceStatus');
     const answerForm = document.getElementById('answerForm');
     const answerInput = document.getElementById('answerInput');
     const mcOptions = document.getElementById('mcOptions');
@@ -414,6 +491,33 @@
 
     function isNextQuestionVisible() {
       return !nextBtn.classList.contains('hidden');
+    }
+
+    function normalizeVoiceText(value) {
+      return String(value || '')
+        .toLowerCase()
+        .trim()
+        .replace(/[.,/#!$%^&*;:{}=\-_`~()?"'[\]\\]/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim();
+    }
+
+    function getCurrentQuestionKey() {
+      return state.currentQuestion ? `${state.currentQuestion.id}:${state.roundAnswered}` : '';
+    }
+
+    function isVoiceNextCommand(transcript) {
+      const normalized = normalizeVoiceText(transcript);
+      if (!normalized) return false;
+      return new Set([
+        'next',
+        'next question',
+        'continue',
+        'go next',
+        'neste',
+        'neste spørsmål',
+        'fortsett'
+      ]).has(normalized);
     }
 
     function getQuestionType(question) {
@@ -640,6 +744,276 @@
       mcOptions.innerHTML = '';
       state.awaitingRetry = false;
       state.pendingRevealAnswerEncoded = '';
+      state.voice.isProcessing = false;
+      state.voice.lastQuestionKey = '';
+      state.voice.lastSubmittedTranscript = '';
+      syncInputModeUi();
+    }
+
+    function renderVoiceStatus() {
+      voiceStatus.className = 'voice-status';
+      if (state.inputMode !== 'voice') {
+        voiceStatus.textContent = '';
+        return;
+      }
+
+      if (!state.voice.supported) {
+        voiceStatus.classList.add('error');
+        voiceStatus.textContent = ui().voiceUnsupported;
+        return;
+      }
+
+      if (state.voice.permissionDenied) {
+        voiceStatus.classList.add('error');
+        voiceStatus.textContent = ui().voicePermissionDenied;
+        return;
+      }
+
+      if (state.voice.isProcessing || state.isSubmitting) {
+        voiceStatus.textContent = ui().voiceProcessing;
+        return;
+      }
+
+      if (state.voice.isListening) {
+        voiceStatus.classList.add('ok');
+        voiceStatus.textContent = ui().voiceListening;
+        return;
+      }
+
+      voiceStatus.textContent = '';
+    }
+
+    function syncInputModeUi() {
+      const isVoice = state.inputMode === 'voice';
+      textModeBtn.classList.toggle('is-active', !isVoice);
+      voiceModeBtn.classList.toggle('is-active', isVoice);
+
+      if (!state.currentQuestion) {
+        answerInput.disabled = true;
+        answerInput.classList.remove('input-disabled');
+        renderVoiceStatus();
+        return;
+      }
+
+      if (getQuestionType(state.currentQuestion) === 'text') {
+        answerInput.disabled = isVoice || state.isSubmitting || isNextQuestionVisible();
+        answerInput.classList.toggle('input-disabled', isVoice);
+      }
+
+      for (const optionInput of mcOptions.querySelectorAll('input[name="mcOption"]')) {
+        if (isVoice && !state.isSubmitting && !isNextQuestionVisible()) {
+          optionInput.disabled = true;
+        }
+      }
+
+      renderVoiceStatus();
+    }
+
+    function stopVoiceListening() {
+      state.voice.shouldListen = false;
+      if (state.voice.restartTimer) {
+        clearTimeout(state.voice.restartTimer);
+        state.voice.restartTimer = null;
+      }
+      if (state.voice.recognition && state.voice.isListening) {
+        state.voice.recognition.stop();
+      }
+      state.voice.isListening = false;
+      renderVoiceStatus();
+    }
+
+    function scheduleVoiceRestart(delayMs = 300) {
+      if (!state.voice.supported || !state.voice.recognition) return;
+      if (!state.voice.shouldListen || state.inputMode !== 'voice') return;
+      if (!state.isQuestActive || !state.currentQuestion || state.isSubmitting) return;
+      if (state.voice.permissionDenied) return;
+      if (state.voice.restartTimer) return;
+      if (state.voice.restartAttempts >= 8) return;
+
+      state.voice.restartTimer = setTimeout(() => {
+        state.voice.restartTimer = null;
+        startVoiceListening();
+      }, delayMs);
+    }
+
+    function startVoiceListening() {
+      if (!state.voice.supported || !state.voice.recognition) return;
+      if (!state.voice.shouldListen || state.inputMode !== 'voice') return;
+      if (!state.isQuestActive || !state.currentQuestion || state.isSubmitting) return;
+      if (state.voice.isListening) return;
+      if (state.voice.permissionDenied) return;
+
+      try {
+        state.voice.recognition.start();
+      } catch (error) {
+        // Browser can throw if start is called too soon; retry with backoff.
+        state.voice.restartAttempts += 1;
+        scheduleVoiceRestart(600 + (state.voice.restartAttempts * 200));
+      }
+    }
+
+    function setInputMode(mode) {
+      const nextMode = mode === 'voice' ? 'voice' : 'text';
+      if (nextMode === 'voice' && !state.voice.supported) {
+        state.inputMode = 'text';
+        renderVoiceStatus();
+        return;
+      }
+
+      state.inputMode = nextMode;
+      state.voice.isProcessing = false;
+      if (state.inputMode === 'voice') {
+        state.voice.shouldListen = true;
+        state.voice.restartAttempts = 0;
+        startVoiceListening();
+      } else {
+        stopVoiceListening();
+      }
+
+      syncInputModeUi();
+    }
+
+    function resolveSpokenMultipleChoice(transcript, question) {
+      const normalized = normalizeVoiceText(transcript);
+      if (!normalized) return null;
+      const options = Array.isArray(question?.options) ? question.options : [];
+      if (!options.length) return null;
+
+      const letterMap = new Map([
+        ['a', 0], ['ay', 0],
+        ['b', 1], ['bee', 1],
+        ['c', 2], ['see', 2],
+        ['d', 3], ['dee', 3]
+      ]);
+      const numberMap = new Map([
+        ['1', 0], ['one', 0], ['en', 0],
+        ['2', 1], ['two', 1], ['to', 1], ['too', 1], ['too', 1],
+        ['3', 2], ['three', 2], ['tre', 2],
+        ['4', 3], ['four', 3], ['fire', 3]
+      ]);
+
+      const compactTokens = normalized.split(' ').filter(Boolean);
+      for (const token of compactTokens) {
+        if (letterMap.has(token)) {
+          const idx = letterMap.get(token);
+          if (idx < options.length) return String(options[idx].option_id);
+        }
+      }
+
+      for (const token of compactTokens) {
+        if (numberMap.has(token)) {
+          const idx = numberMap.get(token);
+          if (idx < options.length) return String(options[idx].option_id);
+        }
+      }
+
+      const normalizedOptions = options.map((option) => ({
+        optionId: String(option.option_id),
+        text: normalizeVoiceText(option.option_en || '')
+      }));
+
+      const exactMatch = normalizedOptions.find((option) => option.text && option.text === normalized);
+      if (exactMatch) return exactMatch.optionId;
+
+      const containsMatches = normalizedOptions.filter((option) =>
+        option.text && (option.text.includes(normalized) || normalized.includes(option.text))
+      );
+      return containsMatches.length === 1 ? containsMatches[0].optionId : null;
+    }
+
+    async function handleVoiceTranscript(rawTranscript) {
+      const transcript = normalizeVoiceText(rawTranscript);
+      if (!transcript) return;
+      if (state.inputMode !== 'voice' || !state.currentQuestion || state.isSubmitting) return;
+
+      if (isNextQuestionVisible()) {
+        if (isVoiceNextCommand(transcript)) {
+          state.voice.lastSubmittedTranscript = transcript;
+          await proceedAfterAnswer();
+        }
+        return;
+      }
+
+      const questionKey = getCurrentQuestionKey();
+      if (state.voice.lastQuestionKey !== questionKey) {
+        state.voice.lastQuestionKey = questionKey;
+        state.voice.lastSubmittedTranscript = '';
+      }
+      if (state.voice.lastSubmittedTranscript === transcript) return;
+
+      const questionType = getQuestionType(state.currentQuestion);
+      let answer = transcript;
+
+      if (questionType === 'multiple_choice') {
+        answer = resolveSpokenMultipleChoice(transcript, state.currentQuestion);
+        if (!answer) {
+          questionStatus.className = 'status error';
+          questionStatus.textContent = ui().voiceOptionNoMatch;
+          return;
+        }
+        const selectedInput = mcOptions.querySelector(`input[name="mcOption"][value="${CSS.escape(answer)}"]`);
+        if (selectedInput) selectedInput.checked = true;
+      } else {
+        answerInput.value = rawTranscript.trim();
+      }
+
+      state.voice.lastSubmittedTranscript = transcript;
+      state.voice.isProcessing = true;
+      renderVoiceStatus();
+      await submitCurrentAnswer(answer);
+      state.voice.isProcessing = false;
+      renderVoiceStatus();
+    }
+
+    function setupVoiceRecognition() {
+      const SpeechRecognitionCtor = window.SpeechRecognition || window.webkitSpeechRecognition;
+      if (!SpeechRecognitionCtor) {
+        state.voice.supported = false;
+        renderVoiceStatus();
+        return;
+      }
+
+      state.voice.supported = true;
+      const recognition = new SpeechRecognitionCtor();
+      recognition.continuous = true;
+      recognition.interimResults = false;
+      recognition.maxAlternatives = 1;
+      recognition.lang = activeLang === 'no' ? 'nb-NO' : 'en-US';
+
+      recognition.onstart = () => {
+        state.voice.isListening = true;
+        state.voice.restartAttempts = 0;
+        renderVoiceStatus();
+      };
+
+      recognition.onresult = async (event) => {
+        const results = Array.from(event.results || []);
+        const finalResult = [...results].reverse().find((result) => result.isFinal);
+        const transcript = finalResult?.[0]?.transcript || '';
+        if (!transcript) return;
+        await handleVoiceTranscript(transcript);
+      };
+
+      recognition.onerror = (event) => {
+        state.voice.isListening = false;
+        if (event?.error === 'not-allowed' || event?.error === 'service-not-allowed') {
+          state.voice.permissionDenied = true;
+          setInputMode('text');
+          renderVoiceStatus();
+          return;
+        }
+        state.voice.restartAttempts += 1;
+        renderVoiceStatus();
+      };
+
+      recognition.onend = () => {
+        state.voice.isListening = false;
+        renderVoiceStatus();
+        scheduleVoiceRestart(400);
+      };
+
+      state.voice.recognition = recognition;
+      renderVoiceStatus();
     }
 
     function setAllCategorySelection(selected) {
@@ -828,6 +1202,13 @@
         submitBtn.disabled = false;
         state.awaitingRetry = false;
         state.pendingRevealAnswerEncoded = '';
+        state.voice.isProcessing = false;
+        state.voice.lastQuestionKey = getCurrentQuestionKey();
+        state.voice.lastSubmittedTranscript = '';
+        syncInputModeUi();
+        if (state.inputMode === 'voice') {
+          startVoiceListening();
+        }
         nextBtn.classList.add('hidden');
         return true;
       } catch (error) {
@@ -880,14 +1261,15 @@
       await loadNextQuestion();
     }
 
-    async function submitAnswer(event) {
-      event.preventDefault();
+    async function submitCurrentAnswer(forcedAnswer = null) {
       if (!state.currentQuestion || state.isSubmitting) return;
 
       const questionType = getQuestionType(state.currentQuestion);
       let answer = '';
 
-      if (questionType === 'multiple_choice') {
+      if (typeof forcedAnswer === 'string' && forcedAnswer.trim()) {
+        answer = forcedAnswer.trim();
+      } else if (questionType === 'multiple_choice') {
         const selectedOptionId = getSelectedOptionId();
         if (!Number.isInteger(selectedOptionId)) {
           questionStatus.className = 'status error';
@@ -908,6 +1290,8 @@
 
       state.isSubmitting = true;
       submitBtn.disabled = true;
+      stopVoiceListening();
+      renderVoiceStatus();
 
       try {
         const response = await fetch('/api/quiz/answer', {
@@ -938,9 +1322,17 @@
           showAnswerBtn.classList.add('hidden');
           if (questionType === 'text') {
             answerInput.value = '';
-            answerInput.focus();
+            if (state.inputMode !== 'voice') {
+              answerInput.focus();
+            }
           }
           submitBtn.disabled = false;
+          if (state.inputMode === 'voice') {
+            state.voice.isProcessing = false;
+            state.voice.lastSubmittedTranscript = '';
+            state.voice.shouldListen = true;
+            scheduleVoiceRestart(250);
+          }
           return;
         }
 
@@ -987,7 +1379,17 @@
         submitBtn.disabled = false;
       } finally {
         state.isSubmitting = false;
+        if (state.inputMode === 'voice') {
+          state.voice.shouldListen = true;
+          scheduleVoiceRestart(250);
+        }
+        syncInputModeUi();
       }
+    }
+
+    async function submitAnswer(event) {
+      event.preventDefault();
+      await submitCurrentAnswer();
     }
 
     async function resetCategoryProgress() {
@@ -1034,6 +1436,8 @@
       resetLabel.textContent = ui().resetCategoryLabel;
       resetCategoryBtn.textContent = ui().resetCategory;
       answerInput.placeholder = ui().placeholder;
+      textModeBtn.textContent = ui().inputModeText;
+      voiceModeBtn.textContent = ui().inputModeVoice;
     }
 
     questionCountInput.addEventListener('input', renderQuestionCountState);
@@ -1053,6 +1457,17 @@
     startQuestBtn.addEventListener('click', startQuest);
     answerForm.addEventListener('submit', submitAnswer);
     resetCategoryBtn.addEventListener('click', resetCategoryProgress);
+    textModeBtn.addEventListener('click', () => setInputMode('text'));
+    voiceModeBtn.addEventListener('click', () => setInputMode('voice'));
+
+    document.addEventListener('visibilitychange', () => {
+      if (document.hidden) {
+        stopVoiceListening();
+      } else if (state.inputMode === 'voice') {
+        state.voice.shouldListen = true;
+        scheduleVoiceRestart(400);
+      }
+    });
 
     document.addEventListener('keydown', (event) => {
       if (event.key !== 'Enter') return;
@@ -1065,6 +1480,8 @@
     async function init() {
       state.session = await fetchSession();
       renderStaticText();
+      setupVoiceRecognition();
+      setInputMode('text');
       await refreshOverview();
     }
 

--- a/random10/index.html
+++ b/random10/index.html
@@ -32,6 +32,13 @@
     .result-item-status.wrong { color:var(--bad); }
     .result-item-answer { margin:0 0 8px; color:var(--muted); }
     .result-item-answer strong { color:var(--txt); }
+    .input-mode { display:inline-flex; border:1px solid var(--bd); border-radius:999px; overflow:hidden; margin:4px 0 10px; }
+    .mode-btn { border:0; border-radius:0; padding:8px 12px; background:transparent; color:var(--txt); }
+    .mode-btn.is-active { background:var(--accent); color:#111; }
+    .voice-status { min-height:1.25rem; margin:0 0 10px; color:var(--muted); font-size:14px; font-weight:600; }
+    .voice-status.error { color:var(--bad); }
+    .voice-status.ok { color:var(--ok); }
+    .input-disabled { opacity:0.65; cursor:not-allowed; }
   </style>
 </head>
 <body>
@@ -60,6 +67,11 @@
       </div>
       <h2 id="questionTitle">Question</h2>
       <p id="questionCategory" class="muted"></p>
+      <div class="input-mode" role="group" aria-label="Input mode toggle">
+        <button id="textModeBtn" type="button" class="mode-btn is-active">Text</button>
+        <button id="voiceModeBtn" type="button" class="mode-btn">Voice</button>
+      </div>
+      <p id="voiceStatus" class="voice-status" aria-live="polite"></p>
       <form id="answerForm">
         <input id="answerInput" type="text" placeholder="Write your answer here" autocomplete="off" />
         <div id="mcOptions" class="hidden" style="display:grid;gap:8px;margin-top:10px;"></div>
@@ -137,7 +149,14 @@
         answerSubmitError: 'Could not submit answer. Try again.',
         almostStatus: 'Almost! Try one more time.',
         wrongStatus: 'Not quite. You can reveal the answer and continue.',
-        positiveMessages: ['Good!', 'Great job!', 'Nice one!', 'Excellent!', 'Well done!']
+        positiveMessages: ['Good!', 'Great job!', 'Nice one!', 'Excellent!', 'Well done!'],
+        inputModeText: 'Text',
+        inputModeVoice: 'Voice',
+        voiceListening: '🎙️ Listening…',
+        voiceProcessing: '⏳ Processing speech…',
+        voiceUnsupported: 'Voice mode is not supported in this browser.',
+        voicePermissionDenied: 'Microphone access denied. Switch to text mode or allow microphone access.',
+        voiceOptionNoMatch: 'Could not map speech to an option. Try letter, number or option text.'
       },
       no: {
         title: 'Random10 quiz',
@@ -182,7 +201,14 @@
         answerSubmitError: 'Kunne ikke sende svar. Prøv igjen.',
         almostStatus: 'Nesten! Prøv én gang til.',
         wrongStatus: 'Ikke helt. Du kan vise fasit og gå videre.',
-        positiveMessages: ['Bra!', 'Godt jobba!', 'Nice!', 'Supert!', 'Flott!']
+        positiveMessages: ['Bra!', 'Godt jobba!', 'Nice!', 'Supert!', 'Flott!'],
+        inputModeText: 'Tekst',
+        inputModeVoice: 'Stemmen',
+        voiceListening: '🎙️ Lytter…',
+        voiceProcessing: '⏳ Behandler tale…',
+        voiceUnsupported: 'Stemmemodus støttes ikke i denne nettleseren.',
+        voicePermissionDenied: 'Mikrofontilgang ble avslått. Bytt til tekstmodus eller tillat mikrofon.',
+        voiceOptionNoMatch: 'Klarte ikke å mappe talen til et alternativ. Prøv bokstav, tall eller alternativtekst.'
       }
     };
 
@@ -197,6 +223,9 @@
     const progressText = document.getElementById('progressText');
     const questionTitle = document.getElementById('questionTitle');
     const questionCategory = document.getElementById('questionCategory');
+    const textModeBtn = document.getElementById('textModeBtn');
+    const voiceModeBtn = document.getElementById('voiceModeBtn');
+    const voiceStatus = document.getElementById('voiceStatus');
     const answerInput = document.getElementById('answerInput');
     const mcOptions = document.getElementById('mcOptions');
     const statusText = document.getElementById('statusText');
@@ -235,7 +264,20 @@
       isSubmitting: false,
       isAdvancing: false,
       quizStarted: false,
-      pendingRevealAnswerEncoded: ''
+      pendingRevealAnswerEncoded: '',
+      inputMode: 'text',
+      voice: {
+        supported: false,
+        recognition: null,
+        isListening: false,
+        isProcessing: false,
+        shouldListen: false,
+        restartTimer: null,
+        restartAttempts: 0,
+        permissionDenied: false,
+        lastQuestionKey: '',
+        lastSubmittedTranscript: ''
+      }
     };
 
     function syncLanguageFromStorage() {
@@ -266,6 +308,34 @@
     function getSelectedOptionId() {
       const selected = mcOptions.querySelector('input[name="mcOption"]:checked');
       return selected ? Number(selected.value) : null;
+    }
+
+    function normalizeVoiceText(value) {
+      return String(value || '')
+        .toLowerCase()
+        .trim()
+        .replace(/[.,/#!$%^&*;:{}=\-_`~()?"'[\]\\]/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim();
+    }
+
+    function getCurrentQuestionKey() {
+      const question = state.questions[state.index];
+      return question ? `${question.id}:${state.index}` : '';
+    }
+
+    function isVoiceNextCommand(transcript) {
+      const normalized = normalizeVoiceText(transcript);
+      if (!normalized) return false;
+      return new Set([
+        'next',
+        'next question',
+        'continue',
+        'go next',
+        'neste',
+        'neste spørsmål',
+        'fortsett'
+      ]).has(normalized);
     }
 
     function renderMcOptions(question) {
@@ -309,6 +379,221 @@
       return match?.option_en || String(selectedOptionId || '');
     }
 
+    function renderVoiceStatus() {
+      voiceStatus.className = 'voice-status';
+      if (state.inputMode !== 'voice') {
+        voiceStatus.textContent = '';
+        return;
+      }
+      const c = uiCopy();
+      if (!state.voice.supported) {
+        voiceStatus.classList.add('error');
+        voiceStatus.textContent = c.voiceUnsupported;
+      } else if (state.voice.permissionDenied) {
+        voiceStatus.classList.add('error');
+        voiceStatus.textContent = c.voicePermissionDenied;
+      } else if (state.voice.isProcessing || state.isSubmitting) {
+        voiceStatus.textContent = c.voiceProcessing;
+      } else if (state.voice.isListening) {
+        voiceStatus.classList.add('ok');
+        voiceStatus.textContent = c.voiceListening;
+      } else {
+        voiceStatus.textContent = '';
+      }
+    }
+
+    function syncInputModeUi() {
+      const question = state.questions[state.index];
+      const isVoice = state.inputMode === 'voice';
+      textModeBtn.classList.toggle('is-active', !isVoice);
+      voiceModeBtn.classList.toggle('is-active', isVoice);
+      if (!question) {
+        renderVoiceStatus();
+        return;
+      }
+      if (getQuestionType(question) === 'text') {
+        answerInput.disabled = isVoice || submitBtn.disabled;
+        answerInput.classList.toggle('input-disabled', isVoice);
+      }
+      if (getQuestionType(question) === 'multiple_choice') {
+        for (const input of mcOptions.querySelectorAll('input[name="mcOption"]')) {
+          if (isVoice && !submitBtn.disabled) input.disabled = true;
+        }
+      }
+      renderVoiceStatus();
+    }
+
+    function stopVoiceListening() {
+      state.voice.shouldListen = false;
+      if (state.voice.restartTimer) {
+        clearTimeout(state.voice.restartTimer);
+        state.voice.restartTimer = null;
+      }
+      if (state.voice.recognition && state.voice.isListening) {
+        state.voice.recognition.stop();
+      }
+      state.voice.isListening = false;
+      renderVoiceStatus();
+    }
+
+    function scheduleVoiceRestart(delayMs = 300) {
+      const question = state.questions[state.index];
+      if (!state.voice.supported || !state.voice.recognition) return;
+      if (!state.quizStarted || !question || state.inputMode !== 'voice') return;
+      if (!state.voice.shouldListen || state.voice.permissionDenied) return;
+      if (state.isSubmitting || state.isAdvancing) return;
+      if (submitBtn.disabled && !isNextQuestionVisible()) return;
+      if (state.voice.restartTimer || state.voice.restartAttempts >= 8) return;
+      state.voice.restartTimer = setTimeout(() => {
+        state.voice.restartTimer = null;
+        startVoiceListening();
+      }, delayMs);
+    }
+
+    function startVoiceListening() {
+      const question = state.questions[state.index];
+      if (!state.voice.supported || !state.voice.recognition) return;
+      if (!state.quizStarted || !question || state.inputMode !== 'voice') return;
+      if (!state.voice.shouldListen || state.voice.permissionDenied) return;
+      if (state.isSubmitting || state.isAdvancing) return;
+      if (submitBtn.disabled && !isNextQuestionVisible()) return;
+      if (state.voice.isListening) return;
+      try {
+        state.voice.recognition.start();
+      } catch (error) {
+        state.voice.restartAttempts += 1;
+        scheduleVoiceRestart(600 + (state.voice.restartAttempts * 200));
+      }
+    }
+
+    function setInputMode(mode) {
+      const nextMode = mode === 'voice' ? 'voice' : 'text';
+      if (nextMode === 'voice' && !state.voice.supported) {
+        state.inputMode = 'text';
+        renderVoiceStatus();
+        return;
+      }
+      state.inputMode = nextMode;
+      state.voice.isProcessing = false;
+      if (state.inputMode === 'voice') {
+        state.voice.shouldListen = true;
+        state.voice.restartAttempts = 0;
+        startVoiceListening();
+      } else {
+        stopVoiceListening();
+      }
+      syncInputModeUi();
+    }
+
+    function resolveSpokenMultipleChoice(transcript, question) {
+      const normalized = normalizeVoiceText(transcript);
+      if (!normalized) return null;
+      const options = Array.isArray(question?.options) ? question.options : [];
+      if (!options.length) return null;
+      const letterMap = new Map([['a', 0], ['ay', 0], ['b', 1], ['bee', 1], ['c', 2], ['see', 2], ['d', 3], ['dee', 3]]);
+      const numberMap = new Map([['1', 0], ['one', 0], ['en', 0], ['2', 1], ['two', 1], ['to', 1], ['3', 2], ['three', 2], ['tre', 2], ['4', 3], ['four', 3], ['fire', 3]]);
+      const tokens = normalized.split(' ').filter(Boolean);
+      for (const token of tokens) {
+        if (letterMap.has(token)) {
+          const idx = letterMap.get(token);
+          if (idx < options.length) return String(options[idx].option_id);
+        }
+      }
+      for (const token of tokens) {
+        if (numberMap.has(token)) {
+          const idx = numberMap.get(token);
+          if (idx < options.length) return String(options[idx].option_id);
+        }
+      }
+      const normalizedOptions = options.map((option) => ({ id: String(option.option_id), text: normalizeVoiceText(option.option_en || '') }));
+      const exactMatch = normalizedOptions.find((option) => option.text === normalized);
+      if (exactMatch) return exactMatch.id;
+      const containsMatches = normalizedOptions.filter((option) => option.text && (option.text.includes(normalized) || normalized.includes(option.text)));
+      return containsMatches.length === 1 ? containsMatches[0].id : null;
+    }
+
+    async function handleVoiceTranscript(rawTranscript) {
+      const transcript = normalizeVoiceText(rawTranscript);
+      const question = state.questions[state.index];
+      if (!transcript || state.inputMode !== 'voice' || !question || state.isSubmitting) return;
+      if (isNextQuestionVisible()) {
+        if (isVoiceNextCommand(transcript)) {
+          state.voice.lastSubmittedTranscript = transcript;
+          moveNextQuestion();
+        }
+        return;
+      }
+      const questionKey = getCurrentQuestionKey();
+      if (state.voice.lastQuestionKey !== questionKey) {
+        state.voice.lastQuestionKey = questionKey;
+        state.voice.lastSubmittedTranscript = '';
+      }
+      if (state.voice.lastSubmittedTranscript === transcript) return;
+      let answer = transcript;
+      if (getQuestionType(question) === 'multiple_choice') {
+        answer = resolveSpokenMultipleChoice(transcript, question);
+        if (!answer) {
+          statusText.className = 'status wrong';
+          statusText.textContent = uiCopy().voiceOptionNoMatch;
+          return;
+        }
+        const selectedInput = mcOptions.querySelector(`input[name="mcOption"][value="${CSS.escape(answer)}"]`);
+        if (selectedInput) selectedInput.checked = true;
+      } else {
+        answerInput.value = rawTranscript.trim();
+      }
+      state.voice.lastSubmittedTranscript = transcript;
+      state.voice.isProcessing = true;
+      renderVoiceStatus();
+      await onSubmitAnswer(answer);
+      state.voice.isProcessing = false;
+      renderVoiceStatus();
+    }
+
+    function setupVoiceRecognition() {
+      const SpeechRecognitionCtor = window.SpeechRecognition || window.webkitSpeechRecognition;
+      if (!SpeechRecognitionCtor) {
+        state.voice.supported = false;
+        renderVoiceStatus();
+        return;
+      }
+      state.voice.supported = true;
+      const recognition = new SpeechRecognitionCtor();
+      recognition.continuous = true;
+      recognition.interimResults = false;
+      recognition.maxAlternatives = 1;
+      recognition.lang = state.language === 'no' ? 'nb-NO' : 'en-US';
+      recognition.onstart = () => {
+        state.voice.isListening = true;
+        state.voice.restartAttempts = 0;
+        renderVoiceStatus();
+      };
+      recognition.onresult = async (event) => {
+        const results = Array.from(event.results || []);
+        const finalResult = [...results].reverse().find((result) => result.isFinal);
+        const transcript = finalResult?.[0]?.transcript || '';
+        if (!transcript) return;
+        await handleVoiceTranscript(transcript);
+      };
+      recognition.onerror = (event) => {
+        state.voice.isListening = false;
+        if (event?.error === 'not-allowed' || event?.error === 'service-not-allowed') {
+          state.voice.permissionDenied = true;
+          setInputMode('text');
+          return;
+        }
+        state.voice.restartAttempts += 1;
+        renderVoiceStatus();
+      };
+      recognition.onend = () => {
+        state.voice.isListening = false;
+        renderVoiceStatus();
+        scheduleVoiceRestart(400);
+      };
+      state.voice.recognition = recognition;
+      renderVoiceStatus();
+    }
+
     function uiCopy() {
       return copy[state.language] || copy[fallbackLanguage];
     }
@@ -322,6 +607,12 @@
       introView.classList.toggle('hidden', view !== 'intro');
       questionView.classList.toggle('hidden', view !== 'question');
       resultView.classList.toggle('hidden', view !== 'result');
+      if (view !== 'question') {
+        stopVoiceListening();
+      } else if (state.inputMode === 'voice') {
+        state.voice.shouldListen = true;
+        scheduleVoiceRestart(200);
+      }
     }
 
     function setStartLoading(isLoading) {
@@ -472,6 +763,13 @@
       nextQuestionBtn.classList.add('hidden');
       abortConfirmRow.classList.add('hidden');
       submitBtn.disabled = false;
+      state.voice.isProcessing = false;
+      state.voice.lastQuestionKey = getCurrentQuestionKey();
+      state.voice.lastSubmittedTranscript = '';
+      syncInputModeUi();
+      if (state.inputMode === 'voice') {
+        startVoiceListening();
+      }
     }
 
     function moveNextQuestion() {
@@ -507,6 +805,7 @@
       state.pendingRevealAnswerEncoded = '';
       abortConfirmRow.classList.add('hidden');
       setStartLoading(false);
+      stopVoiceListening();
     }
 
     async function evaluateAnswer(question, userAnswer, retryAvailable) {
@@ -534,14 +833,16 @@
       return payload;
     }
 
-    async function onSubmitAnswer() {
+    async function onSubmitAnswer(forcedAnswer = null) {
       if (submitBtn.disabled || state.isSubmitting || state.isAdvancing) return;
 
       const question = state.questions[state.index];
       const questionType = getQuestionType(question);
       let userAnswer = '';
       let userAnswerForSummary = '';
-      if (questionType === 'multiple_choice') {
+      if (typeof forcedAnswer === 'string' && forcedAnswer.trim()) {
+        userAnswer = forcedAnswer.trim();
+      } else if (questionType === 'multiple_choice') {
         const selectedOptionId = getSelectedOptionId();
         if (!Number.isInteger(selectedOptionId)) return;
         userAnswer = String(selectedOptionId);
@@ -553,6 +854,7 @@
       }
       const submittedIndex = state.index;
       state.isSubmitting = true;
+      stopVoiceListening();
 
       let result;
       try {
@@ -561,6 +863,10 @@
         state.isSubmitting = false;
         statusText.className = 'status wrong';
         statusText.textContent = uiCopy().answerSubmitError;
+        if (state.inputMode === 'voice') {
+          state.voice.shouldListen = true;
+          scheduleVoiceRestart(300);
+        }
         return;
       }
 
@@ -598,7 +904,12 @@
         statusText.textContent = uiCopy().almostStatus;
         if (questionType === 'text') {
           answerInput.value = '';
-          answerInput.focus();
+          if (state.inputMode !== 'voice') answerInput.focus();
+        }
+        if (state.inputMode === 'voice') {
+          state.voice.lastSubmittedTranscript = '';
+          state.voice.shouldListen = true;
+          scheduleVoiceRestart(250);
         }
         return;
       }
@@ -625,6 +936,11 @@
       for (const input of mcOptions.querySelectorAll('input[name="mcOption"]')) {
         input.disabled = true;
       }
+      syncInputModeUi();
+      if (state.inputMode === 'voice') {
+        state.voice.shouldListen = true;
+        scheduleVoiceRestart(250);
+      }
     }
 
     function applyCopy() {
@@ -645,6 +961,8 @@
       questionSectionHeading.textContent = c.questionTitle;
       answerInput.placeholder = c.answerPlaceholder;
       submitBtn.textContent = c.submitAnswer;
+      textModeBtn.textContent = c.inputModeText;
+      voiceModeBtn.textContent = c.inputModeVoice;
       showAnswerBtn.textContent = c.showAnswer;
       nextQuestionBtn.textContent = c.nextQuestion;
       resultHeading.textContent = c.resultTitle;
@@ -652,6 +970,7 @@
       resultCounterItems[1].lastChild.textContent = ` ${c.wrongCount}`;
       answeredQuestionsHeading.textContent = c.answeredQuestionsHeading;
       playAgainBtn.textContent = c.playAgain;
+      renderVoiceStatus();
     }
 
     startBtn.addEventListener('click', async () => {
@@ -689,7 +1008,7 @@
 
     cancelAbortBtn.addEventListener('click', () => {
       abortConfirmRow.classList.add('hidden');
-      answerInput.focus();
+      if (state.inputMode !== 'voice') answerInput.focus();
     });
 
     answerForm.addEventListener('submit', (event) => {
@@ -726,6 +1045,18 @@
 
     syncLanguageFromStorage();
     applyCopy();
+    setupVoiceRecognition();
+    setInputMode('text');
+    textModeBtn.addEventListener('click', () => setInputMode('text'));
+    voiceModeBtn.addEventListener('click', () => setInputMode('voice'));
+    document.addEventListener('visibilitychange', () => {
+      if (document.hidden) {
+        stopVoiceListening();
+      } else if (state.inputMode === 'voice') {
+        state.voice.shouldListen = true;
+        scheduleVoiceRestart(400);
+      }
+    });
   </script>
 
   <script src='https://storage.ko-fi.com/cdn/scripts/overlay-widget.js'></script>


### PR DESCRIPTION
### Motivation

- Provide an alternative voice-driven input mode for several quiz pages to improve accessibility and hands-free play. 
- Make speech input work for both free-text and multiple-choice questions with graceful fallbacks for unsupported browsers and denied microphone permission. 

### Description

- Added UI for an input-mode toggle and a live voice status (`textModeBtn`, `voiceModeBtn`, `voiceStatus`) and new localized copy keys (`inputModeText`, `inputModeVoice`, `voiceListening`, `voiceProcessing`, `voiceUnsupported`, `voicePermissionDenied`, `voiceOptionNoMatch`) in `quiz-categories/index.html`, `quiz-quest/index.html`, and `random10/index.html`. 
- Implemented voice runtime state and helpers (`voice` state, `setupVoiceRecognition`, `startVoiceListening`, `stopVoiceListening`, `scheduleVoiceRestart`, `renderVoiceStatus`, `syncInputModeUi`) that use the browser Web Speech API and manage listening/restarts and permission errors. 
- Implemented speech processing flow (`handleVoiceTranscript`, `normalizeVoiceText`, `isVoiceNextCommand`, `getCurrentQuestionKey`, `resolveSpokenMultipleChoice`) to normalize transcripts, map speech to MC option ids (letters/numbers/option text), handle next-question voice commands, and submit answers via existing `evaluateAnswer`/`/api/quiz/answer` flows using new `submitCurrentAnswer` (or adapted `submitCurrentAnswer`/`onSubmitAnswer` depending on page). 
- Integrated voice mode into UI lifecycle: toggling input mode, disabling inputs during voice mode or while submitting, starting/stopping recognition on view changes and visibility changes, and preserving language selection for recognition (`en-US` / `nb-NO`). 
- Minor UX tweaks: avoid focusing text input when voice mode is active and ensure consistent state resets for `lastQuestionKey`/`lastSubmittedTranscript` and `isProcessing` flags. 

### Testing

- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cea7d41e0c8333a18270a941a228d8)