### PR TITLE
Skil kategorisvar fra Quest-progresjon

### DIFF
--- a/api/quiz/answer.js
+++ b/api/quiz/answer.js
@@ -95,6 +95,7 @@ module.exports = async function handler(req, res) {
   try {
     const body = parseJsonBody(req.body);
     const { questionId: rawQuestionId, answer: rawAnswer = '' } = body;
+    const shouldPersistProgress = body.persistProgress !== false;
     const questionId = Number(rawQuestionId);
     const answer = String(rawAnswer).trim();
 
@@ -146,7 +147,12 @@ module.exports = async function handler(req, res) {
 
     const session = await getSessionFromCookies(req, res, { allowRefresh: true });
 
-    if (session && session.id && (evaluation.status === 'correct' || evaluation.status === 'wrong')) {
+    if (
+      shouldPersistProgress
+      && session
+      && session.id
+      && (evaluation.status === 'correct' || evaluation.status === 'wrong')
+    ) {
       await persistProgress(session.id, questionId, evaluation.status === 'correct');
     }
 

--- a/quiz-categories/index.html
+++ b/quiz-categories/index.html
@@ -1313,6 +1313,7 @@
           questionId,
           answer,
           retryAvailable,
+          persistProgress: false,
           mode: 'categories',
           lang: runtimeState.activeLang
         })


### PR DESCRIPTION
### Motivation
- Quiz Categories og Quiz Quest deler samme spørsmålspool, men Categories skal ikke påvirke hvilke spørsmål som er markert som løst i Quest.

### Description
- La til et nytt request-felt `persistProgress` i `POST /api/quiz/answer` og bruker `body.persistProgress !== false` for å bestemme om progresjon skal skrives til `user_answers` i `api/quiz/answer.js`.
- Endret klienten i `quiz-categories/index.html` til å sende `persistProgress: false` når svar valideres, slik at riktige svar i Categories ikke blir lagret som løst i Quest.
- Standardoppførselen er uendret for andre klienter; progresjon lagres med mindre `persistProgress` eksplisitt settes til `false`.

### Testing
- Kjørte en syntaks-/type-sjekk med `node --check api/quiz/answer.js`, som fullførte uten feil.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ceb2ae27c08333bda4eda499d9dd85)