### PR TITLE
Persist quiz progress only in quest mode; add client flag and batch reset UI

### DIFF
--- a/api/quiz/answer.js
+++ b/api/quiz/answer.js
@@ -95,6 +95,7 @@ module.exports = async function handler(req, res) {
   try {
     const body = parseJsonBody(req.body);
     const { questionId: rawQuestionId, answer: rawAnswer = '' } = body;
+    const shouldPersistProgress = body.mode === 'quest' && body.persistProgress !== false;
     const questionId = Number(rawQuestionId);
     const answer = String(rawAnswer).trim();
 
@@ -146,7 +147,12 @@ module.exports = async function handler(req, res) {
 
     const session = await getSessionFromCookies(req, res, { allowRefresh: true });
 
-    if (session && session.id && (evaluation.status === 'correct' || evaluation.status === 'wrong')) {
+    if (
+      shouldPersistProgress
+      && session
+      && session.id
+      && (evaluation.status === 'correct' || evaluation.status === 'wrong')
+    ) {
       await persistProgress(session.id, questionId, evaluation.status === 'correct');
     }
 

--- a/quiz-categories/index.html
+++ b/quiz-categories/index.html
@@ -1313,6 +1313,7 @@
           questionId,
           answer,
           retryAvailable,
+          persistProgress: false,
           mode: 'categories',
           lang: runtimeState.activeLang
         })

--- a/quiz-quest/index.html
+++ b/quiz-quest/index.html
@@ -280,9 +280,7 @@
       </div>
 
       <div class="controls">
-        <label for="resetCategorySelect" class="muted" id="resetLabel">Reset category</label>
-        <select id="resetCategorySelect"></select>
-        <button id="resetCategoryBtn" type="button">Reset category</button>
+        <button id="resetCategoryBtn" type="button">Reset selected categories</button>
       </div>
     </section>
 
@@ -334,11 +332,11 @@
         showAnswer: 'Show answer',
         hideAnswer: 'Hide answer',
         back: 'Back to sarcasm.games',
-        resetCategory: 'Reset category',
-        resetCategoryLabel: 'Reset category',
-        resetUserDone: 'Category progress reset.',
-        resetGuestDone: 'Guest progress reset for this category.',
-        resetNeedsCategory: 'Choose a category to reset.',
+        resetCategory: 'Reset selected categories',
+        resetUserDone: 'Selected category progress reset.',
+        resetGuestDone: 'Guest progress reset for selected categories.',
+        resetNeedsCategory: 'Choose at least one category to reset.',
+        resetConfirm: 'Are you sure you want to reset progress for {count} selected categories?',
         failedOverview: 'Could not load category overview.',
         failedQuestion: 'Could not load a question.',
         failedAnswer: 'Could not validate answer.',
@@ -381,11 +379,11 @@
         showAnswer: 'Vis fasit',
         hideAnswer: 'Skjul fasit',
         back: 'Tilbake til sarcasm.games',
-        resetCategory: 'Reset kategori',
-        resetCategoryLabel: 'Reset kategori',
-        resetUserDone: 'Kategorifremgang er resatt.',
-        resetGuestDone: 'Gjestefremgang for kategorien er resatt.',
-        resetNeedsCategory: 'Velg en kategori å resette.',
+        resetCategory: 'Reset valgte kategorier',
+        resetUserDone: 'Fremgang for valgte kategorier er resatt.',
+        resetGuestDone: 'Gjestefremgang for valgte kategorier er resatt.',
+        resetNeedsCategory: 'Velg minst én kategori å resette.',
+        resetConfirm: 'Er du sikker på at du vil resette fremgang for {count} valgte kategorier?',
         failedOverview: 'Kunne ikke laste kategorioversikt.',
         failedQuestion: 'Kunne ikke hente spørsmål.',
         failedAnswer: 'Kunne ikke sjekke svar.',
@@ -455,8 +453,6 @@
     const questionCountInput = document.getElementById('questionCount');
     const countMeta = document.getElementById('countMeta');
     const startQuestBtn = document.getElementById('startQuestBtn');
-    const resetLabel = document.getElementById('resetLabel');
-    const resetCategorySelect = document.getElementById('resetCategorySelect');
     const resetCategoryBtn = document.getElementById('resetCategoryBtn');
     const backLink = document.getElementById('backLink');
     const questionSection = document.getElementById('questionSection');
@@ -713,6 +709,7 @@
     function renderQuestionCountState() {
       const remaining = getSelectedRemainingCount();
       const hasPool = remaining > 0;
+      renderResetState();
 
       questionCountInput.disabled = !hasPool;
       startQuestBtn.disabled = !hasPool;
@@ -1043,28 +1040,8 @@
       setupView.classList.toggle('hidden', active);
     }
 
-    function renderResetCategories() {
-      const previous = resetCategorySelect.value;
-      resetCategorySelect.innerHTML = '';
-
-      for (const category of state.categories) {
-        const option = document.createElement('option');
-        option.value = category.name;
-        option.textContent = category.name;
-        resetCategorySelect.appendChild(option);
-      }
-
-      if (!state.categories.length) {
-        const option = document.createElement('option');
-        option.value = '';
-        option.textContent = ui().noCategories;
-        resetCategorySelect.appendChild(option);
-      }
-
-      const exists = state.categories.some((category) => category.name === previous);
-      resetCategorySelect.value = exists ? previous : (state.categories[0]?.name || '');
-      resetCategorySelect.disabled = !state.categories.length;
-      resetCategoryBtn.disabled = !state.categories.length;
+    function renderResetState() {
+      resetCategoryBtn.disabled = selectedCategories().length < 1;
     }
 
     function renderCategories() {
@@ -1080,7 +1057,7 @@
         startQuestBtn.disabled = true;
         renderPoolStatus();
         renderQuestionCountState();
-        renderResetCategories();
+        renderResetState();
         return;
       }
 
@@ -1123,7 +1100,7 @@
 
       renderPoolStatus();
       renderQuestionCountState();
-      renderResetCategories();
+      renderResetState();
     }
 
     function markGuestSolved(question) {
@@ -1409,20 +1386,27 @@
     }
 
     async function resetCategoryProgress() {
-      const category = resetCategorySelect.value;
-      if (!category) {
+      const categoriesToReset = selectedCategories();
+      if (!categoriesToReset.length) {
         setupStatus.className = 'status error';
         setupStatus.textContent = ui().resetNeedsCategory;
         return;
       }
 
+      const confirmation = ui().resetConfirm.replace('{count}', String(categoriesToReset.length));
+      if (!window.confirm(confirmation)) {
+        return;
+      }
+
       try {
         if (state.session) {
-          await questApi('reset', { category });
+          await Promise.all(categoriesToReset.map((category) => questApi('reset', { category })));
           setupStatus.className = 'status ok';
           setupStatus.textContent = ui().resetUserDone;
         } else {
-          delete state.guestProgress[category];
+          for (const category of categoriesToReset) {
+            delete state.guestProgress[category];
+          }
           state.pendingSolvedQuestionIds = [];
           writeGuestProgressToken(null);
           writeGuestProgress();
@@ -1449,7 +1433,6 @@
       submitBtn.textContent = ui().submit;
       showAnswerBtn.textContent = ui().showAnswer;
       backLink.textContent = ui().back;
-      resetLabel.textContent = ui().resetCategoryLabel;
       resetCategoryBtn.textContent = ui().resetCategory;
       answerInput.placeholder = ui().placeholder;
       textModeBtn.textContent = ui().inputModeText;

--- a/random10/index.html
+++ b/random10/index.html
@@ -833,6 +833,7 @@
           questionId: question.id,
           answer: userAnswer,
           retryAvailable,
+          persistProgress: false,
           mode: 'random10',
           lang: activeLang
         })


### PR DESCRIPTION
### Motivation

- Prevent accidental server-side persistence of quiz progress from non-quest flows and give clients explicit control over when progress should be stored.
- Improve the quest UI to allow resetting progress for multiple selected categories at once with confirmation and clearer copy.

### Description

- Add `shouldPersistProgress` in the API handler to only call `persistProgress` when `body.mode === 'quest'` and `body.persistProgress !== false`.
- Stop progress persistence from category and random10 clients by including `persistProgress: false` in requests to `/api/quiz/answer`.
- Replace the single-category reset select in the quest UI with a batch reset flow that uses the current selection, adds a confirmation prompt, updates copy strings (English and Norwegian), and handles resetting both server-side session categories and guest progress for multiple categories.
- Introduce `renderResetState()` to enable/disable the reset button based on selected categories and remove legacy `resetCategorySelect`/`resetLabel` elements and usages.

### Testing

- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ceb2ae27c08333bda4eda499d9dd85)