### PR TITLE
Add image and audio support for quiz questions (backend + UI)

### DIFF
--- a/api/_lib/quiz-media.js
+++ b/api/_lib/quiz-media.js
@@ -1,0 +1,28 @@
+const QUIZ_MEDIA_BUCKET = 'quiz-media';
+
+function getSupabaseBaseUrl() {
+  const value = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL || '';
+  return value.trim().replace(/\/+$/, '');
+}
+
+function encodeStoragePath(path) {
+  return String(path)
+    .split('/')
+    .map((segment) => encodeURIComponent(segment))
+    .join('/');
+}
+
+function toQuizMediaUrl(path) {
+  if (!path || typeof path !== 'string') return null;
+  const trimmedPath = path.trim();
+  if (!trimmedPath) return null;
+
+  const baseUrl = getSupabaseBaseUrl();
+  if (!baseUrl) return null;
+
+  return `${baseUrl}/storage/v1/object/public/${QUIZ_MEDIA_BUCKET}/${encodeStoragePath(trimmedPath)}`;
+}
+
+module.exports = {
+  toQuizMediaUrl
+};

--- a/api/quiz/quest.js
+++ b/api/quiz/quest.js
@@ -5,6 +5,7 @@ const { isRateLimited } = require('../_lib/rate-limit');
 const { sendQuizRateLimited } = require('../_lib/quiz-rate-limit-response');
 const { createEndpointMetric } = require('../_lib/observability');
 const { parseJsonBody } = require('../_lib/parse-body');
+const { toQuizMediaUrl } = require('../_lib/quiz-media');
 const {
   getGuestProgress,
   saveGuestProgress,
@@ -87,7 +88,9 @@ function mapQuestion(row, lang, options = []) {
     category: row.category || 'General',
     prompt,
     difficulty: Number(row.difficulty) || null,
-    question_type: questionType
+    question_type: questionType,
+    image_url: toQuizMediaUrl(row.image_path),
+    audio_url: toQuizMediaUrl(row.audio_path)
   };
 
   if (questionType === 'multiple_choice') {
@@ -169,7 +172,7 @@ async function getNextQuestionCandidateFromPivot({ userId, categories, solvedQue
   if (userId) {
     const result = await runQuery(
       `WITH preferred AS (
-         SELECT q.id, q.category, q.question_en, q.question_no, q.answers_en, q.difficulty, q.question_type
+         SELECT q.id, q.category, q.question_en, q.question_no, q.answers_en, q.difficulty, q.question_type, q.image_path, q.audio_path
          FROM quiz_questions q
          LEFT JOIN user_answers ua
            ON ua.question_id = q.id
@@ -180,7 +183,7 @@ async function getNextQuestionCandidateFromPivot({ userId, categories, solvedQue
          ORDER BY q.id ASC
          LIMIT 1
        ), fallback AS (
-         SELECT q.id, q.category, q.question_en, q.question_no, q.answers_en, q.difficulty, q.question_type
+         SELECT q.id, q.category, q.question_en, q.question_no, q.answers_en, q.difficulty, q.question_type, q.image_path, q.audio_path
          FROM quiz_questions q
          LEFT JOIN user_answers ua
            ON ua.question_id = q.id
@@ -204,7 +207,7 @@ async function getNextQuestionCandidateFromPivot({ userId, categories, solvedQue
   const excludedIds = solvedQuestionIds.length ? solvedQuestionIds : [0];
   const result = await runQuery(
     `WITH preferred AS (
-       SELECT q.id, q.category, q.question_en, q.question_no, q.answers_en, q.difficulty, q.question_type
+       SELECT q.id, q.category, q.question_en, q.question_no, q.answers_en, q.difficulty, q.question_type, q.image_path, q.audio_path
        FROM quiz_questions q
        WHERE q.category = ANY($1)
          AND NOT (q.id = ANY($2::int[]))
@@ -212,7 +215,7 @@ async function getNextQuestionCandidateFromPivot({ userId, categories, solvedQue
        ORDER BY q.id ASC
        LIMIT 1
      ), fallback AS (
-       SELECT q.id, q.category, q.question_en, q.question_no, q.answers_en, q.difficulty, q.question_type
+       SELECT q.id, q.category, q.question_en, q.question_no, q.answers_en, q.difficulty, q.question_type, q.image_path, q.audio_path
        FROM quiz_questions q
        WHERE q.category = ANY($1)
          AND NOT (q.id = ANY($2::int[]))

--- a/api/quiz/start.js
+++ b/api/quiz/start.js
@@ -3,6 +3,7 @@ const { isRateLimited } = require('../_lib/rate-limit');
 const { sendQuizRateLimited } = require('../_lib/quiz-rate-limit-response');
 const { createEndpointMetric } = require('../_lib/observability');
 const { parseJsonBody } = require('../_lib/parse-body');
+const { toQuizMediaUrl } = require('../_lib/quiz-media');
 
 function normalizeAnswerValues(value) {
   if (!value) return [];
@@ -46,7 +47,9 @@ function mapQuestion(row, lang, optionsByQuestionId = new Map()) {
     category: row.category || 'General',
     prompt,
     difficulty: Number(row.difficulty) || null,
-    question_type: questionType
+    question_type: questionType,
+    image_url: toQuizMediaUrl(row.image_path),
+    audio_url: toQuizMediaUrl(row.audio_path)
   };
 
   if (questionType === 'multiple_choice') {
@@ -337,7 +340,7 @@ module.exports = async function handler(req, res) {
 
       const query = selectedIds.length
         ? await runQuery(
-          `SELECT id, category, question_en, question_no, answers_en, difficulty, question_type
+          `SELECT id, category, question_en, question_no, answers_en, difficulty, question_type, image_path, audio_path
            FROM quiz_questions
            WHERE id = ANY($1::int[])`,
           [selectedIds]
@@ -380,7 +383,7 @@ module.exports = async function handler(req, res) {
 
     const query = selectedIds.length
       ? await runQuery(
-        `SELECT id, category, question_en, question_no, answers_en, difficulty, question_type
+        `SELECT id, category, question_en, question_no, answers_en, difficulty, question_type, image_path, audio_path
          FROM quiz_questions
          WHERE id = ANY($1::int[])`,
         [selectedIds]

--- a/quiz-categories/index.html
+++ b/quiz-categories/index.html
@@ -219,6 +219,24 @@
       line-height:1;
     }
 
+    .question-media {
+      display:grid;
+      gap:10px;
+      margin:0 0 12px;
+    }
+
+    .question-media img {
+      display:block;
+      max-width:100%;
+      border-radius:8px;
+      border:1px solid var(--bd);
+      background:#111;
+    }
+
+    .question-media audio {
+      width:100%;
+    }
+
     .input-mode {
       display: inline-flex;
       border: 1px solid var(--bd);
@@ -352,6 +370,7 @@
         <span id="questionCategory" class="question-meta-chip"></span>
         <span id="questionDifficulty" class="question-meta-chip hidden"></span>
       </div>
+      <div id="questionMedia" class="question-media hidden" aria-live="polite"></div>
       <div class="input-mode" role="group" aria-label="Input mode toggle">
         <button id="textModeBtn" type="button" class="mode-btn is-active">Text</button>
         <button id="voiceModeBtn" type="button" class="mode-btn">Voice</button>
@@ -548,6 +567,7 @@
     const questionTitle = document.getElementById('questionTitle');
     const questionCategory = document.getElementById('questionCategory');
     const questionDifficulty = document.getElementById('questionDifficulty');
+    const questionMedia = document.getElementById('questionMedia');
     const answerForm = document.getElementById('answerForm');
     const textModeBtn = document.getElementById('textModeBtn');
     const voiceModeBtn = document.getElementById('voiceModeBtn');
@@ -707,6 +727,31 @@
       const match = (question?.options || [])
         .find((option) => Number(option.option_id) === Number(selectedOptionId));
       return match?.option_en || String(selectedOptionId || '');
+    }
+
+    function renderQuestionMedia(question) {
+      questionMedia.innerHTML = '';
+
+      const imageUrl = typeof question?.image_url === 'string' ? question.image_url.trim() : '';
+      const audioUrl = typeof question?.audio_url === 'string' ? question.audio_url.trim() : '';
+
+      if (imageUrl) {
+        const image = document.createElement('img');
+        image.src = imageUrl;
+        image.alt = 'Question image';
+        image.loading = 'lazy';
+        questionMedia.appendChild(image);
+      }
+
+      if (audioUrl) {
+        const audio = document.createElement('audio');
+        audio.src = audioUrl;
+        audio.controls = true;
+        audio.preload = 'none';
+        questionMedia.appendChild(audio);
+      }
+
+      questionMedia.classList.toggle('hidden', !questionMedia.childElementCount);
     }
 
     function renderVoiceStatus() {
@@ -1246,6 +1291,7 @@
         .replace('{total}', String(runtimeState.questions.length));
       questionTitle.textContent = question.prompt;
       questionCategory.textContent = uiCopy().category.replace('{category}', question.category || 'General');
+      renderQuestionMedia(question);
 
       const difficultyText = uiCopy().difficulty.replace('{difficulty}', getDifficultyLabel(question.difficulty));
       questionDifficulty.textContent = difficultyText;
@@ -1492,6 +1538,7 @@
       runtimeState.awaitingRetry = false;
       runtimeState.answeredQuestions = [];
       runtimeState.resultFilter = 'all';
+      renderQuestionMedia(null);
       showView('setup');
       renderCountState();
     });
@@ -1509,6 +1556,7 @@
       runtimeState.awaitingRetry = false;
       runtimeState.answeredQuestions = [];
       runtimeState.resultFilter = 'all';
+      renderQuestionMedia(null);
       showView('setup');
       renderCountState();
     });

--- a/quiz-quest/index.html
+++ b/quiz-quest/index.html
@@ -208,6 +208,24 @@
       margin-top: 14px;
     }
 
+    .question-media {
+      display: grid;
+      gap: 10px;
+      margin: 0 0 10px;
+    }
+
+    .question-media img {
+      display: block;
+      max-width: 100%;
+      border-radius: 8px;
+      border: 1px solid var(--bd);
+      background: #111;
+    }
+
+    .question-media audio {
+      width: 100%;
+    }
+
     .input-mode {
       display: inline-flex;
       border: 1px solid var(--bd);
@@ -288,6 +306,7 @@
       <p id="progressText" class="muted"></p>
       <p id="questionCategory" class="muted"></p>
       <h2 id="questionPrompt">Question</h2>
+      <div id="questionMedia" class="question-media hidden" aria-live="polite"></div>
       <div class="input-mode" role="group" aria-label="Input mode toggle">
         <button id="textModeBtn" type="button" class="mode-btn is-active">Text</button>
         <button id="voiceModeBtn" type="button" class="mode-btn">Voice</button>
@@ -472,6 +491,7 @@
     const progressText = document.getElementById('progressText');
     const questionCategory = document.getElementById('questionCategory');
     const questionPrompt = document.getElementById('questionPrompt');
+    const questionMedia = document.getElementById('questionMedia');
     const textModeBtn = document.getElementById('textModeBtn');
     const voiceModeBtn = document.getElementById('voiceModeBtn');
     const voiceStatus = document.getElementById('voiceStatus');
@@ -600,6 +620,31 @@
         label.append(input, text);
         mcOptions.appendChild(label);
       }
+    }
+
+    function renderQuestionMedia(question) {
+      questionMedia.innerHTML = '';
+
+      const imageUrl = typeof question?.image_url === 'string' ? question.image_url.trim() : '';
+      const audioUrl = typeof question?.audio_url === 'string' ? question.audio_url.trim() : '';
+
+      if (imageUrl) {
+        const image = document.createElement('img');
+        image.src = imageUrl;
+        image.alt = 'Question image';
+        image.loading = 'lazy';
+        questionMedia.appendChild(image);
+      }
+
+      if (audioUrl) {
+        const audio = document.createElement('audio');
+        audio.src = audioUrl;
+        audio.controls = true;
+        audio.preload = 'none';
+        questionMedia.appendChild(audio);
+      }
+
+      questionMedia.classList.toggle('hidden', !questionMedia.childElementCount);
     }
 
     function readGuestProgress() {
@@ -760,6 +805,7 @@
     function clearQuestionState() {
       state.currentQuestion = null;
       questionSection.classList.add('hidden');
+      renderQuestionMedia(null);
       questionStatus.textContent = '';
       questionStatus.className = 'status';
       answerReveal.classList.add('hidden');
@@ -1195,6 +1241,7 @@
           .replace('{total}', String(state.roundTarget));
         questionCategory.textContent = formatCategoryLine(question);
         questionPrompt.textContent = question.prompt;
+        renderQuestionMedia(question);
         answerInput.value = '';
         answerInput.placeholder = ui().placeholder;
         if (getQuestionType(question) === 'multiple_choice') {

--- a/random10/index.html
+++ b/random10/index.html
@@ -22,6 +22,9 @@
     .status.wrong { color:var(--bad); }
     input[type="text"] { width:100%; border:1px solid var(--bd); border-radius:8px; background:var(--bg); color:var(--txt); padding:12px; font-size:16px; }
     .progress { color:var(--muted); margin-bottom:12px; }
+    .question-media { display:grid; gap:10px; margin:0 0 12px; }
+    .question-media img { display:block; max-width:100%; border-radius:8px; border:1px solid var(--bd); background:#111; }
+    .question-media audio { width:100%; }
     .result-list { margin:10px 0 0; padding-left:18px; color:var(--muted); }
     .result-list.detailed { list-style:none; padding-left:0; display:grid; gap:10px; }
     .result-item { border:1px solid var(--bd); border-radius:10px; padding:10px; background:#181920; }
@@ -67,6 +70,7 @@
       </div>
       <h2 id="questionTitle">Question</h2>
       <p id="questionCategory" class="muted"></p>
+      <div id="questionMedia" class="question-media hidden" aria-live="polite"></div>
       <div class="input-mode" role="group" aria-label="Input mode toggle">
         <button id="textModeBtn" type="button" class="mode-btn is-active">Text</button>
         <button id="voiceModeBtn" type="button" class="mode-btn">Voice</button>
@@ -228,6 +232,7 @@
     const progressText = document.getElementById('progressText');
     const questionTitle = document.getElementById('questionTitle');
     const questionCategory = document.getElementById('questionCategory');
+    const questionMedia = document.getElementById('questionMedia');
     const textModeBtn = document.getElementById('textModeBtn');
     const voiceModeBtn = document.getElementById('voiceModeBtn');
     const voiceStatus = document.getElementById('voiceStatus');
@@ -692,8 +697,35 @@
         prompt: raw.prompt || raw.question || raw.question_en || raw.question_no || 'Missing question text',
         answers,
         question_type: raw.question_type === 'multiple_choice' ? 'multiple_choice' : 'text',
-        options: Array.isArray(raw.options) ? raw.options : []
+        options: Array.isArray(raw.options) ? raw.options : [],
+        image_url: typeof raw.image_url === 'string' && raw.image_url.trim() ? raw.image_url.trim() : null,
+        audio_url: typeof raw.audio_url === 'string' && raw.audio_url.trim() ? raw.audio_url.trim() : null
       };
+    }
+
+    function renderQuestionMedia(question) {
+      questionMedia.innerHTML = '';
+
+      const imageUrl = typeof question?.image_url === 'string' ? question.image_url.trim() : '';
+      const audioUrl = typeof question?.audio_url === 'string' ? question.audio_url.trim() : '';
+
+      if (imageUrl) {
+        const image = document.createElement('img');
+        image.src = imageUrl;
+        image.alt = 'Question image';
+        image.loading = 'lazy';
+        questionMedia.appendChild(image);
+      }
+
+      if (audioUrl) {
+        const audio = document.createElement('audio');
+        audio.src = audioUrl;
+        audio.controls = true;
+        audio.preload = 'none';
+        questionMedia.appendChild(audio);
+      }
+
+      questionMedia.classList.toggle('hidden', !questionMedia.childElementCount);
     }
 
     function getDifficultyLabel(difficulty) {
@@ -752,6 +784,7 @@
         .replace('{total}', String(state.questions.length));
       questionTitle.textContent = q.prompt;
       questionCategory.textContent = formatCategoryLine(q);
+      renderQuestionMedia(q);
       answerInput.value = '';
       if (getQuestionType(q) === 'multiple_choice') {
         answerInput.classList.add('hidden');
@@ -819,6 +852,7 @@
       statusText.textContent = '';
       answerReveal.classList.add('hidden');
       answerReveal.textContent = '';
+      renderQuestionMedia(null);
       state.pendingRevealAnswerEncoded = '';
       abortConfirmRow.classList.add('hidden');
       setStartLoading(false);


### PR DESCRIPTION
### Motivation

- Serve and render per-question media (images and audio) stored in the Supabase storage bucket so quiz questions can include illustrations and audio clips.

### Description

- Add `api/_lib/quiz-media.js` with `toQuizMediaUrl` that builds public Supabase storage URLs using `SUPABASE_URL` and safely encodes path segments.
- Extend quiz APIs (`api/quiz/quest.js` and `api/quiz/start.js`) to select `image_path` and `audio_path` from `quiz_questions` and include `image_url` and `audio_url` in mapped question objects using `toQuizMediaUrl`.
- Update client pages (`quiz-categories/index.html`, `quiz-quest/index.html`, `random10/index.html`) to include CSS for `.question-media` and add `renderQuestionMedia` functions to inject `<img>` and `<audio>` elements and show/hide the media container appropriately.

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1224bb61483338ce041e142d0cd1e)