### PR TITLE
Exclude seen/solved questions from quest selection and improve quiz media URL resolution

### DIFF
--- a/api/_lib/quiz-media.js
+++ b/api/_lib/quiz-media.js
@@ -1,4 +1,4 @@
-const QUIZ_MEDIA_BUCKET = 'quiz-media';
+const DEFAULT_QUIZ_MEDIA_BUCKET = (process.env.QUIZ_MEDIA_BUCKET || 'quiz-media').trim() || 'quiz-media';
 
 function getSupabaseBaseUrl() {
   const value = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL || '';
@@ -20,19 +20,51 @@ function normalizeStoragePath(path) {
     .replace(/\/{2,}/g, '/');
 }
 
-function toQuizMediaUrl(path) {
-  if (!path || typeof path !== 'string') return null;
-  const normalizedPath = normalizeStoragePath(path);
+function resolveBucketAndPath(rawPath) {
+  const normalizedPath = normalizeStoragePath(rawPath);
   if (!normalizedPath) return null;
 
-  if (/^https?:\/\//i.test(normalizedPath)) {
-    return normalizedPath;
+  const storagePublicPattern = /^(?:storage\/v1\/)?object\/public\/([^/]+)\/(.+)$/i;
+  const storagePublicMatch = normalizedPath.match(storagePublicPattern);
+  if (storagePublicMatch) {
+    return {
+      bucket: storagePublicMatch[1],
+      path: normalizeStoragePath(storagePublicMatch[2])
+    };
   }
+
+  if (normalizedPath.startsWith(`${DEFAULT_QUIZ_MEDIA_BUCKET}/`)) {
+    return {
+      bucket: DEFAULT_QUIZ_MEDIA_BUCKET,
+      path: normalizeStoragePath(normalizedPath.slice(DEFAULT_QUIZ_MEDIA_BUCKET.length + 1))
+    };
+  }
+
+  return {
+    bucket: DEFAULT_QUIZ_MEDIA_BUCKET,
+    path: normalizedPath
+  };
+}
+
+function toQuizMediaUrl(path) {
+  if (!path || typeof path !== 'string') return null;
+  const rawPath = String(path).trim();
+  if (!rawPath) return null;
+
+  if (/^https?:\/\//i.test(rawPath)) {
+    return rawPath;
+  }
+
+  const normalizedPath = normalizeStoragePath(rawPath);
+  if (!normalizedPath) return null;
+
+  const resolved = resolveBucketAndPath(normalizedPath);
+  if (!resolved || !resolved.bucket || !resolved.path) return null;
 
   const baseUrl = getSupabaseBaseUrl();
   if (!baseUrl) return null;
 
-  return `${baseUrl}/storage/v1/object/public/${QUIZ_MEDIA_BUCKET}/${encodeStoragePath(normalizedPath)}`;
+  return `${baseUrl}/storage/v1/object/public/${encodeURIComponent(resolved.bucket)}/${encodeStoragePath(resolved.path)}`;
 }
 
 module.exports = {

--- a/api/quiz/quest.js
+++ b/api/quiz/quest.js
@@ -133,6 +133,8 @@ function randomIndex(max) {
 }
 
 async function getNextQuestionBounds({ userId, categories, solvedQuestionIds }) {
+  const seenIds = normalizeSolvedQuestionIds(solvedQuestionIds);
+
   if (userId) {
     const result = await runQuery(
       `SELECT MIN(q.id)::int AS min_id, MAX(q.id)::int AS max_id
@@ -141,8 +143,9 @@ async function getNextQuestionBounds({ userId, categories, solvedQuestionIds }) 
          ON ua.question_id = q.id
         AND ua.user_id = $2
        WHERE q.category = ANY($1)
-         AND COALESCE(ua.is_correct, FALSE) = FALSE`,
-      [categories, userId]
+         AND COALESCE(ua.is_correct, FALSE) = FALSE
+         AND NOT (q.id = ANY($3::int[]))`,
+      [categories, userId, seenIds.length ? seenIds : [0]]
     );
 
     const row = result.rows[0] || {};
@@ -152,7 +155,7 @@ async function getNextQuestionBounds({ userId, categories, solvedQuestionIds }) 
     };
   }
 
-  const excludedIds = solvedQuestionIds.length ? solvedQuestionIds : [0];
+  const excludedIds = seenIds.length ? seenIds : [0];
   const result = await runQuery(
     `SELECT MIN(q.id)::int AS min_id, MAX(q.id)::int AS max_id
      FROM quiz_questions q
@@ -169,6 +172,8 @@ async function getNextQuestionBounds({ userId, categories, solvedQuestionIds }) 
 }
 
 async function getNextQuestionCandidateFromPivot({ userId, categories, solvedQuestionIds, pivotId }) {
+  const seenIds = normalizeSolvedQuestionIds(solvedQuestionIds);
+
   if (userId) {
     const result = await runQuery(
       `WITH preferred AS (
@@ -179,6 +184,7 @@ async function getNextQuestionCandidateFromPivot({ userId, categories, solvedQue
           AND ua.user_id = $2
          WHERE q.category = ANY($1)
            AND COALESCE(ua.is_correct, FALSE) = FALSE
+           AND NOT (q.id = ANY($4::int[]))
            AND q.id >= $3
          ORDER BY q.id ASC
          LIMIT 1
@@ -190,6 +196,7 @@ async function getNextQuestionCandidateFromPivot({ userId, categories, solvedQue
           AND ua.user_id = $2
          WHERE q.category = ANY($1)
            AND COALESCE(ua.is_correct, FALSE) = FALSE
+           AND NOT (q.id = ANY($4::int[]))
            AND q.id < $3
          ORDER BY q.id ASC
          LIMIT 1
@@ -198,13 +205,13 @@ async function getNextQuestionCandidateFromPivot({ userId, categories, solvedQue
        UNION ALL
        SELECT * FROM fallback
        LIMIT 1`,
-      [categories, userId, pivotId]
+      [categories, userId, pivotId, seenIds.length ? seenIds : [0]]
     );
 
     return result.rows[0] || null;
   }
 
-  const excludedIds = solvedQuestionIds.length ? solvedQuestionIds : [0];
+  const excludedIds = seenIds.length ? seenIds : [0];
   const result = await runQuery(
     `WITH preferred AS (
        SELECT q.id, q.category, q.question_en, q.question_no, q.answers_en, q.difficulty, q.question_type, q.image_path, q.audio_path
@@ -384,10 +391,16 @@ module.exports = async function handler(req, res) {
         return;
       }
 
+      const requestSeenIds = normalizeSolvedQuestionIds(body.seenQuestionIds);
+      const excludedQuestionIds = [...new Set([
+        ...guestProgress.solvedQuestionIds,
+        ...requestSeenIds
+      ])];
+
       const bounds = await getNextQuestionBounds({
         userId,
         categories,
-        solvedQuestionIds: guestProgress.solvedQuestionIds
+        solvedQuestionIds: excludedQuestionIds
       });
 
       if (!Number.isInteger(bounds.minId) || !Number.isInteger(bounds.maxId) || bounds.minId > bounds.maxId) {
@@ -407,7 +420,7 @@ module.exports = async function handler(req, res) {
         const row = await getNextQuestionCandidateFromPivot({
           userId,
           categories,
-          solvedQuestionIds: guestProgress.solvedQuestionIds,
+          solvedQuestionIds: excludedQuestionIds,
           pivotId
         });
 

--- a/quiz-quest/index.html
+++ b/quiz-quest/index.html
@@ -453,6 +453,7 @@
       guestProgress: readGuestProgress(),
       guestProgressToken: readGuestProgressToken(),
       pendingSolvedQuestionIds: [],
+      seenQuestionIds: [],
       roundTarget: 0,
       roundAnswered: 0,
       isQuestActive: false,
@@ -732,6 +733,10 @@
         if (!requestPayload.solvedQuestionIdDeltas) {
           requestPayload.solvedQuestionIds = getGuestSolvedQuestionIds();
         }
+      }
+
+      if (action === 'next' && state.seenQuestionIds.length) {
+        requestPayload.seenQuestionIds = [...new Set(state.seenQuestionIds)];
       }
 
       const response = await fetch('/api/quiz/quest', {
@@ -1233,6 +1238,9 @@
         }
 
         state.currentQuestion = question;
+        if (Number.isInteger(question.id) && question.id > 0 && !state.seenQuestionIds.includes(question.id)) {
+          state.seenQuestionIds.push(question.id);
+        }
         setupStatus.className = 'status';
         setupStatus.textContent = '';
         questionSection.classList.remove('hidden');
@@ -1306,6 +1314,7 @@
       const requested = Number(questionCountInput.value);
       state.roundTarget = Math.max(1, Math.min(Number.isInteger(requested) ? requested : 1, available));
       state.roundAnswered = 0;
+      state.seenQuestionIds = [];
       questionCountInput.value = String(state.roundTarget);
       setQuestActive(true);
 
@@ -1335,6 +1344,7 @@
       stopVoiceListening();
       clearQuestionState();
       setQuestActive(false);
+      state.seenQuestionIds = [];
       setupStatus.className = 'status';
       setupStatus.textContent = ui().abortDone;
       await refreshOverview();


### PR DESCRIPTION
### Motivation
- Prevent repeating questions during a quest by excluding questions the user/guest has already seen or solved. 
- Allow more robust handling of Supabase storage paths and public object URLs for quiz media. 
- Normalize and safely encode bucket and path components to avoid malformed storage URLs.

### Description
- Added `resolveBucketAndPath` and replaced `QUIZ_MEDIA_BUCKET` with `DEFAULT_QUIZ_MEDIA_BUCKET` in `api/_lib/quiz-media.js`, and updated `toQuizMediaUrl` to accept full `http(s)` URLs, parse `storage/v1/object/public` paths, normalize inputs, and encode bucket and path components using `encodeURIComponent` and `encodeStoragePath`.
- In `api/quiz/quest.js` the request/processing of solved/seen IDs was normalized and deduplicated using `normalizeSolvedQuestionIds`, and those IDs are now passed into the SQL queries to exclude seen/solved questions for both authenticated and guest flows (updated queries to accept a parameterized int array for exclusion).
- Client changes in `quiz-quest/index.html` add a `seenQuestionIds` state, send `seenQuestionIds` with `action: 'next'` requests, push question IDs when loading a question, and reset `seenQuestionIds` when starting or aborting a quest.

### Testing
- Ran the server test suite with `npm test` and linters with `npm run lint`, and both completed successfully. 
- Performed a client build check with `npm run build` to ensure the front-end changes compile, and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d16c54dccc8333a9c6f6ed14a77748)