### PR TITLE
Track seenQuestionIds to avoid duplicate questions and improve Supabase storage URL handling

### DIFF
--- a/api/_lib/quiz-media.js
+++ b/api/_lib/quiz-media.js
@@ -1,8 +1,22 @@
-const QUIZ_MEDIA_BUCKET = 'quiz-media';
+const DEFAULT_QUIZ_MEDIA_BUCKET = (process.env.QUIZ_MEDIA_BUCKET || 'quiz-media').trim() || 'quiz-media';
 
 function getSupabaseBaseUrl() {
-  const value = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL || '';
-  return value.trim().replace(/\/+$/, '');
+  const explicitValue = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL || '';
+  const explicitUrl = explicitValue.trim().replace(/\/+$/, '');
+  if (explicitUrl) return explicitUrl;
+
+  const dbUrl = String(process.env.SUPABASE_DB_URL || process.env.DATABASE_URL || '').trim();
+  if (!dbUrl) return '';
+
+  try {
+    const parsed = new URL(dbUrl);
+    const host = String(parsed.hostname || '').trim().toLowerCase();
+    const match = host.match(/^db\.([a-z0-9-]+)\.supabase\.co$/i);
+    if (!match) return '';
+    return `https://${match[1]}.supabase.co`;
+  } catch (error) {
+    return '';
+  }
 }
 
 function encodeStoragePath(path) {
@@ -20,19 +34,51 @@ function normalizeStoragePath(path) {
     .replace(/\/{2,}/g, '/');
 }
 
-function toQuizMediaUrl(path) {
-  if (!path || typeof path !== 'string') return null;
-  const normalizedPath = normalizeStoragePath(path);
+function resolveBucketAndPath(rawPath) {
+  const normalizedPath = normalizeStoragePath(rawPath);
   if (!normalizedPath) return null;
 
-  if (/^https?:\/\//i.test(normalizedPath)) {
-    return normalizedPath;
+  const storagePublicPattern = /^(?:storage\/v1\/)?object\/public\/([^/]+)\/(.+)$/i;
+  const storagePublicMatch = normalizedPath.match(storagePublicPattern);
+  if (storagePublicMatch) {
+    return {
+      bucket: storagePublicMatch[1],
+      path: normalizeStoragePath(storagePublicMatch[2])
+    };
   }
+
+  if (normalizedPath.startsWith(`${DEFAULT_QUIZ_MEDIA_BUCKET}/`)) {
+    return {
+      bucket: DEFAULT_QUIZ_MEDIA_BUCKET,
+      path: normalizeStoragePath(normalizedPath.slice(DEFAULT_QUIZ_MEDIA_BUCKET.length + 1))
+    };
+  }
+
+  return {
+    bucket: DEFAULT_QUIZ_MEDIA_BUCKET,
+    path: normalizedPath
+  };
+}
+
+function toQuizMediaUrl(path) {
+  if (!path || typeof path !== 'string') return null;
+  const rawPath = String(path).trim();
+  if (!rawPath) return null;
+
+  if (/^https?:\/\//i.test(rawPath)) {
+    return rawPath;
+  }
+
+  const normalizedPath = normalizeStoragePath(rawPath);
+  if (!normalizedPath) return null;
+
+  const resolved = resolveBucketAndPath(normalizedPath);
+  if (!resolved || !resolved.bucket || !resolved.path) return null;
 
   const baseUrl = getSupabaseBaseUrl();
   if (!baseUrl) return null;
 
-  return `${baseUrl}/storage/v1/object/public/${QUIZ_MEDIA_BUCKET}/${encodeStoragePath(normalizedPath)}`;
+  return `${baseUrl}/storage/v1/object/public/${encodeURIComponent(resolved.bucket)}/${encodeStoragePath(resolved.path)}`;
 }
 
 module.exports = {

--- a/api/quiz/quest.js
+++ b/api/quiz/quest.js
@@ -133,6 +133,8 @@ function randomIndex(max) {
 }
 
 async function getNextQuestionBounds({ userId, categories, solvedQuestionIds }) {
+  const seenIds = normalizeSolvedQuestionIds(solvedQuestionIds);
+
   if (userId) {
     const result = await runQuery(
       `SELECT MIN(q.id)::int AS min_id, MAX(q.id)::int AS max_id
@@ -141,8 +143,9 @@ async function getNextQuestionBounds({ userId, categories, solvedQuestionIds }) 
          ON ua.question_id = q.id
         AND ua.user_id = $2
        WHERE q.category = ANY($1)
-         AND COALESCE(ua.is_correct, FALSE) = FALSE`,
-      [categories, userId]
+         AND COALESCE(ua.is_correct, FALSE) = FALSE
+         AND NOT (q.id = ANY($3::int[]))`,
+      [categories, userId, seenIds.length ? seenIds : [0]]
     );
 
     const row = result.rows[0] || {};
@@ -152,7 +155,7 @@ async function getNextQuestionBounds({ userId, categories, solvedQuestionIds }) 
     };
   }
 
-  const excludedIds = solvedQuestionIds.length ? solvedQuestionIds : [0];
+  const excludedIds = seenIds.length ? seenIds : [0];
   const result = await runQuery(
     `SELECT MIN(q.id)::int AS min_id, MAX(q.id)::int AS max_id
      FROM quiz_questions q
@@ -169,6 +172,8 @@ async function getNextQuestionBounds({ userId, categories, solvedQuestionIds }) 
 }
 
 async function getNextQuestionCandidateFromPivot({ userId, categories, solvedQuestionIds, pivotId }) {
+  const seenIds = normalizeSolvedQuestionIds(solvedQuestionIds);
+
   if (userId) {
     const result = await runQuery(
       `WITH preferred AS (
@@ -179,6 +184,7 @@ async function getNextQuestionCandidateFromPivot({ userId, categories, solvedQue
           AND ua.user_id = $2
          WHERE q.category = ANY($1)
            AND COALESCE(ua.is_correct, FALSE) = FALSE
+           AND NOT (q.id = ANY($4::int[]))
            AND q.id >= $3
          ORDER BY q.id ASC
          LIMIT 1
@@ -190,6 +196,7 @@ async function getNextQuestionCandidateFromPivot({ userId, categories, solvedQue
           AND ua.user_id = $2
          WHERE q.category = ANY($1)
            AND COALESCE(ua.is_correct, FALSE) = FALSE
+           AND NOT (q.id = ANY($4::int[]))
            AND q.id < $3
          ORDER BY q.id ASC
          LIMIT 1
@@ -198,13 +205,13 @@ async function getNextQuestionCandidateFromPivot({ userId, categories, solvedQue
        UNION ALL
        SELECT * FROM fallback
        LIMIT 1`,
-      [categories, userId, pivotId]
+      [categories, userId, pivotId, seenIds.length ? seenIds : [0]]
     );
 
     return result.rows[0] || null;
   }
 
-  const excludedIds = solvedQuestionIds.length ? solvedQuestionIds : [0];
+  const excludedIds = seenIds.length ? seenIds : [0];
   const result = await runQuery(
     `WITH preferred AS (
        SELECT q.id, q.category, q.question_en, q.question_no, q.answers_en, q.difficulty, q.question_type, q.image_path, q.audio_path
@@ -384,10 +391,16 @@ module.exports = async function handler(req, res) {
         return;
       }
 
+      const requestSeenIds = normalizeSolvedQuestionIds(body.seenQuestionIds);
+      const excludedQuestionIds = [...new Set([
+        ...guestProgress.solvedQuestionIds,
+        ...requestSeenIds
+      ])];
+
       const bounds = await getNextQuestionBounds({
         userId,
         categories,
-        solvedQuestionIds: guestProgress.solvedQuestionIds
+        solvedQuestionIds: excludedQuestionIds
       });
 
       if (!Number.isInteger(bounds.minId) || !Number.isInteger(bounds.maxId) || bounds.minId > bounds.maxId) {
@@ -407,7 +420,7 @@ module.exports = async function handler(req, res) {
         const row = await getNextQuestionCandidateFromPivot({
           userId,
           categories,
-          solvedQuestionIds: guestProgress.solvedQuestionIds,
+          solvedQuestionIds: excludedQuestionIds,
           pivotId
         });
 

--- a/quiz-quest/index.html
+++ b/quiz-quest/index.html
@@ -453,6 +453,7 @@
       guestProgress: readGuestProgress(),
       guestProgressToken: readGuestProgressToken(),
       pendingSolvedQuestionIds: [],
+      seenQuestionIds: [],
       roundTarget: 0,
       roundAnswered: 0,
       isQuestActive: false,
@@ -732,6 +733,10 @@
         if (!requestPayload.solvedQuestionIdDeltas) {
           requestPayload.solvedQuestionIds = getGuestSolvedQuestionIds();
         }
+      }
+
+      if (action === 'next' && state.seenQuestionIds.length) {
+        requestPayload.seenQuestionIds = [...new Set(state.seenQuestionIds)];
       }
 
       const response = await fetch('/api/quiz/quest', {
@@ -1221,8 +1226,25 @@
       startQuestBtn.disabled = true;
 
       try {
-        const payload = await questApi('next', { categories });
-        const question = payload.question || null;
+        const maxAttempts = 6;
+        let question = null;
+
+        for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+          const payload = await questApi('next', { categories });
+          const candidate = payload.question || null;
+          if (!candidate) {
+            question = null;
+            break;
+          }
+
+          const candidateId = Number(candidate.id);
+          if (Number.isInteger(candidateId) && candidateId > 0 && state.seenQuestionIds.includes(candidateId)) {
+            continue;
+          }
+
+          question = candidate;
+          break;
+        }
 
         if (!question) {
           clearQuestionState();
@@ -1233,6 +1255,9 @@
         }
 
         state.currentQuestion = question;
+        if (Number.isInteger(question.id) && question.id > 0 && !state.seenQuestionIds.includes(question.id)) {
+          state.seenQuestionIds.push(question.id);
+        }
         setupStatus.className = 'status';
         setupStatus.textContent = '';
         questionSection.classList.remove('hidden');
@@ -1306,6 +1331,7 @@
       const requested = Number(questionCountInput.value);
       state.roundTarget = Math.max(1, Math.min(Number.isInteger(requested) ? requested : 1, available));
       state.roundAnswered = 0;
+      state.seenQuestionIds = [];
       questionCountInput.value = String(state.roundTarget);
       setQuestActive(true);
 
@@ -1335,6 +1361,7 @@
       stopVoiceListening();
       clearQuestionState();
       setQuestActive(false);
+      state.seenQuestionIds = [];
       setupStatus.className = 'status';
       setupStatus.textContent = ui().abortDone;
       await refreshOverview();


### PR DESCRIPTION
### Motivation

- Prevent the quiz from returning duplicate questions during a session/round by tracking and excluding already-seen question IDs on both client and server sides. 
- Make generation of public Supabase storage URLs more robust by deriving the base URL from multiple env vars and supporting various storage path formats.

### Description

- Added `DEFAULT_QUIZ_MEDIA_BUCKET`, improved `getSupabaseBaseUrl()` to derive the Supabase base URL from `SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_URL`, or by parsing `SUPABASE_DB_URL`/`DATABASE_URL`, and added `resolveBucketAndPath()` to extract bucket and path variants in `api/_lib/quiz-media.js` and updated `toQuizMediaUrl()` to support these cases.  
- Updated question-selection logic in `api/quiz/quest.js` to normalize and pass a combined set of excluded/seen question IDs into SQL queries (`getNextQuestionBounds` and `getNextQuestionCandidateFromPivot`) to avoid returning already-seen questions for both authenticated users and guests.  
- Client-side changes in `quiz-quest/index.html` to maintain `state.seenQuestionIds`, send `seenQuestionIds` with `next` requests, retry up to 6 times to avoid local duplicates, and clear/reset `seenQuestionIds` on new rounds or aborts.

### Testing

- Ran the project automated test suite via `npm test`, which completed successfully.  
- Performed automated API call/selection smoke checks for the `next` flow to verify that seen IDs are excluded and that media URL generation produces valid `storage/v1/object/public` URLs; the checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d16c54dccc8333a9c6f6ed14a77748)