### PR TITLE
Aktiver Pokémon-only quiz-flyt fra forsidens knapp

### DIFF
--- a/index.html
+++ b/index.html
@@ -178,7 +178,7 @@
       { href: '/random10/', title: 'Random 10 quiz', tooltip: { en: 'Quick 10-question mode', no: 'Rask modus med 10 spørsmål' } },
       { href: '/quiz-categories/', title: 'Quiz categories', tooltip: { en: 'Choose categories and play', no: 'Velg kategorier og spill' } },
       { href: '/quiz-quest/', title: 'Quiz quest', tooltip: { en: 'Progress by category with reset support', no: 'Fremgang per kategori med reset-støtte' } },
-      { href: '/pokemon-quiz/', title: 'Pokémon quiz', tooltip: { en: 'Pokémon mode (placeholder)', no: 'Pokémon-modus (placeholder)' } },
+      { href: '/quiz-categories/?onlyCategory=Pok%C3%A9mon', title: 'Pokémon quiz', tooltip: { en: 'Only Pokémon questions', no: 'Kun Pokémon-spørsmål' } },
     ];
 
     const I18N = {

--- a/pokemon-quiz/index.html
+++ b/pokemon-quiz/index.html
@@ -16,8 +16,8 @@
 <body>
   <main class="card">
     <h1>Pokémon quiz</h1>
-    <p>This is a placeholder page. We will build this quiz mode step by step.</p>
-    <a href="/">Back to sarcasm.games</a>
+    <p>Pokémon quiz is now available in Quiz categories with Pokémon preselected.</p>
+    <a href="/quiz-categories/?onlyCategory=Pok%C3%A9mon">Start Pokémon quiz</a>
   </main>
 
 

--- a/quiz-categories/index.html
+++ b/quiz-categories/index.html
@@ -553,6 +553,8 @@
     };
 
     const activeLang = readQuizLanguage();
+    const queryParams = new URLSearchParams(window.location.search);
+    const lockedCategoryName = (queryParams.get('onlyCategory') || '').trim();
     const categoryGrid = document.getElementById('categoryGrid');
     const selectAllBtn = document.getElementById('selectAllBtn');
     const deselectAllBtn = document.getElementById('deselectAllBtn');
@@ -633,6 +635,19 @@
 
     function uiCopy() {
       return copy[runtimeState.activeLang] || copy[fallbackLanguage];
+    }
+
+    function normalizeCategoryName(value) {
+      return String(value || '').trim().toLowerCase();
+    }
+
+    function hasLockedCategory() {
+      return Boolean(lockedCategoryName);
+    }
+
+    function isLockedCategory(name) {
+      if (!hasLockedCategory()) return false;
+      return normalizeCategoryName(name) === normalizeCategoryName(lockedCategoryName);
     }
 
     function encodeAnswerForReveal(answer) {
@@ -1160,10 +1175,14 @@
         return;
       }
 
-      selectAllBtn.disabled = false;
-      deselectAllBtn.disabled = false;
+      selectAllBtn.disabled = hasLockedCategory();
+      deselectAllBtn.disabled = hasLockedCategory();
 
       runtimeState.categories.forEach((category, index) => {
+        if (hasLockedCategory() && !isLockedCategory(category.name)) {
+          return;
+        }
+
         const wrapper = document.createElement('article');
         wrapper.className = 'cat';
         if (category.selected) {
@@ -1175,6 +1194,7 @@
         checkbox.type = 'checkbox';
         checkbox.checked = category.selected;
         checkbox.setAttribute('aria-label', `Select ${category.name}`);
+        checkbox.disabled = hasLockedCategory();
 
         checkbox.addEventListener('change', () => {
           runtimeState.categories[index].selected = checkbox.checked;
@@ -1399,8 +1419,16 @@
         runtimeState.categories = categories.map((category) => ({
           name: category.name,
           questionCount: Number(category.questionCount) || 0,
-          selected: false
+          selected: hasLockedCategory() ? isLockedCategory(category.name) : false
         }));
+
+        if (hasLockedCategory() && !runtimeState.categories.some((category) => category.selected)) {
+          runtimeState.categories = [];
+          statusEl.classList.add('error');
+          statusEl.textContent = `Could not find category "${lockedCategoryName}".`;
+          renderCategories();
+          return;
+        }
 
         statusEl.classList.remove('error');
         statusEl.textContent = uiCopy().loadedCategories
@@ -1568,9 +1596,12 @@
 
     function applyCopy() {
       const c = uiCopy();
-      document.title = c.title;
-      setupHeading.textContent = c.title;
-      setupLead.textContent = c.setupLead;
+      const pageTitle = hasLockedCategory() ? `${lockedCategoryName} quiz` : c.title;
+      document.title = pageTitle;
+      setupHeading.textContent = pageTitle;
+      setupLead.textContent = hasLockedCategory()
+        ? `Only ${lockedCategoryName} questions are shown in this mode.`
+        : c.setupLead;
       statusEl.textContent = c.loadingCategories;
       questionCountLabel.firstChild.textContent = `${c.questionCount} `;
       selectAllBtn.textContent = c.selectAll;


### PR DESCRIPTION
### Motivation
- Gjør at forsidens «Pokémon quiz»-knapp starter en quiz som bare viser Pokémon-spørsmål ved å deep-linke til quiz-kategoriene med en låst kategori.

### Description
- Endret forside `index.html` slik at Pokémon-kortet lenker til `/quiz-categories/?onlyCategory=Pok%C3%A9mon` i stedet for til placeholder-siden.
- Oppdatert `pokemon-quiz/index.html` for å peke brukeren til den nye Pokémon-låste kategoriflyten.
- Lagt til URL-parameter-håndtering i `quiz-categories/index.html` (leser `onlyCategory`) og tre hjelpefunksjoner `normalizeCategoryName`, `hasLockedCategory` og `isLockedCategory` for å støtte låst kategori-modus.
- I låst kategori-modus blir kun den matchende kategorien rendret og preselected, checkboxer og «select all / deselect all» deaktiveres, og siden får tilpasset tittel/lead; hvis kategorien ikke finnes vises en feilmelding.

### Testing
- Kjørte `git diff --check` som returnerte `OK`.
- Kjørte `npm run verify:main` som feilet med forventet resultat fordi skriptet krever branch `main` (test feilet på grunn av branch, ikke endringene).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d22e2ad67c8333960e773eb5171983)