### PR TITLE
Add i18n, daily rollover, chunked archive and state v2 to Daily Click

### DIFF
--- a/dailyclick/app.js
+++ b/dailyclick/app.js
@@ -1,178 +1,244 @@
-const STORAGE_KEY = "daily-click-state";
-const MAX_VISIBLE_BUTTONS = 30;
+import { getQuizLanguage } from '/lib/client/quiz-language.js';
+
+const STORAGE_KEY = 'daily-click-state-v2';
+const CHUNK_SIZE = 30;
+const MAX_DEBUG_LEVEL = 200;
 
 const BUTTON_COLORS = [
-  "linear-gradient(145deg, #ef4444, #b91c1c)",
-  "linear-gradient(145deg, #f97316, #c2410c)",
-  "linear-gradient(145deg, #f59e0b, #b45309)",
-  "linear-gradient(145deg, #10b981, #047857)",
-  "linear-gradient(145deg, #06b6d4, #0e7490)",
-  "linear-gradient(145deg, #3b82f6, #1d4ed8)",
-  "linear-gradient(145deg, #8b5cf6, #6d28d9)",
-  "linear-gradient(145deg, #ec4899, #be185d)",
+  'linear-gradient(145deg, #ef4444, #b91c1c)',
+  'linear-gradient(145deg, #f97316, #c2410c)',
+  'linear-gradient(145deg, #f59e0b, #b45309)',
+  'linear-gradient(145deg, #10b981, #047857)',
+  'linear-gradient(145deg, #06b6d4, #0e7490)',
+  'linear-gradient(145deg, #3b82f6, #1d4ed8)',
+  'linear-gradient(145deg, #8b5cf6, #6d28d9)',
+  'linear-gradient(145deg, #ec4899, #be185d)'
 ];
 
-function newBaseState() {
-  return { level: 1, clicks: [0], dayFinished: false, showArchive: false };
+const I18N = {
+  en: {
+    title: 'Daily Click Challenge',
+    reset: 'Reset progress',
+    debugAdvance: 'Debug: force next day',
+    debugStreak: 'Debug streak',
+    progressReset: 'Progress reset to day 1.',
+    invalidDebug: `Invalid value. Choose a number between 1 and ${MAX_DEBUG_LEVEL}.`,
+    debugSet: (day) => `Debug: set to day ${day}.`,
+    debugPrompt: `Set streak/day (1-${MAX_DEBUG_LEVEL}):`,
+    statusDone: (day) => `Day ${day} is complete. Come back tomorrow for the next day.`,
+    statusPlay: (day) => `Day ${day}: complete ${day} button${day > 1 ? 's' : ''}.`,
+    buttonTitle: (buttonNo, remaining) => `Button ${buttonNo}: ${remaining} remaining`,
+    buttonDone: (buttonNo) => `✨ BOOM! Button ${buttonNo} completed! ✨`,
+    buttonRemaining: (buttonNo, remaining) => `Button ${buttonNo}: ${remaining} left.`,
+    dayDone: (day) => `🎉 DAY ${day} COMPLETE! Return tomorrow! 🎉`,
+    rolloverWin: (day) => `New calendar day detected. Nice! You're now on day ${day}.`,
+    rolloverLose: 'New calendar day detected. Previous day was unfinished, back to day 1.',
+    archiveTitle: (n, from, to) => `Open archive ${n}: day buttons ${from}-${to}`
+  },
+  no: {
+    title: 'Daglig Klikk-utfordring',
+    reset: 'Nullstill fremgang',
+    debugAdvance: 'Debug: tving ny dag',
+    debugStreak: 'Debug streak',
+    progressReset: 'Fremgang nullstilt til dag 1.',
+    invalidDebug: `Ugyldig verdi. Velg et tall mellom 1 og ${MAX_DEBUG_LEVEL}.`,
+    debugSet: (day) => `Debug: satt til dag ${day}.`,
+    debugPrompt: `Sett streak/dag (1-${MAX_DEBUG_LEVEL}):`,
+    statusDone: (day) => `Dag ${day} er fullført. Kom tilbake i morgen for neste dag.`,
+    statusPlay: (day) => `Dag ${day}: fullfør ${day} knapp${day > 1 ? 'er' : ''}.`,
+    buttonTitle: (buttonNo, remaining) => `Knapp ${buttonNo}: ${remaining} igjen`,
+    buttonDone: (buttonNo) => `✨ BOOM! Knapp ${buttonNo} fullført! ✨`,
+    buttonRemaining: (buttonNo, remaining) => `Knapp ${buttonNo}: ${remaining} igjen.`,
+    dayDone: (day) => `🎉 DAG ${day} FULLFØRT! Kom tilbake i morgen! 🎉`,
+    rolloverWin: (day) => `Ny kalenderdag oppdaget. Nice! Du er nå på dag ${day}.`,
+    rolloverLose: 'Ny kalenderdag oppdaget. Forrige dag var ikke fullført, tilbake til dag 1.',
+    archiveTitle: (n, from, to) => `Åpne arkiv ${n}: dag-knapper ${from}-${to}`
+  }
+};
+
+function t(state) { return I18N[state.language] || I18N.en; }
+function getTodayStamp() { return new Date().toISOString().slice(0, 10); }
+
+function newBaseState(language) {
+  return { language, level: 1, clicks: [0], dayFinished: false, openArchiveGroup: null, lastDayStamp: getTodayStamp() };
 }
 
 function isFinished(state) {
   return Array.from({ length: state.level }, (_, i) => i + 1).every((required, i) => (state.clicks[i] ?? 0) >= required);
 }
 
-function hydrateState() {
+function hydrateState(language) {
   const raw = localStorage.getItem(STORAGE_KEY);
-  if (!raw) return newBaseState();
-
+  if (!raw) return newBaseState(language);
   try {
-    const state = JSON.parse(raw);
-    if (!state || !Number.isInteger(state.level) || state.level < 1 || !Array.isArray(state.clicks)) return newBaseState();
-    const level = state.level;
-    const clicks = state.clicks.slice(0, level);
+    const parsed = JSON.parse(raw);
+    if (!parsed || !Number.isInteger(parsed.level) || parsed.level < 1 || !Array.isArray(parsed.clicks)) return newBaseState(language);
+    const level = parsed.level;
+    const clicks = parsed.clicks.slice(0, level);
     while (clicks.length < level) clicks.push(0);
-    return { level, clicks, dayFinished: isFinished({ level, clicks }), showArchive: false };
+    return {
+      language,
+      level,
+      clicks,
+      dayFinished: isFinished({ level, clicks }),
+      openArchiveGroup: null,
+      lastDayStamp: typeof parsed.lastDayStamp === 'string' ? parsed.lastDayStamp : getTodayStamp()
+    };
   } catch {
-    return newBaseState();
+    return newBaseState(language);
   }
 }
 
 function saveState(state) {
-  localStorage.setItem(STORAGE_KEY, JSON.stringify({ level: state.level, clicks: state.clicks }));
+  localStorage.setItem(STORAGE_KEY, JSON.stringify({ level: state.level, clicks: state.clicks, lastDayStamp: state.lastDayStamp }));
 }
+function setMessage(text) { document.getElementById('message').textContent = text; }
+function buttonColor(index) { return BUTTON_COLORS[index % BUTTON_COLORS.length]; }
 
-function setMessage(text) {
-  document.getElementById("message").textContent = text;
-}
-
-function buttonColor(index) {
-  return BUTTON_COLORS[index % BUTTON_COLORS.length];
-}
-
-function startNewDay(state) {
+function startNewCalendarDay(state) {
+  const texts = t(state);
   if (isFinished(state)) {
-    const nextLevel = state.level + 1;
-    state.level = nextLevel;
-    state.clicks = Array.from({ length: nextLevel }, () => 0);
-    setMessage(`Ny dag startet! Nå er du på dag ${nextLevel}.`);
+    state.level += 1;
+    state.clicks = Array.from({ length: state.level }, () => 0);
+    setMessage(texts.rolloverWin(state.level));
   } else {
     state.level = 1;
     state.clicks = [0];
-    setMessage("Du fullførte ikke alt. Tilbake til dag 1.");
+    setMessage(texts.rolloverLose);
   }
   state.dayFinished = false;
-  state.showArchive = false;
-  saveState(state);
-  render(state);
+  state.openArchiveGroup = null;
+}
+
+function applyDailyRollover(state) {
+  const today = getTodayStamp();
+  if (state.lastDayStamp !== today) {
+    startNewCalendarDay(state);
+    state.lastDayStamp = today;
+    saveState(state);
+  }
 }
 
 function createGameButton(state, index) {
+  const texts = t(state);
   const requiredClicks = index + 1;
   const currentClicks = state.clicks[index] ?? 0;
   const remaining = Math.max(requiredClicks - currentClicks, 0);
-
-  const button = document.createElement("button");
-  button.className = "daily-button";
+  const button = document.createElement('button');
+  button.className = 'daily-button';
   button.style.background = buttonColor(index);
   button.disabled = state.dayFinished || remaining === 0;
   button.textContent = `${remaining}`;
-  button.title = `Button ${requiredClicks}: ${remaining} remaining`;
-
-  button.addEventListener("click", () => {
+  button.title = texts.buttonTitle(requiredClicks, remaining);
+  button.addEventListener('click', () => {
     if (state.dayFinished || (state.clicks[index] ?? 0) >= requiredClicks) return;
-
     state.clicks[index] += 1;
-    const remainingAfterClick = Math.max(requiredClicks - state.clicks[index], 0);
-
-    if (remainingAfterClick === 0) {
-      setMessage(`✨ BOOM! Knapp ${requiredClicks} fullført! ✨`);
-    } else {
-      setMessage(`Knapp ${requiredClicks}: ${remainingAfterClick} igjen.`);
-    }
-
+    const left = Math.max(requiredClicks - state.clicks[index], 0);
+    setMessage(left === 0 ? texts.buttonDone(requiredClicks) : texts.buttonRemaining(requiredClicks, left));
     state.dayFinished = isFinished(state);
-    if (state.dayFinished) {
-      setMessage(`🎉 DAG ${state.level} FULLFØRT! Trykk "Start ny dag"! 🎉`);
-    }
+    if (state.dayFinished) setMessage(texts.dayDone(state.level));
+    saveState(state);
+    render(state);
+  });
+  return button;
+}
 
+function renderArchiveStars(state, container) {
+  const fullGroupsBeforeCurrent = Math.floor((state.level - 1) / CHUNK_SIZE);
+  if (fullGroupsBeforeCurrent <= 0) return;
+
+  const starsRow = document.createElement('div');
+  starsRow.className = 'stars-row';
+
+  for (let group = 0; group < fullGroupsBeforeCurrent; group += 1) {
+    const from = group * CHUNK_SIZE + 1;
+    const to = (group + 1) * CHUNK_SIZE;
+    const star = document.createElement('button');
+    star.className = `archive-button ${state.openArchiveGroup === group ? 'active' : ''}`;
+    star.textContent = `⭐${group + 1}`;
+    star.title = t(state).archiveTitle(group + 1, from, to);
+    star.addEventListener('click', () => {
+      state.openArchiveGroup = state.openArchiveGroup === group ? null : group;
+      render(state);
+    });
+    starsRow.appendChild(star);
+  }
+
+  container.appendChild(starsRow);
+
+  if (state.openArchiveGroup !== null) {
+    const archiveGrid = document.createElement('div');
+    archiveGrid.className = 'archive-grid';
+    const start = state.openArchiveGroup * CHUNK_SIZE;
+    const end = start + CHUNK_SIZE;
+    for (let i = start; i < end; i += 1) {
+      archiveGrid.appendChild(createGameButton(state, i));
+    }
+    container.appendChild(archiveGrid);
+  }
+}
+
+function render(state) {
+  const texts = t(state);
+  document.documentElement.lang = state.language === 'no' ? 'no' : 'en';
+  document.getElementById('title').textContent = texts.title;
+  document.getElementById('reset').textContent = texts.reset;
+  document.getElementById('new-day').textContent = texts.debugAdvance;
+  document.getElementById('debug-streak').textContent = texts.debugStreak;
+
+  state.dayFinished = isFinished(state);
+  document.getElementById('status').textContent = state.dayFinished ? texts.statusDone(state.level) : texts.statusPlay(state.level);
+
+  const buttonsContainer = document.getElementById('buttons');
+  buttonsContainer.innerHTML = '';
+
+  const currentChunkStart = Math.floor((state.level - 1) / CHUNK_SIZE) * CHUNK_SIZE;
+  const currentChunkEnd = state.level;
+  const currentGrid = document.createElement('div');
+  currentGrid.className = 'current-grid';
+  for (let i = currentChunkStart; i < currentChunkEnd; i += 1) {
+    currentGrid.appendChild(createGameButton(state, i));
+  }
+
+  renderArchiveStars(state, buttonsContainer);
+  buttonsContainer.appendChild(currentGrid);
+}
+
+function main() {
+  const language = getQuizLanguage();
+  const state = hydrateState(language);
+  applyDailyRollover(state);
+  saveState(state);
+  render(state);
+
+  document.getElementById('reset').addEventListener('click', () => {
+    const fresh = newBaseState(state.language);
+    saveState(fresh);
+    setMessage(t(state).progressReset);
+    render(fresh);
+  });
+
+  document.getElementById('new-day').addEventListener('click', () => {
+    startNewCalendarDay(state);
+    state.lastDayStamp = getTodayStamp();
     saveState(state);
     render(state);
   });
 
-  return button;
-}
-
-function render(state) {
-  const status = document.getElementById("status");
-  const buttonsContainer = document.getElementById("buttons");
-
-  state.dayFinished = isFinished(state);
-  status.textContent = state.dayFinished
-    ? `Dag ${state.level} er fullført. Start ny dag for å fortsette.`
-    : `Dag ${state.level}: fullfør ${state.level} knapp${state.level > 1 ? "er" : ""}.`;
-
-  buttonsContainer.innerHTML = "";
-
-  if (state.level <= MAX_VISIBLE_BUTTONS) {
-    for (let i = 0; i < state.level; i += 1) {
-      buttonsContainer.appendChild(createGameButton(state, i));
-    }
-  } else {
-    const topRow = document.createElement("div");
-    topRow.className = "overflow-row";
-
-    const archiveButton = document.createElement("button");
-    archiveButton.className = "archive-button";
-    archiveButton.textContent = "⭐";
-    archiveButton.title = "Vis/skjul de første 30 knappene";
-    archiveButton.addEventListener("click", () => {
-      state.showArchive = !state.showArchive;
-      render(state);
-    });
-
-    topRow.appendChild(archiveButton);
-    topRow.appendChild(createGameButton(state, state.level - 1));
-    buttonsContainer.appendChild(topRow);
-
-    if (state.showArchive) {
-      const archiveGrid = document.createElement("div");
-      archiveGrid.className = "archive-grid";
-      for (let i = 0; i < MAX_VISIBLE_BUTTONS; i += 1) {
-        archiveGrid.appendChild(createGameButton(state, i));
-      }
-      buttonsContainer.appendChild(archiveGrid);
-    }
-  }
-}
-
-function main() {
-  const state = hydrateState();
-  saveState(state);
-  render(state);
-
-  document.getElementById("reset").addEventListener("click", () => {
-    const freshState = newBaseState();
-    saveState(freshState);
-    setMessage("Progress reset til dag 1.");
-    render(freshState);
-  });
-
-  document.getElementById("new-day").addEventListener("click", () => startNewDay(state));
-
-  document.getElementById("debug-streak").addEventListener("click", () => {
-    const input = prompt("Sett streak/dag (1-200):", `${state.level}`);
+  document.getElementById('debug-streak').addEventListener('click', () => {
+    const input = prompt(t(state).debugPrompt, `${state.level}`);
     if (!input) return;
     const wanted = Number.parseInt(input, 10);
-    if (!Number.isInteger(wanted) || wanted < 1 || wanted > 200) {
-      setMessage("Ugyldig verdi. Velg et tall mellom 1 og 200.");
+    if (!Number.isInteger(wanted) || wanted < 1 || wanted > MAX_DEBUG_LEVEL) {
+      setMessage(t(state).invalidDebug);
       return;
     }
-
     state.level = wanted;
     state.clicks = Array.from({ length: wanted }, () => 0);
     state.dayFinished = false;
-    state.showArchive = false;
+    state.openArchiveGroup = null;
     saveState(state);
-    setMessage(`Debug: satt til dag ${wanted}.`);
+    setMessage(t(state).debugSet(wanted));
     render(state);
   });
 }

--- a/dailyclick/index.html
+++ b/dailyclick/index.html
@@ -9,7 +9,7 @@
   <body>
     <main class="container">
       <header class="header">
-        <h1>Daily Click Challenge</h1>
+        <h1 id="title">Daily Click Challenge</h1>
         <p id="status" class="status"></p>
       </header>
 
@@ -24,6 +24,6 @@
       </div>
     </main>
 
-    <script src="app.js"></script>
+    <script type="module" src="app.js"></script>
   </body>
 </html>

--- a/dailyclick/styles.css
+++ b/dailyclick/styles.css
@@ -3,11 +3,8 @@
   color: #1f2937;
   background: radial-gradient(circle at top, #f8fafc, #e5e7eb);
 }
-
 * { box-sizing: border-box; }
-
 body { margin: 0; min-height: 100vh; }
-
 .container {
   min-height: 100vh;
   width: min(1200px, 100vw);
@@ -17,40 +14,43 @@ body { margin: 0; min-height: 100vh; }
   gap: 0.75rem;
   padding: clamp(0.75rem, 1.5vw, 1.25rem);
 }
-
 .header {
   background: white;
   border-radius: 14px;
   padding: 0.75rem 1rem;
   box-shadow: 0 8px 20px rgba(0, 0, 0, 0.08);
 }
-
 h1 { margin: 0 0 0.25rem; font-size: clamp(1.1rem, 2.4vw, 1.6rem); }
 .status { margin: 0; font-size: 0.95rem; }
-
 .button-grid { display: grid; gap: 0.75rem; align-content: start; }
-
+.current-grid, .archive-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(54px, 78px));
+  gap: 0.55rem;
+}
+.stars-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
 .daily-button {
   border: none;
   width: 100%;
+  max-width: 78px;
   aspect-ratio: 1 / 1;
   border-radius: 999px;
   color: white;
-  font-size: clamp(0.9rem, 1.7vw, 1.15rem);
+  font-size: 0.95rem;
   font-weight: 700;
   cursor: pointer;
   transition: transform 0.12s ease, filter 0.2s ease, opacity 0.2s ease, box-shadow 0.25s ease;
   box-shadow: 0 8px 14px rgba(0, 0, 0, 0.18);
 }
-
 .daily-button:hover:enabled { filter: brightness(1.08); }
 .daily-button:active:enabled { transform: translateY(2px) scale(0.98); }
 .daily-button:disabled { opacity: 0.45; cursor: not-allowed; }
-
 .message { margin: 0; min-height: 1.5rem; font-weight: 700; color: #065f46; }
-
 .controls { display: flex; flex-wrap: wrap; gap: 0.5rem; }
-
 .control-button {
   border: 1px solid #9ca3af;
   background: white;
@@ -60,33 +60,20 @@ h1 { margin: 0 0 0.25rem; font-size: clamp(1.1rem, 2.4vw, 1.6rem); }
   cursor: pointer;
   font-size: 0.82rem;
 }
-
 .debug-button { border-color: #7c3aed; color: #5b21b6; }
-
-.overflow-row {
-  display: grid;
-  grid-template-columns: minmax(60px, 90px) minmax(80px, 140px);
-  gap: 0.75rem;
-  align-items: start;
-}
-
 .archive-button {
   border: none;
   border-radius: 999px;
-  aspect-ratio: 1 / 1;
-  font-size: 1.4rem;
+  min-width: 62px;
+  height: 40px;
+  padding: 0 0.6rem;
+  font-size: 0.95rem;
   cursor: pointer;
   background: linear-gradient(145deg, #111827, #374151);
   color: white;
   box-shadow: 0 8px 14px rgba(0, 0, 0, 0.22);
 }
-
-.archive-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(54px, 1fr));
-  gap: 0.55rem;
-}
-
-@media (min-height: 540px) {
-  .button-grid { grid-template-columns: repeat(auto-fit, minmax(70px, 1fr)); }
+.archive-button.active {
+  outline: 2px solid #f59e0b;
+  outline-offset: 2px;
 }


### PR DESCRIPTION
### Motivation

- Modernize the daily-click app with language support and a more robust daily rollover to avoid losing progress across calendar days.
- Support large streaks by chunking older buttons into an archive and persisting additional state metadata to enable rollover and archive UI.

### Description

- Introduce i18n with English and Norwegian translations via `I18N` and a helper `t(state)`, and set the document language and UI texts in `render`.
- Bump storage format to `daily-click-state-v2` and extend state with `language`, `openArchiveGroup`, and `lastDayStamp`, persisted by `saveState` and restored by `hydrateState`.
- Add calendar rollover logic with `getTodayStamp`, `applyDailyRollover`, and `startNewCalendarDay` to advance or reset the streak when a new day is detected, and wire the manual new-day button to this flow.
- Replace the single large visible button grid with chunking using `CHUNK_SIZE` (30), render a stars-based archive navigator via `renderArchiveStars`, and update button creation and messages to use localized strings and improved UX.
- Miscellaneous refactors and improvements: migrate to ES module (`<script type="module">`), import `getQuizLanguage`, rename/clean helper functions, introduce `MAX_DEBUG_LEVEL`, and update CSS for `.current-grid`, `.archive-grid`, and `.stars-row` layouts.

### Testing

- No automated tests were added or run for this change.
- Manual smoke checks performed via the browser (local) to verify UI renders, language selection, rollover behavior, archive toggling, debug streak input and reset button worked as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15e41c78dc83339843dc215718528f)