### PR TITLE
Refactor dailyclick: i18n, archive chunks, celebration UI, and daily rollover

### DIFF
--- a/dailyclick/app.js
+++ b/dailyclick/app.js
@@ -1,97 +1,192 @@
-const STORAGE_KEY = "daily-click-state";
-const MAX_VISIBLE_BUTTONS = 30;
+import { getQuizLanguage } from '/lib/client/quiz-language.js';
+
+const STORAGE_KEY = 'daily-click-state-v2';
+const CHUNK_SIZE = 30;
+const MAX_DEBUG_LEVEL = 200;
+const MILESTONE_STEP = 10;
+const APP_BUILD_ID = 'dailyclick-2026-05-26-c';
 
 const BUTTON_COLORS = [
-  "linear-gradient(145deg, #ef4444, #b91c1c)",
-  "linear-gradient(145deg, #f97316, #c2410c)",
-  "linear-gradient(145deg, #f59e0b, #b45309)",
-  "linear-gradient(145deg, #10b981, #047857)",
-  "linear-gradient(145deg, #06b6d4, #0e7490)",
-  "linear-gradient(145deg, #3b82f6, #1d4ed8)",
-  "linear-gradient(145deg, #8b5cf6, #6d28d9)",
-  "linear-gradient(145deg, #ec4899, #be185d)",
+  'linear-gradient(145deg, #ef4444, #b91c1c)',
+  'linear-gradient(145deg, #f97316, #c2410c)',
+  'linear-gradient(145deg, #f59e0b, #b45309)',
+  'linear-gradient(145deg, #10b981, #047857)',
+  'linear-gradient(145deg, #06b6d4, #0e7490)',
+  'linear-gradient(145deg, #3b82f6, #1d4ed8)',
+  'linear-gradient(145deg, #8b5cf6, #6d28d9)',
+  'linear-gradient(145deg, #ec4899, #be185d)'
 ];
 
-function newBaseState() {
-  return { level: 1, clicks: [0], dayFinished: false, showArchive: false };
+const I18N = {
+  en: {
+    title: 'Daily Click Challenge', reset: 'Reset progress', debugAdvance: 'Debug: force next day', debugStreak: 'Debug streak',
+    progressReset: 'Progress reset to day 1.', invalidDebug: `Invalid value. Choose a number between 1 and ${MAX_DEBUG_LEVEL}.`,
+    debugSet: (day) => `Debug: set to day ${day}.`, debugPrompt: `Set streak/day (1-${MAX_DEBUG_LEVEL}):`,
+    statusDone: (day) => `Day ${day} is complete. Come back tomorrow for the next day.`,
+    statusPlay: (day) => `Day ${day}: complete ${day} button${day > 1 ? 's' : ''}.`,
+    buttonTitle: (buttonNo, remaining) => `Button ${buttonNo}: ${remaining} remaining`,
+    buttonDone: (buttonNo) => `✨ BOOM! Button ${buttonNo} completed! ✨`,
+    buttonRemaining: (buttonNo, remaining) => `Button ${buttonNo}: ${remaining} left.`,
+    dayDone: (day) => `🎉 DAY ${day} COMPLETE! Return tomorrow! 🎉`,
+    rolloverWin: (day) => `New calendar day detected. Nice! You're now on day ${day}.`,
+    rolloverLose: 'New calendar day detected. Previous day was unfinished, back to day 1.',
+    archiveTitle: (n, from, to) => `Open archive ${n}: day buttons ${from}-${to}`,
+    archiveDone: (n) => `Archive ${n} complete`,
+    archiveCompleted: (n) => `✅ Archive ${n} completed!`,
+    archiveNudge: 'Archive opened. Other buttons are hidden while viewing this star.',
+    celebrationMilestoneTitle: (day) => `🏆 DAY ${day} MASTERED!`,
+    celebrationMilestoneSubtitle: 'You are unstoppable. Legendary consistency!',
+    celebrationDayTitle: (day) => `🔥 Day ${day} complete!`,
+    celebrationDaySubtitle: 'You crushed this challenge. Come back tomorrow!'
+  },
+  no: {
+    title: 'Daglig Klikk-utfordring', reset: 'Nullstill fremgang', debugAdvance: 'Debug: tving ny dag', debugStreak: 'Debug streak',
+    progressReset: 'Fremgang nullstilt til dag 1.', invalidDebug: `Ugyldig verdi. Velg et tall mellom 1 og ${MAX_DEBUG_LEVEL}.`,
+    debugSet: (day) => `Debug: satt til dag ${day}.`, debugPrompt: `Sett streak/dag (1-${MAX_DEBUG_LEVEL}):`,
+    statusDone: (day) => `Dag ${day} er fullført. Kom tilbake i morgen for neste dag.`,
+    statusPlay: (day) => `Dag ${day}: fullfør ${day} knapp${day > 1 ? 'er' : ''}.`,
+    buttonTitle: (buttonNo, remaining) => `Knapp ${buttonNo}: ${remaining} igjen`,
+    buttonDone: (buttonNo) => `✨ BOOM! Knapp ${buttonNo} fullført! ✨`,
+    buttonRemaining: (buttonNo, remaining) => `Knapp ${buttonNo}: ${remaining} igjen.`,
+    dayDone: (day) => `🎉 DAG ${day} FULLFØRT! Kom tilbake i morgen! 🎉`,
+    rolloverWin: (day) => `Ny kalenderdag oppdaget. Nice! Du er nå på dag ${day}.`,
+    rolloverLose: 'Ny kalenderdag oppdaget. Forrige dag var ikke fullført, tilbake til dag 1.',
+    archiveTitle: (n, from, to) => `Åpne arkiv ${n}: dag-knapper ${from}-${to}`,
+    archiveDone: (n) => `Arkiv ${n} fullført`,
+    archiveCompleted: (n) => `✅ Arkiv ${n} fullført!`,
+    archiveNudge: 'Arkiv åpnet. Andre knapper skjules mens denne stjernen vises.',
+    celebrationMilestoneTitle: (day) => `🏆 DAG ${day} MESTRET!`,
+    celebrationMilestoneSubtitle: 'Helt rått! Du er i verdensklasse!',
+    celebrationDayTitle: (day) => `🔥 Dag ${day} fullført!`,
+    celebrationDaySubtitle: 'Du knuste utfordringen. Kom tilbake i morgen!'
+  }
+};
+
+const CELEBRATION_TIMEOUT_MS = 2400;
+let celebrationTimer = null;
+
+function t(state) { return I18N[state.language] || I18N.en; }
+function getTodayStamp() { return new Date().toISOString().slice(0, 10); }
+function isFinished(state) { return Array.from({ length: state.level }, (_, i) => i + 1).every((required, i) => (state.clicks[i] ?? 0) >= required); }
+function buttonColor(index) { return BUTTON_COLORS[index % BUTTON_COLORS.length]; }
+function updateMessage(text) { document.getElementById('message').textContent = text; }
+
+function newBaseState(language) {
+  return { language, level: 1, clicks: [0], dayFinished: false, openArchiveGroup: null, lastDayStamp: getTodayStamp() };
 }
 
-function isFinished(state) {
-  return Array.from({ length: state.level }, (_, i) => i + 1).every((required, i) => (state.clicks[i] ?? 0) >= required);
-}
-
-function hydrateState() {
+function hydrateState(language) {
   const raw = localStorage.getItem(STORAGE_KEY);
-  if (!raw) return newBaseState();
-
+  if (!raw) return newBaseState(language);
   try {
-    const state = JSON.parse(raw);
-    if (!state || !Number.isInteger(state.level) || state.level < 1 || !Array.isArray(state.clicks)) return newBaseState();
-    const level = state.level;
-    const clicks = state.clicks.slice(0, level);
+    const parsed = JSON.parse(raw);
+    if (!parsed || !Number.isInteger(parsed.level) || parsed.level < 1 || !Array.isArray(parsed.clicks)) return newBaseState(language);
+    const level = parsed.level;
+    const clicks = parsed.clicks.slice(0, level);
     while (clicks.length < level) clicks.push(0);
-    return { level, clicks, dayFinished: isFinished({ level, clicks }), showArchive: false };
-  } catch {
-    return newBaseState();
+    return { language, level, clicks, dayFinished: isFinished({ level, clicks }), openArchiveGroup: null, lastDayStamp: typeof parsed.lastDayStamp === 'string' ? parsed.lastDayStamp : getTodayStamp() };
+  } catch { return newBaseState(language); }
+}
+
+function saveState(state) { localStorage.setItem(STORAGE_KEY, JSON.stringify({ level: state.level, clicks: state.clicks, lastDayStamp: state.lastDayStamp })); }
+
+function isArchiveGroupComplete(state, group) {
+  const start = group * CHUNK_SIZE;
+  const end = start + CHUNK_SIZE;
+  for (let i = start; i < end; i += 1) {
+    const needed = i + 1;
+    if ((state.clicks[i] ?? 0) < needed) return false;
+  }
+  return true;
+}
+
+function showCelebration(title, subtitle) {
+  const wrap = document.getElementById('celebration');
+  const titleEl = document.getElementById('celebration-title');
+  const subEl = document.getElementById('celebration-subtitle');
+  const layer = document.getElementById('confetti-layer');
+
+  titleEl.textContent = title;
+  subEl.textContent = subtitle;
+  layer.innerHTML = '';
+
+  const colors = ['#f43f5e', '#f59e0b', '#22c55e', '#06b6d4', '#3b82f6', '#a855f7'];
+  for (let i = 0; i < 90; i += 1) {
+    const piece = document.createElement('span');
+    piece.className = 'confetti-piece';
+    piece.style.left = `${Math.random() * 100}%`;
+    piece.style.background = colors[i % colors.length];
+    piece.style.animationDuration = `${2 + Math.random() * 1.4}s`;
+    piece.style.animationDelay = `${Math.random() * 0.35}s`;
+    layer.appendChild(piece);
+  }
+
+  wrap.classList.add('show');
+  if (celebrationTimer) clearTimeout(celebrationTimer);
+  celebrationTimer = setTimeout(() => { wrap.classList.remove('show'); }, CELEBRATION_TIMEOUT_MS);
+}
+
+function maybeCelebrateDay(state) {
+  const texts = t(state);
+  if (state.level % MILESTONE_STEP === 0) {
+    showCelebration(texts.celebrationMilestoneTitle(state.level), texts.celebrationMilestoneSubtitle);
+  } else {
+    showCelebration(texts.celebrationDayTitle(state.level), texts.celebrationDaySubtitle);
   }
 }
 
-function saveState(state) {
-  localStorage.setItem(STORAGE_KEY, JSON.stringify({ level: state.level, clicks: state.clicks }));
-}
-
-function setMessage(text) {
-  document.getElementById("message").textContent = text;
-}
-
-function buttonColor(index) {
-  return BUTTON_COLORS[index % BUTTON_COLORS.length];
-}
-
-function startNewDay(state) {
+function startNewCalendarDay(state) {
+  const texts = t(state);
   if (isFinished(state)) {
-    const nextLevel = state.level + 1;
-    state.level = nextLevel;
-    state.clicks = Array.from({ length: nextLevel }, () => 0);
-    setMessage(`Ny dag startet! Nå er du på dag ${nextLevel}.`);
+    state.level += 1;
+    state.clicks = Array.from({ length: state.level }, () => 0);
+    updateMessage(texts.rolloverWin(state.level));
   } else {
     state.level = 1;
     state.clicks = [0];
-    setMessage("Du fullførte ikke alt. Tilbake til dag 1.");
+    updateMessage(texts.rolloverLose);
   }
   state.dayFinished = false;
-  state.showArchive = false;
-  saveState(state);
-  render(state);
+  state.openArchiveGroup = null;
+}
+
+function applyDailyRollover(state) {
+  const today = getTodayStamp();
+  if (state.lastDayStamp !== today) {
+    startNewCalendarDay(state);
+    state.lastDayStamp = today;
+    saveState(state);
+  }
 }
 
 function createGameButton(state, index) {
+  const texts = t(state);
   const requiredClicks = index + 1;
   const currentClicks = state.clicks[index] ?? 0;
   const remaining = Math.max(requiredClicks - currentClicks, 0);
 
-  const button = document.createElement("button");
-  button.className = "daily-button";
+  const button = document.createElement('button');
+  button.className = 'daily-button';
   button.style.background = buttonColor(index);
   button.disabled = state.dayFinished || remaining === 0;
   button.textContent = `${remaining}`;
-  button.title = `Button ${requiredClicks}: ${remaining} remaining`;
+  button.title = texts.buttonTitle(requiredClicks, remaining);
 
-  button.addEventListener("click", () => {
+  button.addEventListener('click', () => {
     if (state.dayFinished || (state.clicks[index] ?? 0) >= requiredClicks) return;
-
     state.clicks[index] += 1;
-    const remainingAfterClick = Math.max(requiredClicks - state.clicks[index], 0);
+    const left = Math.max(requiredClicks - state.clicks[index], 0);
+    updateMessage(left === 0 ? texts.buttonDone(requiredClicks) : texts.buttonRemaining(requiredClicks, left));
 
-    if (remainingAfterClick === 0) {
-      setMessage(`✨ BOOM! Knapp ${requiredClicks} fullført! ✨`);
-    } else {
-      setMessage(`Knapp ${requiredClicks}: ${remainingAfterClick} igjen.`);
+    if (state.openArchiveGroup !== null && isArchiveGroupComplete(state, state.openArchiveGroup)) {
+      updateMessage(texts.archiveCompleted(state.openArchiveGroup + 1));
+      state.openArchiveGroup = null;
     }
 
     state.dayFinished = isFinished(state);
     if (state.dayFinished) {
-      setMessage(`🎉 DAG ${state.level} FULLFØRT! Trykk "Start ny dag"! 🎉`);
+      updateMessage(texts.dayDone(state.level));
+      maybeCelebrateDay(state);
     }
 
     saveState(state);
@@ -101,78 +196,104 @@ function createGameButton(state, index) {
   return button;
 }
 
-function render(state) {
-  const status = document.getElementById("status");
-  const buttonsContainer = document.getElementById("buttons");
+function renderArchiveStars(state, container) {
+  const fullGroupsBeforeCurrent = Math.floor((state.level - 1) / CHUNK_SIZE);
+  if (fullGroupsBeforeCurrent <= 0) return;
 
-  state.dayFinished = isFinished(state);
-  status.textContent = state.dayFinished
-    ? `Dag ${state.level} er fullført. Start ny dag for å fortsette.`
-    : `Dag ${state.level}: fullfør ${state.level} knapp${state.level > 1 ? "er" : ""}.`;
+  const starsRow = document.createElement('div');
+  starsRow.className = 'stars-row';
 
-  buttonsContainer.innerHTML = "";
-
-  if (state.level <= MAX_VISIBLE_BUTTONS) {
-    for (let i = 0; i < state.level; i += 1) {
-      buttonsContainer.appendChild(createGameButton(state, i));
-    }
-  } else {
-    const topRow = document.createElement("div");
-    topRow.className = "overflow-row";
-
-    const archiveButton = document.createElement("button");
-    archiveButton.className = "archive-button";
-    archiveButton.textContent = "⭐";
-    archiveButton.title = "Vis/skjul de første 30 knappene";
-    archiveButton.addEventListener("click", () => {
-      state.showArchive = !state.showArchive;
+  for (let group = 0; group < fullGroupsBeforeCurrent; group += 1) {
+    const from = group * CHUNK_SIZE + 1;
+    const to = (group + 1) * CHUNK_SIZE;
+    const star = document.createElement('button');
+    const isOpen = state.openArchiveGroup === group;
+    const isDone = isArchiveGroupComplete(state, group);
+    star.className = `archive-button${isOpen ? ' active' : ''}${isDone ? ' done' : ''}`;
+    star.textContent = isDone ? `✅⭐${group + 1}` : `⭐${group + 1}`;
+    star.title = isDone ? t(state).archiveDone(group + 1) : t(state).archiveTitle(group + 1, from, to);
+    star.addEventListener('click', () => {
+      state.openArchiveGroup = isOpen ? null : group;
+      if (state.openArchiveGroup !== null) updateMessage(t(state).archiveNudge);
       render(state);
     });
+    starsRow.appendChild(star);
+  }
 
-    topRow.appendChild(archiveButton);
-    topRow.appendChild(createGameButton(state, state.level - 1));
-    buttonsContainer.appendChild(topRow);
+  container.appendChild(starsRow);
 
-    if (state.showArchive) {
-      const archiveGrid = document.createElement("div");
-      archiveGrid.className = "archive-grid";
-      for (let i = 0; i < MAX_VISIBLE_BUTTONS; i += 1) {
-        archiveGrid.appendChild(createGameButton(state, i));
-      }
-      buttonsContainer.appendChild(archiveGrid);
-    }
+  if (state.openArchiveGroup !== null) {
+    const archiveGrid = document.createElement('div');
+    archiveGrid.className = 'archive-grid';
+    const start = state.openArchiveGroup * CHUNK_SIZE;
+    const end = start + CHUNK_SIZE;
+    for (let i = start; i < end; i += 1) archiveGrid.appendChild(createGameButton(state, i));
+    container.appendChild(archiveGrid);
+  }
+}
+
+function render(state) {
+  const texts = t(state);
+  document.documentElement.lang = state.language === 'no' ? 'no' : 'en';
+  document.getElementById('title').textContent = texts.title;
+  document.getElementById('reset').textContent = texts.reset;
+  document.getElementById('new-day').textContent = texts.debugAdvance;
+  document.getElementById('debug-streak').textContent = texts.debugStreak;
+
+  state.dayFinished = isFinished(state);
+  document.getElementById('status').textContent = state.dayFinished ? texts.statusDone(state.level) : texts.statusPlay(state.level);
+
+  const buttonsContainer = document.getElementById('buttons');
+  buttonsContainer.innerHTML = '';
+
+  renderArchiveStars(state, buttonsContainer);
+
+  if (state.openArchiveGroup === null) {
+    const currentChunkStart = Math.floor((state.level - 1) / CHUNK_SIZE) * CHUNK_SIZE;
+    const currentChunkEnd = state.level;
+    const currentGrid = document.createElement('div');
+    currentGrid.className = 'current-grid';
+    for (let i = currentChunkStart; i < currentChunkEnd; i += 1) currentGrid.appendChild(createGameButton(state, i));
+    buttonsContainer.appendChild(currentGrid);
   }
 }
 
 function main() {
-  const state = hydrateState();
+  console.info('[dailyclick] build', APP_BUILD_ID);
+  const language = getQuizLanguage();
+  const state = hydrateState(language);
+  applyDailyRollover(state);
   saveState(state);
   render(state);
 
-  document.getElementById("reset").addEventListener("click", () => {
-    const freshState = newBaseState();
-    saveState(freshState);
-    setMessage("Progress reset til dag 1.");
-    render(freshState);
+  document.getElementById('reset').addEventListener('click', () => {
+    const fresh = newBaseState(state.language);
+    saveState(fresh);
+    updateMessage(t(state).progressReset);
+    render(fresh);
   });
 
-  document.getElementById("new-day").addEventListener("click", () => startNewDay(state));
+  document.getElementById('new-day').addEventListener('click', () => {
+    startNewCalendarDay(state);
+    state.lastDayStamp = getTodayStamp();
+    saveState(state);
+    render(state);
+  });
 
-  document.getElementById("debug-streak").addEventListener("click", () => {
-    const input = prompt("Sett streak/dag (1-200):", `${state.level}`);
+  document.getElementById('debug-streak').addEventListener('click', () => {
+    const input = prompt(t(state).debugPrompt, `${state.level}`);
     if (!input) return;
     const wanted = Number.parseInt(input, 10);
-    if (!Number.isInteger(wanted) || wanted < 1 || wanted > 200) {
-      setMessage("Ugyldig verdi. Velg et tall mellom 1 og 200.");
+    if (!Number.isInteger(wanted) || wanted < 1 || wanted > MAX_DEBUG_LEVEL) {
+      updateMessage(t(state).invalidDebug);
       return;
     }
-
     state.level = wanted;
     state.clicks = Array.from({ length: wanted }, () => 0);
     state.dayFinished = false;
-    state.showArchive = false;
+    state.openArchiveGroup = null;
     saveState(state);
-    setMessage(`Debug: satt til dag ${wanted}.`);
+    updateMessage(t(state).debugSet(wanted));
     render(state);
   });
 }

--- a/dailyclick/index.html
+++ b/dailyclick/index.html
@@ -9,7 +9,7 @@
   <body>
     <main class="container">
       <header class="header">
-        <h1>Daily Click Challenge</h1>
+        <h1 id="title">Daily Click Challenge</h1>
         <p id="status" class="status"></p>
       </header>
 
@@ -24,6 +24,14 @@
       </div>
     </main>
 
-    <script src="app.js"></script>
+    <div id="celebration" class="celebration" aria-live="assertive" aria-atomic="true">
+      <div class="celebration-content">
+        <p id="celebration-title" class="celebration-title"></p>
+        <p id="celebration-subtitle" class="celebration-subtitle"></p>
+      </div>
+      <div id="confetti-layer" class="confetti-layer" aria-hidden="true"></div>
+    </div>
+
+    <script type="module" src="app.js?v=20260526b"></script>
   </body>
 </html>

--- a/dailyclick/styles.css
+++ b/dailyclick/styles.css
@@ -3,11 +3,8 @@
   color: #1f2937;
   background: radial-gradient(circle at top, #f8fafc, #e5e7eb);
 }
-
 * { box-sizing: border-box; }
-
 body { margin: 0; min-height: 100vh; }
-
 .container {
   min-height: 100vh;
   width: min(1200px, 100vw);
@@ -17,76 +14,55 @@ body { margin: 0; min-height: 100vh; }
   gap: 0.75rem;
   padding: clamp(0.75rem, 1.5vw, 1.25rem);
 }
-
-.header {
-  background: white;
-  border-radius: 14px;
-  padding: 0.75rem 1rem;
-  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.08);
-}
-
-h1 { margin: 0 0 0.25rem; font-size: clamp(1.1rem, 2.4vw, 1.6rem); }
-.status { margin: 0; font-size: 0.95rem; }
-
-.button-grid { display: grid; gap: 0.75rem; align-content: start; }
-
-.daily-button {
-  border: none;
-  width: 100%;
-  aspect-ratio: 1 / 1;
-  border-radius: 999px;
-  color: white;
-  font-size: clamp(0.9rem, 1.7vw, 1.15rem);
-  font-weight: 700;
-  cursor: pointer;
-  transition: transform 0.12s ease, filter 0.2s ease, opacity 0.2s ease, box-shadow 0.25s ease;
-  box-shadow: 0 8px 14px rgba(0, 0, 0, 0.18);
-}
-
+.header { background: white; border-radius: 14px; padding: 0.75rem 1rem; box-shadow: 0 8px 20px rgba(0,0,0,.08); }
+h1 { margin: 0 0 .25rem; font-size: clamp(1.1rem, 2.4vw, 1.6rem); }
+.status { margin: 0; font-size: .95rem; }
+.button-grid { display: grid; gap: .75rem; align-content: start; }
+.current-grid, .archive-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(54px, 78px)); gap: .55rem; }
+.stars-row { display: flex; flex-wrap: wrap; gap: .5rem; }
+.daily-button { border:none; width:100%; max-width:78px; aspect-ratio:1/1; border-radius:999px; color:#fff; font-size:.95rem; font-weight:700; cursor:pointer; transition: transform .12s ease, filter .2s ease, opacity .2s ease, box-shadow .25s ease; box-shadow:0 8px 14px rgba(0,0,0,.18); }
 .daily-button:hover:enabled { filter: brightness(1.08); }
 .daily-button:active:enabled { transform: translateY(2px) scale(0.98); }
-.daily-button:disabled { opacity: 0.45; cursor: not-allowed; }
+.daily-button:disabled { opacity: .45; cursor: not-allowed; }
+.message { margin:0; min-height:1.5rem; font-weight:700; color:#065f46; }
+.controls { display:flex; flex-wrap:wrap; gap:.5rem; }
+.control-button { border:1px solid #9ca3af; background:#fff; color:#374151; padding:.45rem .7rem; border-radius:10px; cursor:pointer; font-size:.82rem; }
+.debug-button { border-color:#7c3aed; color:#5b21b6; }
+.archive-button { border:none; border-radius:999px; min-width:70px; height:40px; padding:0 .6rem; font-size:.95rem; cursor:pointer; background:linear-gradient(145deg,#111827,#374151); color:#fff; box-shadow:0 8px 14px rgba(0,0,0,.22); }
+.archive-button.active { outline:2px solid #f59e0b; outline-offset:2px; }
+.archive-button.done { background: linear-gradient(145deg, #15803d, #065f46); }
 
-.message { margin: 0; min-height: 1.5rem; font-weight: 700; color: #065f46; }
-
-.controls { display: flex; flex-wrap: wrap; gap: 0.5rem; }
-
-.control-button {
-  border: 1px solid #9ca3af;
-  background: white;
-  color: #374151;
-  padding: 0.45rem 0.7rem;
-  border-radius: 10px;
-  cursor: pointer;
-  font-size: 0.82rem;
+.celebration {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 50;
 }
-
-.debug-button { border-color: #7c3aed; color: #5b21b6; }
-
-.overflow-row {
-  display: grid;
-  grid-template-columns: minmax(60px, 90px) minmax(80px, 140px);
-  gap: 0.75rem;
-  align-items: start;
+.celebration.show { opacity: 1; }
+.celebration-content {
+  text-align: center;
+  padding: 1rem 1.25rem;
+  background: rgba(17, 24, 39, 0.82);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 14px;
+  color: #fff;
+  max-width: min(92vw, 700px);
+  animation: pop-in .35s ease;
 }
-
-.archive-button {
-  border: none;
-  border-radius: 999px;
-  aspect-ratio: 1 / 1;
-  font-size: 1.4rem;
-  cursor: pointer;
-  background: linear-gradient(145deg, #111827, #374151);
-  color: white;
-  box-shadow: 0 8px 14px rgba(0, 0, 0, 0.22);
+.celebration-title { margin: 0; font-size: clamp(1.2rem, 4vw, 2.4rem); font-weight: 800; letter-spacing: .03em; text-shadow: 0 0 12px rgba(245, 158, 11, .75); }
+.celebration-subtitle { margin: .4rem 0 0; font-size: clamp(.9rem, 2vw, 1.25rem); color: #fde68a; }
+.confetti-layer { position:absolute; inset:0; overflow:hidden; }
+.confetti-piece {
+  position: absolute;
+  top: -20px;
+  width: 10px;
+  height: 16px;
+  border-radius: 2px;
+  animation: fall linear forwards;
 }
-
-.archive-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(54px, 1fr));
-  gap: 0.55rem;
-}
-
-@media (min-height: 540px) {
-  .button-grid { grid-template-columns: repeat(auto-fit, minmax(70px, 1fr)); }
-}
+@keyframes fall { to { transform: translateY(110vh) rotate(900deg); opacity: .9; } }
+@keyframes pop-in { from { transform: scale(.88); opacity: 0; } to { transform: scale(1); opacity: 1; } }


### PR DESCRIPTION
### Motivation
- Modernize the app to support language selection, better archive handling for large day counts, a celebration UI, and reliable daily rollover tracking.
- Reduce legacy state edge-cases by versioning storage and persisting a day stamp to handle calendar rollovers.

### Description
- Introduces `I18N` with English and Norwegian texts and uses `getQuizLanguage()` via `import` to hydrate the UI language and set `document.documentElement.lang`.
- Bumps storage key to `daily-click-state-v2` and persists `lastDayStamp` to implement calendar rollover via `applyDailyRollover()` and `startNewCalendarDay()` that advance/reset `level` correctly.
- Adds archive/chunk support using `CHUNK_SIZE = 30` with archive star buttons, `isArchiveGroupComplete()` and `renderArchiveStars()` to view previous groups of buttons; switches UI to show current chunk by default.
- Adds celebratory overlay and confetti (`showCelebration()`, `maybeCelebrateDay()`), increases debug limit with `MAX_DEBUG_LEVEL`, and centralizes messaging via `t(state)` and `updateMessage()`.
- Updates `index.html` to add `id` attributes for dynamic text, the celebration markup, and loads `app.js` as a module with a query version; styles updated in `styles.css` for grids, archive buttons, and celebration visuals.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15e41c78dc83339843dc215718528f)