### PR TITLE
Expand quiz difficulty scale to five levels

### DIFF
--- a/api/admin/insert-quiz.js
+++ b/api/admin/insert-quiz.js
@@ -8,7 +8,7 @@ function readString(value) {
 
 function normalizeDifficulty(value) {
   const parsed = Number(value);
-  if (!Number.isInteger(parsed) || parsed < 1 || parsed > 3) return null;
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > 5) return null;
   return parsed;
 }
 
@@ -93,7 +93,7 @@ module.exports = async function handler(req, res) {
 
     const normalizedEntries = entries.map(normalizeEntry);
     if (normalizedEntries.some((entry) => entry === null)) {
-      res.status(400).json({ error: 'Each entry requires category, question_en, question_no, answers[] and difficulty (1-3)' });
+      res.status(400).json({ error: 'Each entry requires category, question_en, question_no, answers[] and difficulty (1-5)' });
       return;
     }
 

--- a/api/quiz/start.js
+++ b/api/quiz/start.js
@@ -154,7 +154,7 @@ function normalizeDifficultyFilter(value) {
 
   const normalized = rawValues
     .map((entry) => Number(entry))
-    .filter((entry) => Number.isInteger(entry) && entry >= 1 && entry <= 3);
+    .filter((entry) => Number.isInteger(entry) && entry >= 1 && entry <= 5);
 
   return [...new Set(normalized)];
 }

--- a/docs/quiz-api-contract.md
+++ b/docs/quiz-api-contract.md
@@ -14,6 +14,18 @@ This document reflects the API behavior implemented in:
 - Text-answer matching is delegated to `lib/server/quiz-answer-evaluator.js`.
 - Multiple-choice correctness is evaluated via `quiz_question_options`.
 
+### Difficulty scale
+
+| Value | English | Norwegian |
+| --- | --- | --- |
+| `1` | Easy | Lett |
+| `2` | Medium | Medium |
+| `3` | Somewhat hard | Litt vanskelig |
+| `4` | Hard | Vanskelig |
+| `5` | Extreme | Ekstrem |
+
+Difficulty filters accept unique integer values from `1` through `5`. Values outside that range are ignored.
+
 ## Question object shape (as returned by `/start` and `/quest` today)
 
 ```json
@@ -52,7 +64,7 @@ Used by batch modes (`random10`, `categories`).
   "lang": "en | no",
   "count": 10,
   "categories": ["General", "History"],
-  "difficulty": [1, 2, 3]
+  "difficulty": [1, 2, 3, 4, 5]
 }
 ```
 
@@ -62,7 +74,7 @@ Used by batch modes (`random10`, `categories`).
 {
   "mode": "random10",
   "count": 10,
-  "difficulty": [1, 2, 3],
+  "difficulty": [1, 2, 3, 4, 5],
   "questions": []
 }
 ```

--- a/insertquiz/index.html
+++ b/insertquiz/index.html
@@ -60,9 +60,11 @@
         <div>
           <label for="difficulty">Difficulty</label>
           <select id="difficulty">
-            <option value="1">1</option>
-            <option value="2">2</option>
-            <option value="3">3</option>
+            <option value="1">1 — Easy</option>
+            <option value="2">2 — Medium</option>
+            <option value="3">3 — Somewhat hard</option>
+            <option value="4">4 — Hard</option>
+            <option value="5">5 — Extreme</option>
           </select>
         </div>
         <div class="full">
@@ -194,8 +196,8 @@
         return { error: 'Please fill out all fields before adding to queue. Add multiple answers with |.' };
       }
 
-      if (!Number.isInteger(difficulty) || difficulty < 1 || difficulty > 3) {
-        return { error: 'Difficulty must be 1, 2 or 3.' };
+      if (!Number.isInteger(difficulty) || difficulty < 1 || difficulty > 5) {
+        return { error: 'Difficulty must be an integer from 1 to 5.' };
       }
 
       return {

--- a/quiz-categories/index.html
+++ b/quiz-categories/index.html
@@ -457,7 +457,9 @@
         metaLine: '{category} • {difficulty}',
         difficultyEasy: 'Easy',
         difficultyMedium: 'Medium',
+        difficultySomewhatHard: 'Somewhat hard',
         difficultyHard: 'Hard',
+        difficultyExtreme: 'Extreme',
         difficultyUnknown: 'Unknown',
         summary: 'You got {correct} / {total} correct.',
         loadedCategories: 'Loaded {categories} categories and {questions} total questions.',
@@ -523,8 +525,10 @@
         difficulty: 'Vanskelighetsgrad: {difficulty}',
         metaLine: '{category} • {difficulty}',
         difficultyEasy: 'Lett',
-        difficultyMedium: 'Middels',
+        difficultyMedium: 'Medium',
+        difficultySomewhatHard: 'Litt vanskelig',
         difficultyHard: 'Vanskelig',
+        difficultyExtreme: 'Ekstrem',
         difficultyUnknown: 'Ukjent',
         summary: 'Du fikk {correct} / {total} riktige.',
         loadedCategories: 'Lastet {categories} kategorier og {questions} spørsmål totalt.',
@@ -1133,7 +1137,9 @@
 
       if (difficulty === 1) return c.difficultyEasy;
       if (difficulty === 2) return c.difficultyMedium;
-      if (difficulty === 3) return c.difficultyHard;
+      if (difficulty === 3) return c.difficultySomewhatHard;
+      if (difficulty === 4) return c.difficultyHard;
+      if (difficulty === 5) return c.difficultyExtreme;
       return c.difficultyUnknown;
     }
 

--- a/quiz-quest/index.html
+++ b/quiz-quest/index.html
@@ -379,7 +379,9 @@
         noCategories: 'No categories available.',
         difficultyEasy: 'Easy',
         difficultyMedium: 'Medium',
+        difficultySomewhatHard: 'Somewhat hard',
         difficultyHard: 'Hard',
+        difficultyExtreme: 'Extreme',
         inputModeText: 'Text',
         inputModeVoice: 'Voice',
         voiceListening: '🎙️ Listening…',
@@ -431,8 +433,10 @@
         placeholder: 'Skriv svaret ditt',
         noCategories: 'Ingen kategorier tilgjengelig.',
         difficultyEasy: 'Lett',
-        difficultyMedium: 'Middels',
+        difficultyMedium: 'Medium',
+        difficultySomewhatHard: 'Litt vanskelig',
         difficultyHard: 'Vanskelig',
+        difficultyExtreme: 'Ekstrem',
         inputModeText: 'Tekst',
         inputModeVoice: 'Stemmen',
         voiceListening: '🎙️ Lytter…',
@@ -563,7 +567,9 @@
       const parsedDifficulty = Number(difficulty);
       if (parsedDifficulty === 1) return ui().difficultyEasy;
       if (parsedDifficulty === 2) return ui().difficultyMedium;
-      if (parsedDifficulty === 3) return ui().difficultyHard;
+      if (parsedDifficulty === 3) return ui().difficultySomewhatHard;
+      if (parsedDifficulty === 4) return ui().difficultyHard;
+      if (parsedDifficulty === 5) return ui().difficultyExtreme;
       return '';
     }
 

--- a/random10/index.html
+++ b/random10/index.html
@@ -144,7 +144,9 @@
         category: 'Category: {category}',
         difficultyEasy: 'Easy',
         difficultyMedium: 'Medium',
+        difficultySomewhatHard: 'Somewhat hard',
         difficultyHard: 'Hard',
+        difficultyExtreme: 'Extreme',
         answerPrefix: 'Answer: {answer}',
         fetchError: 'Could not load questions right now.',
         notEnoughQuestions: 'Not enough questions available.',
@@ -197,8 +199,10 @@
         progress: 'Spørsmål {current} av {total}',
         category: 'Kategori: {category}',
         difficultyEasy: 'Lett',
-        difficultyMedium: 'Middels',
+        difficultyMedium: 'Medium',
+        difficultySomewhatHard: 'Litt vanskelig',
         difficultyHard: 'Vanskelig',
+        difficultyExtreme: 'Ekstrem',
         answerPrefix: 'Fasit: {answer}',
         fetchError: 'Kunne ikke laste spørsmål nå.',
         notEnoughQuestions: 'Ikke nok spørsmål tilgjengelig.',
@@ -688,7 +692,7 @@
         : [raw.answer, raw.answer_en, raw.answer_no].filter(Boolean);
 
       const parsedDifficulty = Number(raw.difficulty);
-      const difficulty = [1, 2, 3].includes(parsedDifficulty) ? parsedDifficulty : null;
+      const difficulty = [1, 2, 3, 4, 5].includes(parsedDifficulty) ? parsedDifficulty : null;
 
       return {
         id: raw.id || `api-${idx}`,
@@ -733,7 +737,9 @@
 
       if (difficulty === 1) return c.difficultyEasy;
       if (difficulty === 2) return c.difficultyMedium;
-      if (difficulty === 3) return c.difficultyHard;
+      if (difficulty === 3) return c.difficultySomewhatHard;
+      if (difficulty === 4) return c.difficultyHard;
+      if (difficulty === 5) return c.difficultyExtreme;
 
       return '';
     }


### PR DESCRIPTION
### Motivation
- Supabase-basert quiz-data brukte tidligere bare nivåene 1–3, men datatabellen og ønsket UX krever en skala 1–5 med tydelige engelske og norske etiketter.
- Klientvisning, filtrering og admin-inndata må være konsistente slik at nivå 4–5 kan lagres, velges og filtreres korrekt.
- Dokumentasjonen måtte oppdateres for å beskrive den nye tospråklige vanskelighetsskalaen og gyldige filterverdier.

### Description
- Utvidet API-validering i `api/admin/insert-quiz.js` for å akseptere difficulty 1–5 og oppdatert feilmeldingstekst til `(1-5)`. 
- Endret filter-normalisering i `api/quiz/start.js` for å tillate og filtrere på integer-verdier `1` til `5`.
- Oppdatert klientene `random10`, `quiz-quest` og `quiz-categories` med nye engelske og norske etiketter (`difficultySomewhatHard`/`Litt vanskelig`, `difficultyExtreme`/`Ekstrem`) og justert mapping slik at `3 → Somewhat hard`, `4 → Hard`, `5 → Extreme`.
- Oppdatert admininnsettings-UI `insertquiz/index.html` med en 1–5 `select` (visningsetiketter inkludert) og klientvalidering som krever «integer from 1 to 5». 
- Dokumentasjonen `docs/quiz-api-contract.md` fikk en ny «Difficulty scale»-seksjon med tabell for verdier 1–5 og oppdaterte eksempler som viser `difficulty: [1,2,3,4,5]`.

### Testing
- Kjørte `node --check api/admin/insert-quiz.js` og `node --check api/quiz/start.js` for syntakskontroll; begge besto.
- Ekstraherte inline JavaScript fra de endrede HTML-filene og kjørt `node --check` på dem for å sikre gyldig klientkode; kontrollene besto.
- Kjørte et programmatisk verifiseringsskript som bekreftet alle fem engelske og norske etiketter og at mappingene for nivå 1–5 finnes i klientene; verifiseringen besto.
- Kjørte `git diff --check` for å fange whitespace/syntaksproblemer; sjekken besto.
- Laget en Playwright-skjermdump av oppdatert admininnsettingsside for visuell verifikasjon (lagret som `/tmp/insertquiz-difficulty-1-5.png`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a290b688cd483339e06b5ddb156ba9a)