### PR TITLE
Update insert-quiz to require fact_key, support text & multiple-choice, and insert options transactionally

### DIFF
--- a/api/_lib/db.js
+++ b/api/_lib/db.js
@@ -146,6 +146,31 @@ function sanitizeUsernameCandidate(value) {
   return sanitized || null;
 }
 
+async function runTransaction(callback) {
+  if (typeof callback !== 'function') {
+    throw new TypeError('runTransaction requires a callback');
+  }
+
+  const pool = getPool();
+  const client = await pool.connect();
+
+  try {
+    await client.query('BEGIN');
+    const result = await callback(client);
+    await client.query('COMMIT');
+    return result;
+  } catch (error) {
+    try {
+      await client.query('ROLLBACK');
+    } catch (rollbackError) {
+      console.error('[db] Transaction rollback failed', serializeDbError(rollbackError));
+    }
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
 async function runQuery(text, params = []) {
   const pool = getPool();
   const startedAtMs = nowInMs();
@@ -364,6 +389,7 @@ async function listProfiles({ country = null, username = null, email = null } = 
 
 module.exports = {
   runQuery,
+  runTransaction,
   normalizeEmail,
   normalizeUsername,
   normalizeCountry,

--- a/api/admin/insert-quiz.js
+++ b/api/admin/insert-quiz.js
@@ -1,9 +1,24 @@
 const { requireSession } = require('../_lib/auth');
-const { runQuery } = require('../_lib/db');
+const { runTransaction } = require('../_lib/db');
 const { parseJsonBody } = require('../_lib/parse-body');
+
+const QUESTION_TYPES = new Set(['text', 'multiple_choice']);
+const OPTION_COUNT = 4;
 
 function readString(value) {
   return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function normalizeFactKey(value) {
+  if (typeof value !== 'string') return null;
+
+  const normalized = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+
+  return normalized || null;
 }
 
 function normalizeDifficulty(value) {
@@ -12,60 +27,156 @@ function normalizeDifficulty(value) {
   return parsed;
 }
 
-function normalizeEntry(entry) {
-  if (!entry || typeof entry !== 'object') return null;
+function normalizeAnswers(value) {
+  if (!Array.isArray(value)) return [];
 
-  const category = readString(entry.category);
-  const questionEn = readString(entry.question_en);
-  const questionNo = readString(entry.question_no);
-  const answers = Array.isArray(entry.answers)
-    ? entry.answers.map((value) => readString(value)).filter(Boolean)
-    : [];
-  const difficulty = normalizeDifficulty(entry.difficulty);
-
-  if (!category || !questionEn || !questionNo || !answers.length || !difficulty) {
-    return null;
-  }
-
-  return {
-    category,
-    question_en: questionEn,
-    question_no: questionNo,
-    answers,
-    difficulty
-  };
+  const seen = new Set();
+  return value
+    .map((answer) => readString(answer))
+    .filter(Boolean)
+    .filter((answer) => {
+      const key = answer.toLowerCase();
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
 }
 
-async function existsQuizQuestion(category, questionEn) {
-  const result = await runQuery(
-    `SELECT id
-     FROM public.quiz_questions
-     WHERE lower(trim(category)) = lower(trim($1))
-       AND lower(trim(question_en)) = lower(trim($2))
-     LIMIT 1`,
-    [category, questionEn]
-  );
+function normalizeOptions(value) {
+  if (!Array.isArray(value) || value.length !== OPTION_COUNT) {
+    return { error: 'Multiple choice questions require exactly four options.' };
+  }
 
-  return Boolean(result.rows[0]);
+  const options = value.map((option) => ({
+    option_en: readString(option?.option_en),
+    is_correct: option?.is_correct === true
+  }));
+
+  if (options.some((option) => !option.option_en)) {
+    return { error: 'All four multiple choice options must contain text.' };
+  }
+
+  const normalizedOptionTexts = options.map((option) => option.option_en.toLowerCase());
+  if (new Set(normalizedOptionTexts).size !== options.length) {
+    return { error: 'Multiple choice options must be unique (case-insensitive).' };
+  }
+
+  const correctCount = options.filter((option) => option.is_correct).length;
+  if (correctCount !== 1) {
+    return { error: 'Multiple choice questions require exactly one correct option.' };
+  }
+
+  return { value: options };
+}
+
+function normalizeEntry(entry, index) {
+  const entryLabel = `Entry ${index + 1}`;
+  if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+    return { error: `${entryLabel} must be an object.` };
+  }
+
+  const category = readString(entry.category);
+  const factKey = normalizeFactKey(entry.fact_key);
+  const questionType = readString(entry.question_type);
+  const questionEn = readString(entry.question_en);
+  const questionNo = readString(entry.question_no);
+  const difficulty = normalizeDifficulty(entry.difficulty);
+
+  if (!category) return { error: `${entryLabel} requires category.` };
+  if (!factKey) return { error: `${entryLabel} requires a non-empty fact_key.` };
+  if (!QUESTION_TYPES.has(questionType)) {
+    return { error: `${entryLabel} question_type must be "text" or "multiple_choice".` };
+  }
+  if (!questionEn) return { error: `${entryLabel} requires question_en.` };
+  if (!questionNo) return { error: `${entryLabel} requires question_no.` };
+  if (!difficulty) return { error: `${entryLabel} difficulty must be an integer from 1 to 5.` };
+
+  const baseEntry = {
+    category,
+    fact_key: factKey,
+    question_type: questionType,
+    question_en: questionEn,
+    question_no: questionNo,
+    difficulty
+  };
+
+  if (questionType === 'text') {
+    const answers = normalizeAnswers(entry.answers);
+    if (!answers.length) {
+      return { error: `${entryLabel} text questions require at least one accepted answer.` };
+    }
+    return { value: { ...baseEntry, answers, options: [] } };
+  }
+
+  const optionsResult = normalizeOptions(entry.options);
+  if (optionsResult.error) {
+    return { error: `${entryLabel}: ${optionsResult.error}` };
+  }
+
+  return { value: { ...baseEntry, answers: [], options: optionsResult.value } };
 }
 
 async function insertQuizQuestion(entry) {
-  await runQuery(
-    `INSERT INTO public.quiz_questions (
-      category,
-      question_en,
-      question_no,
-      answers_en,
-      difficulty
-    ) VALUES ($1, $2, $3, $4::text[], $5)`,
-    [
-      entry.category,
-      entry.question_en,
-      entry.question_no,
-      entry.answers,
-      entry.difficulty
-    ]
-  );
+  return runTransaction(async (client) => {
+    const duplicateResult = await client.query(
+      `SELECT id
+       FROM public.quiz_questions
+       WHERE lower(trim(question_en)) = lower(trim($1))
+       LIMIT 1`,
+      [entry.question_en]
+    );
+
+    if (duplicateResult.rows[0]) return { duplicate: true };
+
+    const questionResult = await client.query(
+      `INSERT INTO public.quiz_questions (
+        category,
+        fact_key,
+        question_en,
+        question_no,
+        answers_en,
+        difficulty,
+        question_type,
+        verified
+      ) VALUES ($1, $2, $3, $4, $5::text[], $6, $7, false)
+      RETURNING id`,
+      [
+        entry.category,
+        entry.fact_key,
+        entry.question_en,
+        entry.question_no,
+        entry.answers,
+        entry.difficulty,
+        entry.question_type
+      ]
+    );
+
+    const questionId = questionResult.rows[0].id;
+
+    if (entry.question_type === 'multiple_choice') {
+      for (const option of entry.options) {
+        await client.query(
+          `INSERT INTO public.quiz_question_options (
+            question_id,
+            option_en,
+            option_no,
+            is_correct
+          ) VALUES ($1, $2, NULL, $3)`,
+          [questionId, option.option_en, option.is_correct]
+        );
+      }
+    }
+
+    return { duplicate: false, id: questionId };
+  });
+}
+
+function isDuplicateQuestionError(error) {
+  if (error?.code !== '23505') return false;
+
+  const constraint = String(error.constraint || '').toLowerCase();
+  const detail = String(error.detail || '').toLowerCase();
+  return constraint.includes('question_en') || detail.includes('(question_en)');
 }
 
 module.exports = async function handler(req, res) {
@@ -91,24 +202,40 @@ module.exports = async function handler(req, res) {
       return;
     }
 
-    const normalizedEntries = entries.map(normalizeEntry);
-    if (normalizedEntries.some((entry) => entry === null)) {
-      res.status(400).json({ error: 'Each entry requires category, question_en, question_no, answers[] and difficulty (1-5)' });
+    const normalizedResults = entries.map(normalizeEntry);
+    const invalidEntry = normalizedResults.find((result) => result.error);
+    if (invalidEntry) {
+      res.status(400).json({ error: invalidEntry.error });
       return;
     }
 
+    const normalizedEntries = normalizedResults.map((result) => result.value);
     const inserted = [];
     const duplicates = [];
 
     for (const entry of normalizedEntries) {
-      const duplicate = await existsQuizQuestion(entry.category, entry.question_en);
-      if (duplicate) {
-        duplicates.push({ category: entry.category, question_en: entry.question_en });
-        continue;
-      }
+      try {
+        const result = await insertQuizQuestion(entry);
+        if (result.duplicate) {
+          duplicates.push({ category: entry.category, question_en: entry.question_en });
+          continue;
+        }
 
-      await insertQuizQuestion(entry);
-      inserted.push({ category: entry.category, question_en: entry.question_en });
+        inserted.push({
+          id: result.id,
+          category: entry.category,
+          fact_key: entry.fact_key,
+          question_type: entry.question_type,
+          question_en: entry.question_en,
+          verified: false
+        });
+      } catch (error) {
+        if (isDuplicateQuestionError(error)) {
+          duplicates.push({ category: entry.category, question_en: entry.question_en });
+          continue;
+        }
+        throw error;
+      }
     }
 
     res.status(200).json({

--- a/insertquiz/index.html
+++ b/insertquiz/index.html
@@ -19,8 +19,13 @@
     .full { grid-column:1 / -1; }
     label { display:block; margin-bottom:4px; color:var(--muted); font-size:.9rem; }
     input, select { width:100%; box-sizing:border-box; background:var(--bg); color:var(--txt); border:1px solid var(--bd); border-radius:8px; padding:10px 12px; }
+    input[type="radio"] { width:auto; margin:0; accent-color:var(--accent); }
+    .helper { display:block; color:var(--muted); font-size:.82rem; margin-top:4px; }
+    .option-row { display:grid; grid-template-columns:auto 1fr; align-items:center; gap:10px; margin-top:8px; }
+    .option-row label { margin:0; }
     .actions { display:flex; gap:8px; flex-wrap:wrap; margin-top:14px; }
     button { border:0; border-radius:8px; padding:10px 14px; font-weight:700; cursor:pointer; }
+    button:disabled { cursor:not-allowed; opacity:.6; }
     .btn-primary { background:var(--accent); color:#111; }
     .btn-neutral { background:var(--bd); color:var(--txt); }
     .btn-danger { background:var(--danger); color:#fff; }
@@ -30,6 +35,9 @@
     .queue-item { border:1px dashed var(--bd); border-radius:8px; padding:10px; margin-top:8px; }
     .queue-item strong { display:block; }
     .queue-item .queue-actions { margin-top:8px; }
+    .queue-details { margin-top:6px; }
+    .queue-options { margin:6px 0 0; padding-left:22px; }
+    .correct-option { color:var(--accent); font-weight:700; }
     .muted { color: var(--muted); }
     .hidden { display:none !important; }
     .top-links { display:flex; gap:10px; margin-bottom:10px; }
@@ -47,7 +55,7 @@
 
     <div class="card">
       <h1>Insert quiz question</h1>
-      <p class="muted">Admin-only tool for inserting questions into <code>public.quiz_questions</code>.</p>
+      <p class="muted">Admin-only tool for inserting unverified questions for review.</p>
       <div id="accessStatus" class="status">Checking access…</div>
     </div>
 
@@ -55,7 +63,7 @@
       <div class="grid">
         <div>
           <label for="category">Category</label>
-          <input id="category" type="text" />
+          <input id="category" type="text" required />
         </div>
         <div>
           <label for="difficulty">Difficulty</label>
@@ -67,17 +75,50 @@
             <option value="5">5 — Extreme</option>
           </select>
         </div>
+        <div>
+          <label for="factKey">Fact key</label>
+          <input id="factKey" type="text" required placeholder="capital_paris" />
+          <span class="helper">Use a lowercase key such as capital_paris, planet_saturn, pokemon_pikachu, or element_gold. It identifies the core fact/answer and helps spot duplicates.</span>
+        </div>
+        <div>
+          <label for="questionType">Question type</label>
+          <select id="questionType">
+            <option value="text">Text question</option>
+            <option value="multiple_choice">Multiple choice</option>
+          </select>
+        </div>
         <div class="full">
           <label for="questionEn">Question English</label>
-          <input id="questionEn" type="text" />
+          <input id="questionEn" type="text" required />
         </div>
         <div class="full">
           <label for="questionNo">Question Norwegian</label>
-          <input id="questionNo" type="text" />
+          <input id="questionNo" type="text" required />
         </div>
-        <div class="full">
-          <label>Accepted answers</label>
-          <input id="answersInput" type="text" placeholder="Use | between answers (e.g. 5 | five | fem)" />
+        <div class="full" id="answersSection">
+          <label for="answersInput">Accepted answers</label>
+          <input id="answersInput" type="text" required placeholder="France | Frankrike" />
+          <span class="helper">Separate all accepted English and Norwegian answer variants with |.</span>
+        </div>
+        <div class="full hidden" id="optionsSection">
+          <label>Multiple choice options</label>
+          <span class="helper">Enter four unique English options and select exactly one correct answer.</span>
+          <div class="option-row">
+            <input id="correctOption0" type="radio" name="correctOption" value="0" aria-label="Mark option 1 as correct" />
+            <label for="option0"><span class="muted">Option 1</span><input id="option0" class="option-input" type="text" disabled /></label>
+          </div>
+          <div class="option-row">
+            <input id="correctOption1" type="radio" name="correctOption" value="1" aria-label="Mark option 2 as correct" />
+            <label for="option1"><span class="muted">Option 2</span><input id="option1" class="option-input" type="text" disabled /></label>
+          </div>
+          <div class="option-row">
+            <input id="correctOption2" type="radio" name="correctOption" value="2" aria-label="Mark option 3 as correct" />
+            <label for="option2"><span class="muted">Option 3</span><input id="option2" class="option-input" type="text" disabled /></label>
+          </div>
+          <div class="option-row">
+            <input id="correctOption3" type="radio" name="correctOption" value="3" aria-label="Mark option 4 as correct" />
+            <label for="option3"><span class="muted">Option 4</span><input id="option3" class="option-input" type="text" disabled /></label>
+          </div>
         </div>
       </div>
 
@@ -106,12 +147,29 @@
 
     const categoryInput = document.getElementById('category');
     const difficultyInput = document.getElementById('difficulty');
+    const factKeyInput = document.getElementById('factKey');
+    const questionTypeInput = document.getElementById('questionType');
     const questionEnInput = document.getElementById('questionEn');
     const questionNoInput = document.getElementById('questionNo');
     const answersInput = document.getElementById('answersInput');
+    const answersSection = document.getElementById('answersSection');
+    const optionsSection = document.getElementById('optionsSection');
+    const optionInputs = Array.from(document.querySelectorAll('.option-input'));
+    const correctOptionInputs = Array.from(document.querySelectorAll('input[name="correctOption"]'));
+    const submitBtn = document.getElementById('submitBtn');
 
     function readString(value) {
       return typeof value === 'string' && value.trim() ? value.trim() : null;
+    }
+
+    function normalizeFactKey(value) {
+      if (typeof value !== 'string') return null;
+      const normalized = value
+        .trim()
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '_')
+        .replace(/^_+|_+$/g, '');
+      return normalized || null;
     }
 
     function setFormStatus(message, type = 'neutral') {
@@ -124,8 +182,7 @@
     function readAnswers() {
       const rawAnswers = String(answersInput.value || '')
         .split('|')
-        .map((part) => part.trim())
-        .map((value) => readString(value))
+        .map((part) => readString(part))
         .filter(Boolean);
 
       const seen = new Set();
@@ -135,6 +192,53 @@
         seen.add(key);
         return true;
       });
+    }
+
+    function readOptions() {
+      const optionValues = optionInputs.map((input) => readString(input.value));
+      if (optionValues.some((option) => !option)) {
+        return { error: 'Multiple choice questions require all four options.' };
+      }
+
+      const normalizedOptions = optionValues.map((option) => option.toLowerCase());
+      if (new Set(normalizedOptions).size !== optionValues.length) {
+        return { error: 'Multiple choice options must be unique (case-insensitive).' };
+      }
+
+      const selectedCorrectOptions = correctOptionInputs.filter((input) => input.checked);
+      if (selectedCorrectOptions.length !== 1) {
+        return { error: 'Select exactly one correct multiple choice option.' };
+      }
+
+      const correctIndex = Number(selectedCorrectOptions[0].value);
+      return {
+        value: optionValues.map((option_en, index) => ({
+          option_en,
+          is_correct: index === correctIndex
+        }))
+      };
+    }
+
+    function updateQuestionTypeFields() {
+      const isMultipleChoice = questionTypeInput.value === 'multiple_choice';
+      answersSection.classList.toggle('hidden', isMultipleChoice);
+      answersInput.disabled = isMultipleChoice;
+      answersInput.required = !isMultipleChoice;
+      optionsSection.classList.toggle('hidden', !isMultipleChoice);
+      optionInputs.forEach((input) => {
+        input.disabled = !isMultipleChoice;
+        input.required = isMultipleChoice;
+      });
+      correctOptionInputs.forEach((input) => {
+        input.disabled = !isMultipleChoice;
+      });
+    }
+
+    function appendQueueDetail(container, text) {
+      const detail = document.createElement('div');
+      detail.className = 'muted queue-details';
+      detail.textContent = text;
+      container.appendChild(detail);
     }
 
     function renderQueue() {
@@ -150,10 +254,27 @@
 
         const title = document.createElement('strong');
         title.textContent = `${index + 1}. [${item.category}] ${item.question_en}`;
+        container.appendChild(title);
 
-        const meta = document.createElement('div');
-        meta.className = 'muted';
-        meta.textContent = `NO: ${item.question_no} | Answers: ${item.answers.join(', ')} | Difficulty: ${item.difficulty}`;
+        appendQueueDetail(container, `Fact key: ${item.fact_key} | Type: ${item.question_type} | Difficulty: ${item.difficulty}`);
+        appendQueueDetail(container, `Norwegian: ${item.question_no}`);
+
+        if (item.question_type === 'text') {
+          appendQueueDetail(container, `Accepted answers: ${item.answers.join(', ')}`);
+        } else {
+          const optionsList = document.createElement('ol');
+          optionsList.className = 'queue-options';
+          item.options.forEach((option) => {
+            const optionItem = document.createElement('li');
+            optionItem.textContent = option.option_en;
+            if (option.is_correct) {
+              optionItem.textContent += ' — correct';
+              optionItem.className = 'correct-option';
+            }
+            optionsList.appendChild(optionItem);
+          });
+          container.appendChild(optionsList);
+        }
 
         const actions = document.createElement('div');
         actions.className = 'queue-actions';
@@ -169,8 +290,6 @@
         });
         actions.appendChild(removeBtn);
 
-        container.appendChild(title);
-        container.appendChild(meta);
         container.appendChild(actions);
         queueList.appendChild(container);
       });
@@ -178,37 +297,58 @@
 
     function resetFormInputs() {
       categoryInput.value = '';
+      factKeyInput.value = '';
+      questionTypeInput.value = 'text';
       questionEnInput.value = '';
       questionNoInput.value = '';
       answersInput.value = '';
+      optionInputs.forEach((input) => { input.value = ''; });
+      correctOptionInputs.forEach((input) => { input.checked = false; });
       difficultyInput.value = '1';
+      updateQuestionTypeFields();
       categoryInput.focus();
     }
 
     function readFormEntry() {
       const category = readString(categoryInput.value);
+      const fact_key = normalizeFactKey(factKeyInput.value);
+      const question_type = questionTypeInput.value;
       const question_en = readString(questionEnInput.value);
       const question_no = readString(questionNoInput.value);
-      const answers = readAnswers();
       const difficulty = Number(difficultyInput.value);
 
-      if (!category || !question_en || !question_no || !answers.length) {
-        return { error: 'Please fill out all fields before adding to queue. Add multiple answers with |.' };
+      if (!category || !fact_key || !question_en || !question_no) {
+        return { error: 'Category, fact key, and both question texts are required.' };
+      }
+
+      if (!['text', 'multiple_choice'].includes(question_type)) {
+        return { error: 'Question type must be text or multiple choice.' };
       }
 
       if (!Number.isInteger(difficulty) || difficulty < 1 || difficulty > 5) {
         return { error: 'Difficulty must be an integer from 1 to 5.' };
       }
 
-      return {
-        value: {
-          category,
-          question_en,
-          question_no,
-          answers,
-          difficulty
-        }
+      const baseEntry = {
+        category,
+        fact_key,
+        question_type,
+        question_en,
+        question_no,
+        difficulty
       };
+
+      if (question_type === 'text') {
+        const answers = readAnswers();
+        if (!answers.length) {
+          return { error: 'Text questions require at least one accepted answer. Separate variants with |.' };
+        }
+        return { value: { ...baseEntry, answers } };
+      }
+
+      const optionsResult = readOptions();
+      if (optionsResult.error) return optionsResult;
+      return { value: { ...baseEntry, answers: [], options: optionsResult.value } };
     }
 
     function redirectToHome() {
@@ -253,6 +393,12 @@
       }
     }
 
+    questionTypeInput.addEventListener('change', updateQuestionTypeFields);
+    factKeyInput.addEventListener('blur', () => {
+      const normalized = normalizeFactKey(factKeyInput.value);
+      if (normalized) factKeyInput.value = normalized;
+    });
+
     document.getElementById('addBtn').addEventListener('click', () => {
       const result = readFormEntry();
       if (result.error) {
@@ -262,7 +408,7 @@
 
       queue.push(result.value);
       renderQueue();
-      setFormStatus(`Queued question ${queue.length}.`, 'success');
+      setFormStatus(`Queued question ${queue.length}. It will be inserted as unverified.`, 'success');
       resetFormInputs();
     });
 
@@ -273,13 +419,14 @@
       resetFormInputs();
     });
 
-    document.getElementById('submitBtn').addEventListener('click', async () => {
+    submitBtn.addEventListener('click', async () => {
       if (!queue.length) {
         setFormStatus('Add at least one question before submitting.', 'error');
         return;
       }
 
       setFormStatus('Submitting…');
+      submitBtn.disabled = true;
 
       try {
         const response = await fetch('/api/admin/insert-quiz', {
@@ -297,11 +444,11 @@
         }
 
         const duplicateMessage = (data.duplicates || []).length
-          ? `Skipped duplicates: ${(data.duplicates || []).map((item) => `"${item.question_en}" in "${item.category}"`).join(', ')}.`
-          : 'No duplicates found.';
+          ? `Skipped because the question text already exists: ${(data.duplicates || []).map((item) => `"${item.question_en}"`).join(', ')}.`
+          : 'No duplicate question text found.';
 
         setFormStatus(
-          `Inserted ${data.insertedCount || 0} question(s). ${duplicateMessage}`,
+          `Inserted ${data.insertedCount || 0} unverified question(s). ${duplicateMessage}`,
           'success'
         );
 
@@ -310,10 +457,13 @@
         resetFormInputs();
       } catch (error) {
         setFormStatus('Insert failed due to network error.', 'error');
+      } finally {
+        submitBtn.disabled = false;
       }
     });
 
     difficultyInput.value = '1';
+    updateQuestionTypeFields();
     ensureAdminAccess();
   </script>
 </body>


### PR DESCRIPTION
### Motivation
- Støtte den nye `fact_key`/`verified`-arbeidsflyten og la verktøyet lage både tekstspørsmål og flervalgsspørsmål for gjennomgang i databasen.
- Hindre at nye spørsmål settes direkte som verifisert og sikre at flervalgsalternativer lagres atomisk sammen med spørsmålet.

### Description
- Frontend: oppdaterte `insertquiz/index.html` for å legge til obligatorisk `fact_key`, en `question_type`-velger, dynamiske felter for `answers` eller fire multiple-choice-alternativer med én korrekt radio, samt forbedret køvisning som viser `fact_key` og spørsmålstype. (`insertquiz/index.html`).
- Backend: erstattet enkel innsettingsflyt med strukturert validering i `api/admin/insert-quiz.js` som normaliserer `fact_key`, krever `question_type` (`text` eller `multiple_choice`), validerer tekstsvar eller nøyaktig fire unike alternativer med én korrekt, og sørger for `answers_en = []` for flervalg og `verified = false` for alle nye rader.
- Atomisitet: la til en generell transaksjonshjelper `runTransaction` i `api/_lib/db.js` og bruker en transaksjon for å sette inn spørsmålet og de fire `quiz_question_options` slik at feil ruller tilbake hele operasjonen.
- Feilhåndtering: håndterer duplicate `question_en` både før innsetting og ved å tolke Postgres-feilkode `23505`, og returnerer klare valideringsfeil; admin-/session-sjekk er beholdt.

### Testing
- Kjørt `node --check api/_lib/db.js` for syntakssjekk av DB-hjelperen (suksess).
- Kjørt `node --check api/admin/insert-quiz.js` for syntakssjekk av API-håndtereren (suksess).
- Parset frontend-inline-skript med `new Function(...)` for enkel syntakskontroll av `insertquiz/index.html` (suksess).
- Kjørt mocked end-to-end API-sjekker i Node som simulerer `requireSession`, DB-transaksjon og bekrefter: `fact_key`-normalisering, `verified=false`, tekstsvar lagres i `answers_en`, flervalg setter `answers_en = []`, fire `quiz_question_options` blir opprettet, og transaksjonens `COMMIT`/`ROLLBACK`/`release`-flyt (suksess).
- Forsøk på å kjøre headless UI-sjekk med Playwright mislyktes fordi miljøet blokkerte nedlasting av nettleser (HTTP 403), så visuell automatisert test kunne ikke fullføres (feilet).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29325818dc8333b3c28aae3aababc3)