### PR TITLE
Update queued quiz success fallback text

### DIFF
--- a/insertquiz/index.html
+++ b/insertquiz/index.html
@@ -445,7 +445,7 @@
 
         const duplicateMessage = (data.duplicates || []).length
           ? `Skipped because the question text already exists: ${(data.duplicates || []).map((item) => `"${item.question_en}"`).join(', ')}.`
-          : 'No duplicate question text found.';
+          : 'No identical question text found.';
 
         setFormStatus(
           `Inserted ${data.insertedCount || 0} unverified question(s). ${duplicateMessage}`,


### PR DESCRIPTION
### Motivation
- Oppdater lesbarheten i suksessfallback-meldingen etter innsending av kølagte quizspørsmål ved å bytte `No duplicate question text found.` til `No identical question text found.`.

### Description
- Endret synlig tekst i `insertquiz/index.html`: erstattet `No duplicate question text found.` med `No identical question text found.` uten å endre logikk, validering, API-kall eller backend.

### Testing
- Kjørte `node --check` på det uttrukne inline-JavaScript, `git diff --check`, og kontrollerte med `rg` at `No identical question text found.` forekommer én gang og at `No duplicate question text found.` ikke forekommer; alle automatiske sjekker besto.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a293907061483338fed00aae878480f)